### PR TITLE
Stove fixes and improvements

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
@@ -52,11 +52,10 @@ public class StoveBlock extends Block
 				StoveTileEntity stovetileentity = (StoveTileEntity)tileentity;
 				Optional<CampfireCookingRecipe> optional = stovetileentity.findMatchingRecipe(itemstack);
 				if (optional.isPresent()) {
-					if (!worldIn.isRemote && stovetileentity.addItem(player.abilities.isCreativeMode ? itemstack.copy() : itemstack, optional.get().getCookTime())) {
+					if (!worldIn.isRemote && !stovetileentity.isStoveBlockedAbove() && stovetileentity.addItem(player.abilities.isCreativeMode ? itemstack.copy() : itemstack, optional.get().getCookTime())) {
 						player.addStat(Stats.INTERACT_WITH_CAMPFIRE);
 						return ActionResultType.SUCCESS;
 					}
-
 					return ActionResultType.CONSUME;
 				} else {
 					if (usedItem instanceof ShovelItem) {

--- a/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
@@ -141,7 +141,6 @@ public class StoveBlock extends Block
 
 			Direction direction = stateIn.get(HorizontalBlock.HORIZONTAL_FACING);
 			Direction.Axis direction$axis = direction.getAxis();
-			double d3 = 0.52D;
 			double d4 = rand.nextDouble() * 0.6D - 0.3D;
 			double d5 = direction$axis == Direction.Axis.X ? (double)direction.getXOffset() * 0.52D : d4;
 			double d6 = rand.nextDouble() * 6.0D / 16.0D;

--- a/src/main/java/vectorwing/farmersdelight/blocks/StoveTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StoveTileEntity.java
@@ -2,7 +2,9 @@ package vectorwing.farmersdelight.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.util.math.shapes.IBooleanFunction;
 import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import vectorwing.farmersdelight.init.ModTileEntityTypes;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.inventory.*;
@@ -31,6 +33,7 @@ import java.util.Random;
 
 public class StoveTileEntity extends TileEntity implements IClearable, ITickableTileEntity
 {
+	private static final VoxelShape GRILLING_AREA = Block.makeCuboidShape(3.0F, 0.0F, 3.0F, 13.0F, 1.0F, 13.0F);
 	private final int MAX_STACK_SIZE = 6;
 	protected final NonNullList<ItemStack> inventory = NonNullList.withSize(MAX_STACK_SIZE, ItemStack.EMPTY);
 	private final int[] cookingTimes = new int[MAX_STACK_SIZE];
@@ -94,7 +97,7 @@ public class StoveTileEntity extends TileEntity implements IClearable, ITickable
 	public boolean isStoveBlockedAbove() {
 		if (world != null) {
 			BlockState above = world.getBlockState(pos.up());
-			return !above.getCollisionShape(world, pos).isEmpty();
+			return VoxelShapes.compare(GRILLING_AREA, above.getShape(world, pos.up()), IBooleanFunction.AND);
 		}
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
@@ -1,5 +1,6 @@
 package vectorwing.farmersdelight.client.tileentity.renderer;
 
+import net.minecraft.client.renderer.WorldRenderer;
 import vectorwing.farmersdelight.blocks.StoveBlock;
 import vectorwing.farmersdelight.blocks.StoveTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
@@ -46,7 +47,7 @@ public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity>
 				// Resize the items
 				matrixStackIn.scale(0.375F, 0.375F, 0.375F);
 
-				Minecraft.getInstance().getItemRenderer().renderItem(itemstack, ItemCameraTransforms.TransformType.FIXED, combinedLightIn, combinedOverlayIn, matrixStackIn, bufferIn);
+				Minecraft.getInstance().getItemRenderer().renderItem(itemstack, ItemCameraTransforms.TransformType.FIXED, WorldRenderer.getCombinedLight(tileEntityIn.getWorld(), tileEntityIn.getPos().up()), combinedOverlayIn, matrixStackIn, bufferIn);
 				matrixStackIn.pop();
 			}
 		}

--- a/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
@@ -30,7 +30,7 @@ public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity>
 				matrixStackIn.push();
 
 				// Center item above the stove
-				matrixStackIn.translate(0.5D, 1.01D, 0.5D);
+				matrixStackIn.translate(0.5D, 1.02D, 0.5D);
 
 				// Rotate item to face the stove's front side
 				float f = -direction.getHorizontalAngle();
@@ -43,7 +43,7 @@ public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity>
 				Vec2f itemOffset = tileEntityIn.getStoveItemOffset(i);
 				matrixStackIn.translate(itemOffset.x, itemOffset.y, 0.0D);
 
-				// Resize the items? I dunno lmao
+				// Resize the items
 				matrixStackIn.scale(0.375F, 0.375F, 0.375F);
 
 				Minecraft.getInstance().getItemRenderer().renderItem(itemstack, ItemCameraTransforms.TransformType.FIXED, combinedLightIn, combinedOverlayIn, matrixStackIn, bufferIn);


### PR DESCRIPTION
- Stove drops items and cannot grill anything if the block above is touching the middle grill area;
- Fixed items on top of the stove rendering fully dark when unlit.