### PR TITLE
Make saplings grow on rich soil

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/dirt.json
+++ b/src/generated/resources/data/forge/tags/blocks/dirt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "farmersdelight:rich_soil"
+  ]
+}


### PR DESCRIPTION
The code that tries growing a tree checks if the block the sapling is placed on is either tagged with forge:dirt or is farmland (c.f. net.minecraft.world.gen.feature.TreeFeature#place), so the only thing that's needed is to tag rich soil appropriately