### PR TITLE
Code Cleanup

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/FDItemGroup.java
+++ b/src/main/java/vectorwing/farmersdelight/FDItemGroup.java
@@ -9,7 +9,8 @@ import vectorwing.farmersdelight.registry.ModItems;
 import javax.annotation.Nonnull;
 
 @SuppressWarnings("unused")
-public class FDItemGroup extends ItemGroup {
+public class FDItemGroup extends ItemGroup
+{
 	public FDItemGroup(String label) {
 		super(label);
 	}

--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -23,43 +23,42 @@ import vectorwing.farmersdelight.world.CropPatchGeneration;
 
 @Mod(FarmersDelight.MODID)
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
-public class FarmersDelight {
-    public static final Logger LOGGER = LogManager.getLogger();
-    public static final String MODID = "farmersdelight";
+public class FarmersDelight
+{
+	public static final Logger LOGGER = LogManager.getLogger();
+	public static final String MODID = "farmersdelight";
 
-    public static final FDItemGroup ITEM_GROUP = new FDItemGroup(FarmersDelight.MODID);
+	public static final FDItemGroup ITEM_GROUP = new FDItemGroup(FarmersDelight.MODID);
 
-    public FarmersDelight()
-    {
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(CommonEventHandler::init);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEventHandler::init);
-        FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(IRecipeSerializer.class, this::registerRecipeSerializers);
-        MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, CropPatchGeneration::onBiomeLoad);
+	public FarmersDelight() {
+		FMLJavaModLoadingContext.get().getModEventBus().addListener(CommonEventHandler::init);
+		FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEventHandler::init);
+		FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(IRecipeSerializer.class, this::registerRecipeSerializers);
+		MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, CropPatchGeneration::onBiomeLoad);
 
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Configuration.COMMON_CONFIG);
-        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Configuration.CLIENT_CONFIG);
+		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Configuration.COMMON_CONFIG);
+		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Configuration.CLIENT_CONFIG);
 
-        final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
-        ModParticleTypes.PARTICLE_TYPES.register(modEventBus);
-        ModEnchantments.ENCHANTMENTS.register(modEventBus);
-        ModItems.ITEMS.register(modEventBus);
-        ModBlocks.BLOCKS.register(modEventBus);
-        ModEffects.EFFECTS.register(modEventBus);
-        ModBiomeFeatures.FEATURES.register(modEventBus);
-        ModSounds.SOUNDS.register(modEventBus);
-        ModTileEntityTypes.TILES.register(modEventBus);
-        ModContainerTypes.CONTAINER_TYPES.register(modEventBus);
-        ModRecipeSerializers.RECIPE_SERIALIZERS.register(modEventBus);
+		ModParticleTypes.PARTICLE_TYPES.register(modEventBus);
+		ModEnchantments.ENCHANTMENTS.register(modEventBus);
+		ModItems.ITEMS.register(modEventBus);
+		ModBlocks.BLOCKS.register(modEventBus);
+		ModEffects.EFFECTS.register(modEventBus);
+		ModBiomeFeatures.FEATURES.register(modEventBus);
+		ModSounds.SOUNDS.register(modEventBus);
+		ModTileEntityTypes.TILES.register(modEventBus);
+		ModContainerTypes.CONTAINER_TYPES.register(modEventBus);
+		ModRecipeSerializers.RECIPE_SERIALIZERS.register(modEventBus);
 
-        MinecraftForge.EVENT_BUS.register(this);
-    }
+		MinecraftForge.EVENT_BUS.register(this);
+	}
 
-    private void registerRecipeSerializers (RegistryEvent.Register<IRecipeSerializer<?>> event)
-    {
-        Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(FarmersDelight.MODID, "cooking"), CookingPotRecipe.TYPE);
-        event.getRegistry().register(CookingPotRecipe.SERIALIZER);
-        Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(FarmersDelight.MODID, "cutting"), CuttingBoardRecipe.TYPE);
-        event.getRegistry().register(CuttingBoardRecipe.SERIALIZER);
-    }
+	private void registerRecipeSerializers(RegistryEvent.Register<IRecipeSerializer<?>> event) {
+		Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(FarmersDelight.MODID, "cooking"), CookingPotRecipe.TYPE);
+		event.getRegistry().register(CookingPotRecipe.SERIALIZER);
+		Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(FarmersDelight.MODID, "cutting"), CuttingBoardRecipe.TYPE);
+		event.getRegistry().register(CuttingBoardRecipe.SERIALIZER);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/advancement/CuttingBoardTrigger.java
+++ b/src/main/java/vectorwing/farmersdelight/advancement/CuttingBoardTrigger.java
@@ -9,7 +9,8 @@ import net.minecraft.loot.ConditionArrayParser;
 import net.minecraft.util.ResourceLocation;
 import vectorwing.farmersdelight.FarmersDelight;
 
-public class CuttingBoardTrigger extends AbstractCriterionTrigger<CuttingBoardTrigger.Instance> {
+public class CuttingBoardTrigger extends AbstractCriterionTrigger<CuttingBoardTrigger.Instance>
+{
 	private static final ResourceLocation ID = new ResourceLocation(FarmersDelight.MODID, "use_cutting_board");
 
 	public ResourceLocation getId() {
@@ -25,7 +26,8 @@ public class CuttingBoardTrigger extends AbstractCriterionTrigger<CuttingBoardTr
 		return new CuttingBoardTrigger.Instance(player);
 	}
 
-	public static class Instance extends CriterionInstance {
+	public static class Instance extends CriterionInstance
+	{
 		public Instance(EntityPredicate.AndPredicate player) {
 			super(CuttingBoardTrigger.ID, player);
 		}

--- a/src/main/java/vectorwing/farmersdelight/blocks/BasketBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/BasketBlock.java
@@ -2,7 +2,6 @@ package vectorwing.farmersdelight.blocks;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
@@ -32,12 +31,10 @@ import net.minecraft.world.World;
 import vectorwing.farmersdelight.tile.BasketTileEntity;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
-public class BasketBlock extends ContainerBlock implements IWaterLoggable {
+public class BasketBlock extends ContainerBlock implements IWaterLoggable
+{
 	public static final DirectionProperty FACING = BlockStateProperties.FACING;
 	public static final BooleanProperty ENABLED = BlockStateProperties.ENABLED;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -102,29 +99,33 @@ public class BasketBlock extends ContainerBlock implements IWaterLoggable {
 		return shape.simplify();
 	}
 
+	@Override
 	public BlockRenderType getRenderType(BlockState state) {
 		return BlockRenderType.MODEL;
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(FACING, ENABLED, WATERLOGGED);
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		if (!worldIn.isRemote) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof BasketTileEntity) {
-				player.openContainer((BasketTileEntity) tileentity);
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof BasketTileEntity) {
+				player.openContainer((BasketTileEntity) tile);
 			}
 		}
 		return ActionResultType.SUCCESS;
 	}
 
+	@Override
 	public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof IInventory) {
-				InventoryHelper.dropInventoryItems(worldIn, pos, (IInventory) tileentity);
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof IInventory) {
+				InventoryHelper.dropInventoryItems(worldIn, pos, (IInventory) tile);
 				worldIn.updateComparatorOutputLevel(pos, this);
 			}
 
@@ -132,30 +133,33 @@ public class BasketBlock extends ContainerBlock implements IWaterLoggable {
 		}
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
 	}
 
 	// --- HOPPER STUFF ---
 
+	@Override
 	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
 		this.updateState(worldIn, pos, state);
 	}
 
 	private void updateState(World worldIn, BlockPos pos, BlockState state) {
-		boolean flag = !worldIn.isBlockPowered(pos);
-		if (flag != state.get(ENABLED)) {
-			worldIn.setBlockState(pos, state.with(ENABLED, Boolean.valueOf(flag)), 4);
+		boolean isPowered = !worldIn.isBlockPowered(pos);
+		if (isPowered != state.get(ENABLED)) {
+			worldIn.setBlockState(pos, state.with(ENABLED, isPowered), 4);
 		}
-
 	}
 
 	// --- BARREL STUFF ---
 
+	@Override
 	public boolean hasComparatorInputOverride(BlockState state) {
 		return true;
 	}
 
+	@Override
 	public int getComparatorInputOverride(BlockState blockState, World worldIn, BlockPos pos) {
 		return Container.calcRedstone(worldIn.getTileEntity(pos));
 	}
@@ -165,40 +169,48 @@ public class BasketBlock extends ContainerBlock implements IWaterLoggable {
 		return new BasketTileEntity();
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		if (stack.hasDisplayName()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof BasketTileEntity) {
-				((BasketTileEntity) tileentity).setCustomName(stack.getDisplayName());
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof BasketTileEntity) {
+				((BasketTileEntity) tile).setCustomName(stack.getDisplayName());
 			}
 		}
 	}
 
+	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		FluidState ifluidstate = context.getWorld().getFluidState(context.getPos());
-		return this.getDefaultState().with(FACING, context.getNearestLookingDirection().getOpposite()).with(WATERLOGGED, ifluidstate.getFluid() == Fluids.WATER);
+		FluidState fluid = context.getWorld().getFluidState(context.getPos());
+		return this.getDefaultState().with(FACING, context.getNearestLookingDirection().getOpposite()).with(WATERLOGGED, fluid.getFluid() == Fluids.WATER);
 	}
 
+	@Override
 	public BlockState rotate(BlockState state, Rotation rot) {
 		return state.with(FACING, rot.rotate(state.get(FACING)));
 	}
 
+	@Override
 	public BlockState mirror(BlockState state, Mirror mirrorIn) {
 		return state.rotate(mirrorIn.toRotation(state.get(FACING)));
 	}
 
+	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE_FACING.get(state.get(FACING));
 	}
 
+	@Override
 	public VoxelShape getRaytraceShape(BlockState state, IBlockReader worldIn, BlockPos pos) {
 		return OUT_SHAPE;
 	}
 
+	@Override
 	public VoxelShape getCollisionShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE_FACING.get(state.get(FACING));
 	}
 
+	@Override
 	public boolean allowsMovement(BlockState state, IBlockReader worldIn, BlockPos pos, PathType type) {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/CabbagesBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CabbagesBlock.java
@@ -13,7 +13,7 @@ import vectorwing.farmersdelight.registry.ModItems;
 
 public class CabbagesBlock extends CropsBlock
 {
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 5.0D, 16.0D),

--- a/src/main/java/vectorwing/farmersdelight/blocks/CabbagesBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CabbagesBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CropsBlock;
@@ -12,12 +11,9 @@ import net.minecraft.world.IBlockReader;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
-public class CabbagesBlock extends CropsBlock {
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
+public class CabbagesBlock extends CropsBlock
+{
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 5.0D, 16.0D),
@@ -25,8 +21,8 @@ public class CabbagesBlock extends CropsBlock {
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 9.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 9.0D, 16.0D),
-			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 10.0D, 16.0D)};
-
+			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 10.0D, 16.0D)
+	};
 
 	public CabbagesBlock(Properties properties) {
 		super(properties);

--- a/src/main/java/vectorwing/farmersdelight/blocks/CookingPotBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CookingPotBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.IWaterLoggable;
@@ -45,12 +44,10 @@ import vectorwing.farmersdelight.utils.TextUtils;
 import vectorwing.farmersdelight.utils.tags.ModTags;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Random;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
+@SuppressWarnings("deprecation")
 public class CookingPotBlock extends Block implements IWaterLoggable
 {
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 10.0D, 14.0D);
@@ -66,10 +63,12 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		this.setDefaultState(this.stateContainer.getBaseState().with(FACING, Direction.NORTH).with(SUPPORTED, false).with(WATERLOGGED, false));
 	}
 
+	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE;
 	}
 
+	@Override
 	public VoxelShape getCollisionShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return state.get(SUPPORTED) ? SHAPE_SUPPORTED : SHAPE;
 	}
@@ -85,6 +84,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 				.with(WATERLOGGED, ifluidstate.getFluid() == Fluids.WATER);
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		if (stateIn.get(WATERLOGGED)) {
 			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
@@ -100,7 +100,6 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player,
 											 Hand handIn, BlockRayTraceResult result) {
 		if (!worldIn.isRemote) {
@@ -119,7 +118,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		return ActionResultType.SUCCESS;
 	}
 
-	@SuppressWarnings("deprecation")
+	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		ItemStack itemstack = super.getItem(worldIn, pos, state);
 		CookingPotTileEntity tile = (CookingPotTileEntity)worldIn.getTileEntity(pos);
@@ -133,7 +132,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		return itemstack;
 	}
 
-	@SuppressWarnings("deprecation")
+	@Override
 	public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
 			TileEntity tileentity = worldIn.getTileEntity(pos);
@@ -145,6 +144,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		}
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void addInformation(ItemStack stack, @Nullable IBlockReader worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {
 		super.addInformation(stack, worldIn, tooltip, flagIn);
@@ -170,11 +170,13 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		}
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		super.fillStateContainer(builder);
 		builder.add(FACING, SUPPORTED, WATERLOGGED);
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		if (stack.hasDisplayName()) {
 			TileEntity tileentity = worldIn.getTileEntity(pos);
@@ -184,6 +186,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		}
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void animateTick(BlockState stateIn, World worldIn, BlockPos pos, Random rand) {
 		TileEntity tileentity = worldIn.getTileEntity(pos);
@@ -197,13 +200,16 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		}
 	}
 
+	@Override
 	public boolean hasComparatorInputOverride(BlockState state) {
 		return true;
 	}
 
+	@Override
 	public int getComparatorInputOverride(BlockState blockState, World worldIn, BlockPos pos) {
-		if (worldIn.getTileEntity(pos) instanceof CookingPotTileEntity) {
-			ItemStackHandler inventory = ((CookingPotTileEntity) worldIn.getTileEntity(pos)).getInventory();
+		TileEntity tile = worldIn.getTileEntity(pos);
+		if (tile instanceof CookingPotTileEntity) {
+			ItemStackHandler inventory = ((CookingPotTileEntity) tile).getInventory();
 			return MathUtils.calcRedstoneFromItemHandler(inventory);
 		}
 		return 0;
@@ -219,6 +225,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		return ModTileEntityTypes.COOKING_POT_TILE.get().create();
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/CookingPotBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CookingPotBlock.java
@@ -50,11 +50,11 @@ import java.util.Random;
 @SuppressWarnings("deprecation")
 public class CookingPotBlock extends Block implements IWaterLoggable
 {
-	protected static final VoxelShape SHAPE = Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 10.0D, 14.0D);
-	protected static final VoxelShape SHAPE_SUPPORTED = VoxelShapes.or(SHAPE, Block.makeCuboidShape(0.0D, -1.0D, 0.0D, 16.0D, 0.0D, 16.0D));
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final BooleanProperty SUPPORTED = BlockStateProperties.DOWN;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	protected static final VoxelShape SHAPE = Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 10.0D, 14.0D);
+	protected static final VoxelShape SHAPE_SUPPORTED = VoxelShapes.or(SHAPE, Block.makeCuboidShape(0.0D, -1.0D, 0.0D, 16.0D, 0.0D, 16.0D));
 
 	public CookingPotBlock() {
 		super(Properties.create(Material.IRON)
@@ -121,7 +121,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		ItemStack itemstack = super.getItem(worldIn, pos, state);
-		CookingPotTileEntity tile = (CookingPotTileEntity)worldIn.getTileEntity(pos);
+		CookingPotTileEntity tile = (CookingPotTileEntity) worldIn.getTileEntity(pos);
 		CompoundNBT compoundnbt = tile.writeMeal(new CompoundNBT());
 		if (!compoundnbt.isEmpty()) {
 			itemstack.setTagInfo("BlockEntityTag", compoundnbt);
@@ -137,7 +137,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		if (state.getBlock() != newState.getBlock()) {
 			TileEntity tileentity = worldIn.getTileEntity(pos);
 			if (tileentity instanceof CookingPotTileEntity) {
-				InventoryHelper.dropItems(worldIn, pos, ((CookingPotTileEntity)tileentity).getDroppableInventory());
+				InventoryHelper.dropItems(worldIn, pos, ((CookingPotTileEntity) tileentity).getDroppableInventory());
 			}
 
 			super.onReplaced(state, worldIn, pos, newState, isMoving);
@@ -181,7 +181,7 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 		if (stack.hasDisplayName()) {
 			TileEntity tileentity = worldIn.getTileEntity(pos);
 			if (tileentity instanceof CookingPotTileEntity) {
-				((CookingPotTileEntity)tileentity).setCustomName(stack.getDisplayName());
+				((CookingPotTileEntity) tileentity).setCustomName(stack.getDisplayName());
 			}
 		}
 	}
@@ -190,10 +190,10 @@ public class CookingPotBlock extends Block implements IWaterLoggable
 	@OnlyIn(Dist.CLIENT)
 	public void animateTick(BlockState stateIn, World worldIn, BlockPos pos, Random rand) {
 		TileEntity tileentity = worldIn.getTileEntity(pos);
-		if (tileentity instanceof CookingPotTileEntity && ((CookingPotTileEntity)tileentity).isAboveLitHeatSource()) {
-			double d0 = (double)pos.getX() + 0.5D;
+		if (tileentity instanceof CookingPotTileEntity && ((CookingPotTileEntity) tileentity).isAboveLitHeatSource()) {
+			double d0 = (double) pos.getX() + 0.5D;
 			double d1 = pos.getY();
-			double d2 = (double)pos.getZ() + 0.5D;
+			double d2 = (double) pos.getZ() + 0.5D;
 			if (rand.nextInt(10) == 0) {
 				worldIn.playSound(d0, d1, d2, ModSounds.BLOCK_COOKING_POT_BOIL.get(), SoundCategory.BLOCKS, 0.5F, rand.nextFloat() * 0.2F + 0.9F, false);
 			}

--- a/src/main/java/vectorwing/farmersdelight/blocks/CuttingBoardBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CuttingBoardBlock.java
@@ -37,13 +37,24 @@ import javax.annotation.Nullable;
 @SuppressWarnings("deprecation")
 public class CuttingBoardBlock extends Block implements IWaterLoggable
 {
-	protected static final VoxelShape SHAPE = Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 1.0D, 15.0D);
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	protected static final VoxelShape SHAPE = Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 1.0D, 15.0D);
 
 	public CuttingBoardBlock() {
 		super(Properties.create(Material.WOOD).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
 		this.setDefaultState(this.getStateContainer().getBaseState().with(FACING, Direction.NORTH).with(WATERLOGGED, false));
+	}
+
+	public static void spawnCuttingParticles(World worldIn, BlockPos pos, ItemStack stack, int count) {
+		for (int i = 0; i < count; ++i) {
+			Vector3d vec3d = new Vector3d(((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D, Math.random() * 0.1D + 0.1D, ((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D);
+			if (worldIn instanceof ServerWorld) {
+				((ServerWorld) worldIn).spawnParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, 1, vec3d.x, vec3d.y + 0.05D, vec3d.z, 0.0D);
+			} else {
+				worldIn.addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, vec3d.x, vec3d.y + 0.05D, vec3d.z);
+			}
+		}
 	}
 
 	@Override
@@ -71,13 +82,12 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable
 				}
 				if (itemHeld.isEmpty()) {
 					return ActionResultType.PASS;
-				}
-				else if (cuttingBoardTile.addItem(player.abilities.isCreativeMode ? itemHeld.copy() : itemHeld)) {
+				} else if (cuttingBoardTile.addItem(player.abilities.isCreativeMode ? itemHeld.copy() : itemHeld)) {
 					worldIn.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.BLOCK_WOOD_PLACE, SoundCategory.BLOCKS, 1.0F, 0.8F);
 					return ActionResultType.SUCCESS;
 				}
 
-			// Processing the item with the held tool
+				// Processing the item with the held tool
 			} else if (!itemHeld.isEmpty()) {
 				ItemStack boardItem = cuttingBoardTile.getStoredItem().copy();
 				if (cuttingBoardTile.processItemUsingTool(itemHeld, player)) {
@@ -86,12 +96,11 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable
 				}
 				return ActionResultType.PASS;
 
-			// Removing the board's item
+				// Removing the board's item
 			} else if (handIn.equals(Hand.MAIN_HAND)) {
 				if (!player.isCreative()) {
 					InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), cuttingBoardTile.removeItem());
-				}
-				else {
+				} else {
 					cuttingBoardTile.removeItem();
 				}
 				worldIn.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.BLOCK_WOOD_HIT, SoundCategory.BLOCKS, 0.25F, 0.5F);
@@ -99,17 +108,6 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable
 			}
 		}
 		return ActionResultType.PASS;
-	}
-
-	public static void spawnCuttingParticles(World worldIn, BlockPos pos, ItemStack stack, int count) {
-		for (int i = 0; i < count; ++i) {
-			Vector3d vec3d = new Vector3d(((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D, Math.random() * 0.1D + 0.1D, ((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D);
-			if (worldIn instanceof ServerWorld) {
-				((ServerWorld) worldIn).spawnParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, 1, vec3d.x, vec3d.y + 0.05D, vec3d.z, 0.0D);
-			} else {
-				worldIn.addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, vec3d.x, vec3d.y + 0.05D, vec3d.z);
-			}
-		}
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/blocks/CuttingBoardBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/CuttingBoardBlock.java
@@ -34,7 +34,9 @@ import vectorwing.farmersdelight.tile.CuttingBoardTileEntity;
 
 import javax.annotation.Nullable;
 
-public class CuttingBoardBlock extends Block implements IWaterLoggable {
+@SuppressWarnings("deprecation")
+public class CuttingBoardBlock extends Block implements IWaterLoggable
+{
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 1.0D, 15.0D);
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -44,55 +46,57 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 		this.setDefaultState(this.getStateContainer().getBaseState().with(FACING, Direction.NORTH).with(WATERLOGGED, false));
 	}
 
+	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE;
 	}
 
+	@Override
 	public VoxelShape getCollisionShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE;
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
-		TileEntity tileentity = worldIn.getTileEntity(pos);
-		if (tileentity instanceof CuttingBoardTileEntity) {
-			CuttingBoardTileEntity cuttingBoardTE = (CuttingBoardTileEntity) tileentity;
+		TileEntity tile = worldIn.getTileEntity(pos);
+		if (tile instanceof CuttingBoardTileEntity) {
+			CuttingBoardTileEntity cuttingBoardTile = (CuttingBoardTileEntity) tile;
 			ItemStack itemHeld = player.getHeldItem(handIn);
 			ItemStack itemOffhand = player.getHeldItemOffhand();
 
 			// Placing items on the board. It should prefer off-hand placement, unless it's a BlockItem (since it never passes to off-hand...)
-			if (cuttingBoardTE.isEmpty()) {
+			if (cuttingBoardTile.isEmpty()) {
 				if (!itemOffhand.isEmpty() && handIn.equals(Hand.MAIN_HAND) && !(itemHeld.getItem() instanceof BlockItem)) {
 					return ActionResultType.PASS; // main-hand passes to off-hand
 				}
 				if (itemHeld.isEmpty()) {
 					return ActionResultType.PASS;
 				}
-				else if (cuttingBoardTE.addItem(player.abilities.isCreativeMode ? itemHeld.copy() : itemHeld)) {
+				else if (cuttingBoardTile.addItem(player.abilities.isCreativeMode ? itemHeld.copy() : itemHeld)) {
 					worldIn.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.BLOCK_WOOD_PLACE, SoundCategory.BLOCKS, 1.0F, 0.8F);
 					return ActionResultType.SUCCESS;
 				}
-				// Processing the item with the held tool
-			}
-			else if (!itemHeld.isEmpty()) {
-				ItemStack boardItem = cuttingBoardTE.getStoredItem().copy();
-				if (cuttingBoardTE.processItemUsingTool(itemHeld, player)) {
+
+			// Processing the item with the held tool
+			} else if (!itemHeld.isEmpty()) {
+				ItemStack boardItem = cuttingBoardTile.getStoredItem().copy();
+				if (cuttingBoardTile.processItemUsingTool(itemHeld, player)) {
 					spawnCuttingParticles(worldIn, pos, boardItem, 5);
 					return ActionResultType.SUCCESS;
 				}
 				return ActionResultType.PASS;
-				// Removing the board's item
-			}
-			else if (handIn.equals(Hand.MAIN_HAND)) {
+
+			// Removing the board's item
+			} else if (handIn.equals(Hand.MAIN_HAND)) {
 				if (!player.isCreative()) {
-					InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), cuttingBoardTE.removeItem());
+					InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), cuttingBoardTile.removeItem());
 				}
 				else {
-					cuttingBoardTE.removeItem();
+					cuttingBoardTile.removeItem();
 				}
 				worldIn.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.BLOCK_WOOD_HIT, SoundCategory.BLOCKS, 0.25F, 0.5F);
 				return ActionResultType.SUCCESS;
 			}
-
 		}
 		return ActionResultType.PASS;
 	}
@@ -102,18 +106,18 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 			Vector3d vec3d = new Vector3d(((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D, Math.random() * 0.1D + 0.1D, ((double) worldIn.rand.nextFloat() - 0.5D) * 0.1D);
 			if (worldIn instanceof ServerWorld) {
 				((ServerWorld) worldIn).spawnParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, 1, vec3d.x, vec3d.y + 0.05D, vec3d.z, 0.0D);
-			}
-			else {
+			} else {
 				worldIn.addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), pos.getX() + 0.5F, pos.getY() + 0.1F, pos.getZ() + 0.5F, vec3d.x, vec3d.y + 0.05D, vec3d.z);
 			}
 		}
 	}
 
+	@Override
 	public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof CuttingBoardTileEntity) {
-				InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), ((CuttingBoardTileEntity) tileentity).getStoredItem());
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof CuttingBoardTileEntity) {
+				InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), ((CuttingBoardTileEntity) tile).getStoredItem());
 				worldIn.updateComparatorOutputLevel(pos, this);
 			}
 
@@ -121,17 +125,19 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 		}
 	}
 
+	@Override
 	public boolean canSpawnInBlock() {
 		return true;
 	}
 
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		FluidState ifluidstate = context.getWorld().getFluidState(context.getPos());
+		FluidState fluid = context.getWorld().getFluidState(context.getPos());
 		return this.getDefaultState().with(FACING, context.getPlacementHorizontalFacing().getOpposite())
-				.with(WATERLOGGED, ifluidstate.getFluid() == Fluids.WATER);
+				.with(WATERLOGGED, fluid.getFluid() == Fluids.WATER);
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		if (stateIn.get(WATERLOGGED)) {
 			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
@@ -141,9 +147,10 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 				: super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
-		BlockPos blockpos = pos.down();
-		return hasSolidSideOnTop(worldIn, blockpos) || hasEnoughSolidSide(worldIn, blockpos, Direction.UP);
+		BlockPos floorPos = pos.down();
+		return hasSolidSideOnTop(worldIn, floorPos) || hasEnoughSolidSide(worldIn, floorPos, Direction.UP);
 	}
 
 	@Override
@@ -152,14 +159,17 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 		builder.add(FACING, WATERLOGGED);
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
 	}
 
+	@Override
 	public boolean hasComparatorInputOverride(BlockState state) {
 		return true;
 	}
 
+	@Override
 	public int getComparatorInputOverride(BlockState blockState, World worldIn, BlockPos pos) {
 		if (worldIn.getTileEntity(pos) instanceof CuttingBoardTileEntity) {
 			ItemStack boardItem = ((CuttingBoardTileEntity) worldIn.getTileEntity(pos)).getStoredItem();
@@ -180,7 +190,8 @@ public class CuttingBoardBlock extends Block implements IWaterLoggable {
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-	public static class ToolCarvingEvent {
+	public static class ToolCarvingEvent
+	{
 		@SubscribeEvent
 		public static void onSneakPlaceTool(PlayerInteractEvent.RightClickBlock event) {
 			World world = event.getWorld();

--- a/src/main/java/vectorwing/farmersdelight/blocks/LegacyTallRiceCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/LegacyTallRiceCropBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -30,7 +29,6 @@ import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
 public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable, IGrowable
@@ -46,9 +44,26 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 	 * Everything here will be permanently removed once Farmer's Delight is ported to 1.17 in the future.
 	 */
 	@Deprecated
-	public LegacyTallRiceCropBlock(Properties properties)	{
+	public LegacyTallRiceCropBlock(Properties properties) {
 		super(properties);
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, true).with(HALF, DoubleBlockHalf.LOWER).with(AGE, 5));
+	}
+
+	protected static void breakDoublePlant(World world, BlockPos pos, BlockState state, PlayerEntity player) {
+		DoubleBlockHalf doubleblockhalf = state.get(HALF);
+		if (doubleblockhalf == DoubleBlockHalf.UPPER) {
+			BlockPos blockpos = pos.down();
+			BlockState blockstate = world.getBlockState(blockpos);
+			if (blockstate.getBlock() == state.getBlock() && blockstate.get(HALF) == DoubleBlockHalf.LOWER) {
+				if (blockstate.get(HALF) == DoubleBlockHalf.LOWER) {
+					world.setBlockState(blockpos, Blocks.WATER.getDefaultState(), 35);
+				} else {
+					world.setBlockState(blockpos, Blocks.AIR.getDefaultState(), 35);
+				}
+				world.playEvent(player, 2001, blockpos, Block.getStateId(blockstate));
+			}
+		}
+
 	}
 
 	public IntegerProperty getAgeProperty() {
@@ -125,8 +140,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		worldIn.setBlockState(pos, state.with(AGE, i));
 		if (state.get(HALF) == DoubleBlockHalf.UPPER) {
 			worldIn.setBlockState(pos.down(), worldIn.getBlockState(pos.down()).with(AGE, i));
-		}
-		else {
+		} else {
 			worldIn.setBlockState(pos.up(), worldIn.getBlockState(pos.up()).with(AGE, i));
 		}
 	}
@@ -139,8 +153,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		}
 		if (facing.getAxis() != Direction.Axis.Y || half == DoubleBlockHalf.LOWER != (facing == Direction.UP) || facingState.getBlock() == this && facingState.get(HALF) != half) {
 			return half == DoubleBlockHalf.LOWER && facing == Direction.DOWN && !stateIn.isValidPosition(worldIn, currentPos) ? Blocks.AIR.getDefaultState() : stateIn;
-		}
-		else {
+		} else {
 			return Blocks.AIR.getDefaultState();
 		}
 	}
@@ -169,8 +182,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		if (!worldIn.isRemote) {
 			if (player.isCreative()) {
 				breakDoublePlant(worldIn, pos, state, player);
-			}
-			else {
+			} else {
 				spawnDrops(state, worldIn, pos, (TileEntity) null, player, player.getHeldItemMainhand());
 			}
 		}
@@ -180,24 +192,6 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 
 	public void harvestBlock(World worldIn, PlayerEntity player, BlockPos pos, BlockState state, @Nullable TileEntity te, ItemStack stack) {
 		super.harvestBlock(worldIn, player, pos, Blocks.AIR.getDefaultState(), te, stack);
-	}
-
-	protected static void breakDoublePlant(World world, BlockPos pos, BlockState state, PlayerEntity player) {
-		DoubleBlockHalf doubleblockhalf = state.get(HALF);
-		if (doubleblockhalf == DoubleBlockHalf.UPPER) {
-			BlockPos blockpos = pos.down();
-			BlockState blockstate = world.getBlockState(blockpos);
-			if (blockstate.getBlock() == state.getBlock() && blockstate.get(HALF) == DoubleBlockHalf.LOWER) {
-				if (blockstate.get(HALF) == DoubleBlockHalf.LOWER) {
-					world.setBlockState(blockpos, Blocks.WATER.getDefaultState(), 35);
-				}
-				else {
-					world.setBlockState(blockpos, Blocks.AIR.getDefaultState(), 35);
-				}
-				world.playEvent(player, 2001, blockpos, Block.getStateId(blockstate));
-			}
-		}
-
 	}
 
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
@@ -218,8 +212,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		if (state.get(HALF) != DoubleBlockHalf.UPPER) {
 			FluidState ifluidstate = worldIn.getFluidState(pos);
 			return this.isValidGround(worldIn.getBlockState(pos.down()), worldIn, pos) && ifluidstate.isTagged(FluidTags.WATER) && ifluidstate.getLevel() == 8;
-		}
-		else {
+		} else {
 			BlockState blockstate = worldIn.getBlockState(pos.down());
 			if (state.getBlock() != this)
 				return super.isValidPosition(state, worldIn, pos); //Forge: This function is called during world gen and placement, before this block is set, so if we are not 'here' then assume it's the pre-check.

--- a/src/main/java/vectorwing/farmersdelight/blocks/LegacyTallRiceCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/LegacyTallRiceCropBlock.java
@@ -86,6 +86,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		return MathHelper.nextInt(worldIn.rand, 2, 5);
 	}
 
+	@Override
 	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
 		super.tick(state, worldIn, pos, rand);
 		if (!worldIn.isAreaLoaded(pos, 1)) return;
@@ -124,6 +125,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		return ModItems.RICE.get();
 	}
 
+	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		return new ItemStack(this.getSeedsItem());
 	}
@@ -145,6 +147,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		}
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		BlockState blockstate = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 		DoubleBlockHalf half = stateIn.get(HALF);
@@ -158,6 +161,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		}
 	}
 
+	@Override
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		BlockPos blockpos = context.getPos();
@@ -169,6 +173,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 				? super.getStateForPlacement(context) : null;
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
 		worldIn.setBlockState(pos.up(), this.getDefaultState().with(WATERLOGGED, false).with(HALF, DoubleBlockHalf.UPPER), 3);
 	}
@@ -178,6 +183,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		worldIn.setBlockState(pos.up(), this.getDefaultState().with(WATERLOGGED, false).with(HALF, DoubleBlockHalf.UPPER), flags);
 	}
 
+	@Override
 	public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
 		if (!worldIn.isRemote) {
 			if (player.isCreative()) {
@@ -190,10 +196,12 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		super.onBlockHarvested(worldIn, pos, state, player);
 	}
 
+	@Override
 	public void harvestBlock(World worldIn, PlayerEntity player, BlockPos pos, BlockState state, @Nullable TileEntity te, ItemStack stack) {
 		super.harvestBlock(worldIn, player, pos, Blocks.AIR.getDefaultState(), te, stack);
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(WATERLOGGED, AGE, HALF);
 	}
@@ -208,6 +216,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		return state.isSolidSide(worldIn, pos, Direction.UP) && (state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS_BLOCK || state.getBlock() == ModBlocks.RICH_SOIL.get());
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		if (state.get(HALF) != DoubleBlockHalf.UPPER) {
 			FluidState ifluidstate = worldIn.getFluidState(pos);
@@ -235,6 +244,7 @@ public class LegacyTallRiceCropBlock extends BushBlock implements IWaterLoggable
 		return true;
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(HALF) == DoubleBlockHalf.LOWER
 				? Fluids.WATER.getStillFluidState(false)

--- a/src/main/java/vectorwing/farmersdelight/blocks/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/MushroomColonyBlock.java
@@ -23,13 +23,13 @@ import java.util.function.Supplier;
 @SuppressWarnings("deprecation")
 public class MushroomColonyBlock extends BushBlock implements IGrowable
 {
+	public static final IntegerProperty COLONY_AGE = BlockStateProperties.AGE_0_3;
 	protected static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(4.0D, 0.0D, 4.0D, 12.0D, 8.0D, 12.0D),
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 12.0D, 14.0D),
 			Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D),
 	};
-	public static final IntegerProperty COLONY_AGE = BlockStateProperties.AGE_0_3;
 	public final Supplier<Item> mushroomType;
 
 	public MushroomColonyBlock(Properties properties, Supplier<Item> mushroomType) {

--- a/src/main/java/vectorwing/farmersdelight/blocks/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/MushroomColonyBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BushBlock;
@@ -18,14 +17,12 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import vectorwing.farmersdelight.registry.ModBlocks;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 import java.util.function.Supplier;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
-public class MushroomColonyBlock extends BushBlock implements IGrowable {
+public class MushroomColonyBlock extends BushBlock implements IGrowable
+{
 	protected static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(4.0D, 0.0D, 4.0D, 12.0D, 8.0D, 12.0D),
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
@@ -65,26 +62,29 @@ public class MushroomColonyBlock extends BushBlock implements IGrowable {
 		return false;
 	}
 
+	@Override
 	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
 		super.tick(state, worldIn, pos, rand);
-		int i = state.get(COLONY_AGE);
-		if (i < 3 && worldIn.getLightSubtracted(pos.up(), 0) <= 13 && net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, rand.nextInt(5) == 0)) {
-			worldIn.setBlockState(pos, state.with(COLONY_AGE, i + 1), 2);
+		int age = state.get(COLONY_AGE);
+		if (age < 3 && worldIn.getLightSubtracted(pos.up(), 0) <= 13 && net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, rand.nextInt(5) == 0)) {
+			worldIn.setBlockState(pos, state.with(COLONY_AGE, age + 1), 2);
 			net.minecraftforge.common.ForgeHooks.onCropsGrowPost(worldIn, pos, state);
 		}
 	}
 
+	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		return new ItemStack(this.mushroomType.get());
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(COLONY_AGE);
 	}
 
 	@Override
 	public void grow(ServerWorld worldIn, Random rand, BlockPos pos, BlockState state) {
-		int i = Math.min(3, state.get(COLONY_AGE) + 1);
-		worldIn.setBlockState(pos, state.with(COLONY_AGE, i), 2);
+		int age = Math.min(3, state.get(COLONY_AGE) + 1);
+		worldIn.setBlockState(pos, state.with(COLONY_AGE, age), 2);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/OnionsBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/OnionsBlock.java
@@ -1,8 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
-import vectorwing.farmersdelight.registry.ModBlocks;
-import vectorwing.farmersdelight.registry.ModItems;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CropsBlock;
@@ -11,14 +8,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
-public class OnionsBlock extends CropsBlock {
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
+public class OnionsBlock extends CropsBlock
+{
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 4.0D, 16.0D),
@@ -26,8 +21,8 @@ public class OnionsBlock extends CropsBlock {
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 6.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 7.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D),
-			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 9.0D, 16.0D)};
-
+			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 9.0D, 16.0D)
+	};
 
 	public OnionsBlock(Properties properties) {
 		super(properties);

--- a/src/main/java/vectorwing/farmersdelight/blocks/OnionsBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/OnionsBlock.java
@@ -13,7 +13,7 @@ import vectorwing.farmersdelight.registry.ModItems;
 
 public class OnionsBlock extends CropsBlock
 {
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 4.0D, 16.0D),

--- a/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.particles.ParticleTypes;
@@ -15,12 +14,10 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.utils.tags.ModTags;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
-public class OrganicCompostBlock extends Block {
+public class OrganicCompostBlock extends Block
+{
 	public static IntegerProperty COMPOSTING = IntegerProperty.create("composting", 0, 7);
 
 	public OrganicCompostBlock(Properties properties) {
@@ -65,12 +62,12 @@ public class OrganicCompostBlock extends Block {
 		}
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void animateTick(BlockState stateIn, World worldIn, BlockPos pos, Random rand) {
 		super.animateTick(stateIn, worldIn, pos, rand);
 		if (rand.nextInt(10) == 0) {
 			worldIn.addParticle(ParticleTypes.MYCELIUM, (double) pos.getX() + (double) rand.nextFloat(), (double) pos.getY() + 1.1D, (double) pos.getZ() + (double) rand.nextFloat(), 0.0D, 0.0D, 0.0D);
 		}
-
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/PantryBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/PantryBlock.java
@@ -15,7 +15,6 @@ import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
-import net.minecraft.stats.Stats;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
@@ -30,49 +29,46 @@ import vectorwing.farmersdelight.tile.PantryTileEntity;
 import javax.annotation.Nullable;
 import java.util.Random;
 
-public class PantryBlock extends ContainerBlock {
-
+@SuppressWarnings("deprecation")
+public class PantryBlock extends ContainerBlock
+{
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final BooleanProperty OPEN = BlockStateProperties.OPEN;
 
-	public PantryBlock(Properties builder) {
-		super(builder);
-		this.setDefaultState(this.stateContainer.getBaseState().with(FACING, Direction.NORTH).with(OPEN, Boolean.FALSE));
+	public PantryBlock(Properties properties) {
+		super(properties);
+		this.setDefaultState(this.stateContainer.getBaseState().with(FACING, Direction.NORTH).with(OPEN, false));
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
-		if (worldIn.isRemote) {
-			return ActionResultType.SUCCESS;
-		}
-		else {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof PantryTileEntity) {
-				player.openContainer((PantryTileEntity) tileentity);
-				player.addStat(Stats.OPEN_BARREL);
+		if (!worldIn.isRemote) {
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof PantryTileEntity) {
+				player.openContainer((PantryTileEntity) tile);
 			}
-
-			return ActionResultType.SUCCESS;
 		}
+		return ActionResultType.SUCCESS;
 	}
 
+	@Override
 	public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof IInventory) {
-				InventoryHelper.dropInventoryItems(worldIn, pos, (IInventory) tileentity);
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof IInventory) {
+				InventoryHelper.dropInventoryItems(worldIn, pos, (IInventory) tile);
 				worldIn.updateComparatorOutputLevel(pos, this);
 			}
-
 			super.onReplaced(state, worldIn, pos, newState, isMoving);
 		}
 	}
 
+	@Override
 	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
-		TileEntity tileentity = worldIn.getTileEntity(pos);
-		if (tileentity instanceof PantryTileEntity) {
-			((PantryTileEntity) tileentity).pantryTick();
+		TileEntity tile = worldIn.getTileEntity(pos);
+		if (tile instanceof PantryTileEntity) {
+			((PantryTileEntity) tile).pantryTick();
 		}
-
 	}
 
 	@Override
@@ -80,14 +76,14 @@ public class PantryBlock extends ContainerBlock {
 		return this.getDefaultState().with(FACING, context.getPlacementHorizontalFacing().getOpposite());
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		if (stack.hasDisplayName()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof PantryTileEntity) {
-				((PantryTileEntity) tileentity).setCustomName(stack.getDisplayName());
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof PantryTileEntity) {
+				((PantryTileEntity) tile).setCustomName(stack.getDisplayName());
 			}
 		}
-
 	}
 
 	@Override
@@ -96,10 +92,12 @@ public class PantryBlock extends ContainerBlock {
 		builder.add(FACING, OPEN);
 	}
 
+	@Override
 	public boolean hasComparatorInputOverride(BlockState state) {
 		return true;
 	}
 
+	@Override
 	public int getComparatorInputOverride(BlockState blockState, World worldIn, BlockPos pos) {
 		return Container.calcRedstone(worldIn.getTileEntity(pos));
 	}
@@ -110,6 +108,7 @@ public class PantryBlock extends ContainerBlock {
 		return new PantryTileEntity();
 	}
 
+	@Override
 	public BlockRenderType getRenderType(BlockState state) {
 		return BlockRenderType.MODEL;
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/PieBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/PieBlock.java
@@ -96,8 +96,7 @@ public class PieBlock extends Block
 	protected ActionResultType consumeBite(World worldIn, BlockPos pos, BlockState state, PlayerEntity playerIn) {
 		if (!playerIn.canEat(false)) {
 			return ActionResultType.PASS;
-		}
-		else {
+		} else {
 			playerIn.getFoodStats().addStats(this.getBiteHunger(), this.getBiteSaturation());
 			if (this.getPieEffect() != null) {
 				playerIn.addPotionEffect(this.getPieEffect());

--- a/src/main/java/vectorwing/farmersdelight/blocks/PieBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/PieBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mezz.jei.api.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -25,13 +24,11 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import vectorwing.farmersdelight.utils.tags.ModTags;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Supplier;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
-public class PieBlock extends Block {
-
+@SuppressWarnings("deprecation")
+public class PieBlock extends Block
+{
 	public static final IntegerProperty BITES = IntegerProperty.create("bites", 0, 3);
 	protected static final VoxelShape[] SHAPES = new VoxelShape[]{
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D),
@@ -65,10 +62,12 @@ public class PieBlock extends Block {
 		return new EffectInstance(Effects.SPEED, 1800, 0);
 	}
 
+	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPES[state.get(BITES)];
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		ItemStack itemstack = player.getHeldItem(handIn);
 		if (worldIn.isRemote) {
@@ -94,7 +93,7 @@ public class PieBlock extends Block {
 	/**
 	 * Eats a slice from the pie, feeding the player.
 	 */
-	private ActionResultType consumeBite(World worldIn, BlockPos pos, BlockState state, PlayerEntity playerIn) {
+	protected ActionResultType consumeBite(World worldIn, BlockPos pos, BlockState state, PlayerEntity playerIn) {
 		if (!playerIn.canEat(false)) {
 			return ActionResultType.PASS;
 		}
@@ -103,11 +102,10 @@ public class PieBlock extends Block {
 			if (this.getPieEffect() != null) {
 				playerIn.addPotionEffect(this.getPieEffect());
 			}
-			int i = state.get(BITES);
-			if (i < getMaxBites() - 1) {
-				worldIn.setBlockState(pos, state.with(BITES, i + 1), 3);
-			}
-			else {
+			int bites = state.get(BITES);
+			if (bites < getMaxBites() - 1) {
+				worldIn.setBlockState(pos, state.with(BITES, bites + 1), 3);
+			} else {
 				worldIn.removeBlock(pos, false);
 			}
 			worldIn.playSound(null, pos, SoundEvents.ENTITY_GENERIC_EAT, SoundCategory.PLAYERS, 0.8F, 0.8F);
@@ -118,12 +116,11 @@ public class PieBlock extends Block {
 	/**
 	 * Cuts off a bite and drops a slice item, without feeding the player.
 	 */
-	private ActionResultType cutSlice(World worldIn, BlockPos pos, BlockState state) {
-		int i = state.get(BITES);
-		if (i < getMaxBites() - 1) {
-			worldIn.setBlockState(pos, state.with(BITES, i + 1), 3);
-		}
-		else {
+	protected ActionResultType cutSlice(World worldIn, BlockPos pos, BlockState state) {
+		int bites = state.get(BITES);
+		if (bites < getMaxBites() - 1) {
+			worldIn.setBlockState(pos, state.with(BITES, bites + 1), 3);
+		} else {
 			worldIn.removeBlock(pos, false);
 		}
 		InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), this.getPieSliceItem());
@@ -131,26 +128,32 @@ public class PieBlock extends Block {
 		return ActionResultType.SUCCESS;
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		return facing == Direction.DOWN && !stateIn.isValidPosition(worldIn, currentPos) ? Blocks.AIR.getDefaultState() : super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		return worldIn.getBlockState(pos.down()).getMaterial().isSolid();
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(BITES);
 	}
 
+	@Override
 	public int getComparatorInputOverride(BlockState blockState, World worldIn, BlockPos pos) {
 		return getMaxBites() - blockState.get(BITES);
 	}
 
+	@Override
 	public boolean hasComparatorInputOverride(BlockState state) {
 		return true;
 	}
 
+	@Override
 	public boolean allowsMovement(BlockState state, IBlockReader worldIn, BlockPos pos, PathType type) {
 		return false;
 	}
@@ -158,5 +161,4 @@ public class PieBlock extends Block {
 	public int getMaxBites() {
 		return 4;
 	}
-
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceBaleBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceBaleBlock.java
@@ -1,9 +1,7 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
@@ -15,39 +13,37 @@ import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
-public class RiceBaleBlock extends Block {
+public class RiceBaleBlock extends Block
+{
 	public static final DirectionProperty FACING = BlockStateProperties.FACING;
-
-	public RiceBaleBlock() {
-		super(Properties.from(Blocks.HAY_BLOCK));
-	}
 
 	public RiceBaleBlock(Properties properties) {
 		super(properties);
 		this.setDefaultState(this.getStateContainer().getBaseState().with(FACING, Direction.UP));
 	}
 
+	@Override
 	public void onFallenUpon(World worldIn, BlockPos pos, Entity entityIn, float fallDistance) {
 		entityIn.onLivingFall(fallDistance, 0.2F);
 	}
 
+	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		return this.getDefaultState().with(FACING, context.getFace());
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(FACING);
 	}
 
+	@Override
 	public BlockState rotate(BlockState state, Rotation rot) {
 		return state.with(FACING, rot.rotate(state.get(FACING)));
 	}
 
+	@Override
 	public BlockState mirror(BlockState state, Mirror mirrorIn) {
 		return state.rotate(mirrorIn.toRotation(state.get(FACING)));
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
@@ -33,7 +33,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 {
 	public static final IntegerProperty AGE = BlockStateProperties.AGE_0_3;
 	public static final BooleanProperty SUPPORTING = BooleanProperty.create("supporting");
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D),
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 12.0D, 14.0D),
@@ -52,9 +52,9 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 			int age = this.getAge(state);
 			if (age <= this.getMaxAge()) {
 				float chance = 10;
-				if (net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, rand.nextInt((int)(25.0F / chance) + 1) == 0)) {
+				if (net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, rand.nextInt((int) (25.0F / chance) + 1) == 0)) {
 					if (age == this.getMaxAge()) {
-						RiceUpperCropBlock riceUpper = (RiceUpperCropBlock)ModBlocks.RICE_UPPER_CROP.get();
+						RiceUpperCropBlock riceUpper = (RiceUpperCropBlock) ModBlocks.RICE_UPPER_CROP.get();
 						if (riceUpper.getDefaultState().isValidPosition(worldIn, pos.up()) && worldIn.isAirBlock(pos.up())) {
 							worldIn.setBlockState(pos.up(), riceUpper.getDefaultState());
 							net.minecraftforge.common.ForgeHooks.onCropsGrowPost(worldIn, pos, state);
@@ -139,7 +139,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 	public boolean canGrow(IBlockReader worldIn, BlockPos pos, BlockState state, boolean isClient) {
 		BlockState upperState = worldIn.getBlockState(pos.up());
 		if (upperState.getBlock() instanceof RiceUpperCropBlock) {
-			return !((RiceUpperCropBlock)upperState.getBlock()).isMaxAge(upperState);
+			return !((RiceUpperCropBlock) upperState.getBlock()).isMaxAge(upperState);
 		}
 		return true;
 	}
@@ -154,7 +154,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 	}
 
 	@Override
-	public void grow(ServerWorld worldIn, Random rand, BlockPos pos, BlockState state){
+	public void grow(ServerWorld worldIn, Random rand, BlockPos pos, BlockState state) {
 		int ageGrowth = Math.min(this.getAge(state) + this.getBonemealAgeIncrease(worldIn), 7);
 		if (ageGrowth <= this.getMaxAge()) {
 			worldIn.setBlockState(pos, state.with(AGE, ageGrowth));
@@ -166,7 +166,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 					growable.grow(worldIn, worldIn.rand, pos.up(), top);
 				}
 			} else {
-				RiceUpperCropBlock riceUpper = (RiceUpperCropBlock)ModBlocks.RICE_UPPER_CROP.get();
+				RiceUpperCropBlock riceUpper = (RiceUpperCropBlock) ModBlocks.RICE_UPPER_CROP.get();
 				int remainingGrowth = ageGrowth - this.getMaxAge() - 1;
 				if (riceUpper.getDefaultState().isValidPosition(worldIn, pos.up()) && worldIn.isAirBlock(pos.up())) {
 					worldIn.setBlockState(pos, state.with(AGE, this.getMaxAge()));

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
@@ -73,6 +73,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		return SHAPE_BY_AGE[state.get(this.getAgeProperty())];
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		FluidState fluid = worldIn.getFluidState(pos);
 		return super.isValidPosition(state, worldIn, pos) && fluid.isTagged(FluidTags.WATER) && fluid.getLevel() == 8;
@@ -113,6 +114,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		builder.add(AGE, SUPPORTING);
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		BlockState state = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 		if (!state.isAir()) {
@@ -129,6 +131,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		return topState.getBlock() == ModBlocks.RICE_UPPER_CROP.get();
 	}
 
+	@Override
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		FluidState fluid = context.getWorld().getFluidState(context.getPos());

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceCropBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
@@ -27,13 +26,11 @@ import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
-public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContainer {
+public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContainer
+{
 	public static final IntegerProperty AGE = BlockStateProperties.AGE_0_3;
 	public static final BooleanProperty SUPPORTING = BooleanProperty.create("supporting");
 	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
@@ -42,11 +39,12 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 12.0D, 14.0D),
 			Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D)};
 
-	public RiceCropBlock(Properties builder) {
-		super(builder);
+	public RiceCropBlock(Properties properties) {
+		super(properties);
 		this.setDefaultState(this.getDefaultState().with(AGE, 0).with(SUPPORTING, false));
 	}
 
+	@Override
 	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
 		super.tick(state, worldIn, pos, rand);
 		if (!worldIn.isAreaLoaded(pos, 1)) return;
@@ -76,8 +74,8 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 	}
 
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
-		FluidState ifluidstate = worldIn.getFluidState(pos);
-		return super.isValidPosition(state, worldIn, pos) && ifluidstate.isTagged(FluidTags.WATER) && ifluidstate.getLevel() == 8;
+		FluidState fluid = worldIn.getFluidState(pos);
+		return super.isValidPosition(state, worldIn, pos) && fluid.isTagged(FluidTags.WATER) && fluid.getLevel() == 8;
 	}
 
 	@Override
@@ -97,6 +95,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		return 3;
 	}
 
+	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		return new ItemStack(ModItems.RICE.get());
 	}
@@ -115,15 +114,15 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 	}
 
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
-		BlockState blockstate = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
-		if (!blockstate.isAir()) {
+		BlockState state = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
+		if (!state.isAir()) {
 			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
 		}
 		if (facing == Direction.UP) {
-			return blockstate.with(SUPPORTING, isSupportingRiceUpper(facingState));
+			return state.with(SUPPORTING, isSupportingRiceUpper(facingState));
 		}
 
-		return blockstate;
+		return state;
 	}
 
 	public boolean isSupportingRiceUpper(BlockState topState) {
@@ -132,10 +131,11 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		FluidState ifluidstate = context.getWorld().getFluidState(context.getPos());
-		return ifluidstate.isTagged(FluidTags.WATER) && ifluidstate.getLevel() == 8 ? super.getStateForPlacement(context) : null;
+		FluidState fluid = context.getWorld().getFluidState(context.getPos());
+		return fluid.isTagged(FluidTags.WATER) && fluid.getLevel() == 8 ? super.getStateForPlacement(context) : null;
 	}
 
+	@Override
 	public boolean canGrow(IBlockReader worldIn, BlockPos pos, BlockState state, boolean isClient) {
 		BlockState upperState = worldIn.getBlockState(pos.up());
 		if (upperState.getBlock() instanceof RiceUpperCropBlock) {
@@ -144,6 +144,7 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		return true;
 	}
 
+	@Override
 	public boolean canUseBonemeal(World worldIn, Random rand, BlockPos pos, BlockState state) {
 		return true;
 	}
@@ -175,14 +176,17 @@ public class RiceCropBlock extends BushBlock implements IGrowable, ILiquidContai
 		}
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return Fluids.WATER.getStillFluidState(false);
 	}
 
+	@Override
 	public boolean canContainFluid(IBlockReader worldIn, BlockPos pos, BlockState state, Fluid fluidIn) {
 		return false;
 	}
 
+	@Override
 	public boolean receiveFluid(IWorld worldIn, BlockPos pos, BlockState state, FluidState fluidStateIn) {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceUpperCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceUpperCropBlock.java
@@ -20,7 +20,7 @@ import vectorwing.farmersdelight.registry.ModItems;
 public class RiceUpperCropBlock extends CropsBlock
 {
 	public static final IntegerProperty RICE_AGE = BlockStateProperties.AGE_0_3;
-	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D),
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 12.0D, 14.0D),

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceUpperCropBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceUpperCropBlock.java
@@ -17,18 +17,21 @@ import net.minecraft.world.World;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
-public class RiceUpperCropBlock extends CropsBlock {
+public class RiceUpperCropBlock extends CropsBlock
+{
 	public static final IntegerProperty RICE_AGE = BlockStateProperties.AGE_0_3;
 	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[] {
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D),
 			Block.makeCuboidShape(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
 			Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 12.0D, 14.0D),
-			Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D)};
+			Block.makeCuboidShape(1.0D, 0.0D, 1.0D, 15.0D, 16.0D, 15.0D)
+	};
 
-	public RiceUpperCropBlock(Properties builder) {
-		super(builder);
+	public RiceUpperCropBlock(Properties properties) {
+		super(properties);
 	}
 
+	@Override
 	public IntegerProperty getAgeProperty() {
 		return RICE_AGE;
 	}
@@ -58,6 +61,7 @@ public class RiceUpperCropBlock extends CropsBlock {
 		return state.getBlock() == ModBlocks.RICE_CROP.get();
 	}
 
+	@Override
 	protected int getBonemealAgeIncrease(World worldIn) {
 		return MathHelper.nextInt(worldIn.rand, 1, 4);
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/RichSoilBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RichSoilBlock.java
@@ -14,7 +14,7 @@ import java.util.Random;
 @SuppressWarnings("deprecation")
 public class RichSoilBlock extends Block
 {
-	public RichSoilBlock(Properties properties)	{
+	public RichSoilBlock(Properties properties) {
 		super(properties);
 	}
 
@@ -27,11 +27,9 @@ public class RichSoilBlock extends Block
 			}
 			if (plant.getBlock() == Blocks.BROWN_MUSHROOM) {
 				worldIn.setBlockState(pos.up(), ModBlocks.BROWN_MUSHROOM_COLONY.get().getDefaultState().with(MushroomColonyBlock.COLONY_AGE, 0));
-			}
-			if (plant.getBlock() == Blocks.RED_MUSHROOM) {
+			} else if (plant.getBlock() == Blocks.RED_MUSHROOM) {
 				worldIn.setBlockState(pos.up(), ModBlocks.RED_MUSHROOM_COLONY.get().getDefaultState().with(MushroomColonyBlock.COLONY_AGE, 0));
-			}
-			if (plant.getBlock() instanceof IGrowable && MathUtils.RAND.nextInt(10) <= 2) {
+			} else if (plant.getBlock() instanceof IGrowable && MathUtils.RAND.nextInt(10) <= 2) {
 				IGrowable growable = (IGrowable) plant.getBlock();
 				if (growable.canGrow(worldIn, pos.up(), plant, false)) {
 					growable.grow(worldIn, worldIn.rand, pos.up(), plant);
@@ -40,9 +38,9 @@ public class RichSoilBlock extends Block
 		}
 	}
 
-    @Override
-    public boolean canSustainPlant(BlockState state, IBlockReader world, BlockPos pos, Direction facing, net.minecraftforge.common.IPlantable plantable) {
-        net.minecraftforge.common.PlantType type = plantable.getPlantType(world, pos.offset(facing));
-        return type != PlantType.CROP && type != PlantType.NETHER;
-    }
+	@Override
+	public boolean canSustainPlant(BlockState state, IBlockReader world, BlockPos pos, Direction facing, net.minecraftforge.common.IPlantable plantable) {
+		net.minecraftforge.common.PlantType type = plantable.getPlantType(world, pos.offset(facing));
+		return type != PlantType.CROP && type != PlantType.NETHER;
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/RichSoilBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RichSoilBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -10,16 +9,11 @@ import net.minecraftforge.common.PlantType;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.utils.MathUtils;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
-public class RichSoilBlock extends Block {
-	public RichSoilBlock() {
-		super(Properties.from(Blocks.DIRT));
-	}
-
+@SuppressWarnings("deprecation")
+public class RichSoilBlock extends Block
+{
 	public RichSoilBlock(Properties properties)	{
 		super(properties);
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/RichSoilFarmlandBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RichSoilFarmlandBlock.java
@@ -85,6 +85,7 @@ public class RichSoilFarmlandBlock extends FarmlandBlock
 		return type == PlantType.CROP || type == PlantType.PLAINS;
 	}
 
+	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		return !this.getDefaultState().isValidPosition(context.getWorld(), context.getPos()) ? ModBlocks.RICH_SOIL.get().getDefaultState() : super.getStateForPlacement(context);
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/RichSoilFarmlandBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RichSoilFarmlandBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.BlockItemUseContext;
@@ -15,23 +14,21 @@ import net.minecraftforge.common.PlantType;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.utils.MathUtils;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 public class RichSoilFarmlandBlock extends FarmlandBlock
 {
-	public RichSoilFarmlandBlock(Properties builder) {
-		super(builder);
+	public RichSoilFarmlandBlock(Properties properties) {
+		super(properties);
 	}
 
     @Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
-		BlockState blockstate = worldIn.getBlockState(pos.up());
-		return !blockstate.getMaterial().isSolid() || blockstate.getBlock() instanceof FenceGateBlock || blockstate.getBlock() instanceof MovingPistonBlock || blockstate.getBlock() instanceof StemGrownBlock;
+		BlockState aboveState = worldIn.getBlockState(pos.up());
+		return !aboveState.getMaterial().isSolid() || aboveState.getBlock() instanceof FenceGateBlock || aboveState.getBlock() instanceof MovingPistonBlock || aboveState.getBlock() instanceof StemGrownBlock;
 	}
 
+	@Override
 	public boolean isFertile(BlockState state, IBlockReader world, BlockPos pos) {
 		if (this.getBlock() == this)
             return state.get(RichSoilFarmlandBlock.MOISTURE) > 0;
@@ -39,21 +36,23 @@ public class RichSoilFarmlandBlock extends FarmlandBlock
 		return false;
     }
 
+	@Override
     public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
 	    if (!state.isValidPosition(worldIn, pos)) {
             turnToRichSoil(state, worldIn, pos);
         }
     }
 
+	@Override
     public void randomTick(BlockState state, ServerWorld worldIn, BlockPos pos, Random random) {
-        int i = state.get(MOISTURE);
+        int moisture = state.get(MOISTURE);
         if (!hasWater(worldIn, pos) && !worldIn.isRainingAt(pos.up())) {
-            if (i > 0) {
-                worldIn.setBlockState(pos, state.with(MOISTURE, i - 1), 2);
+            if (moisture > 0) {
+                worldIn.setBlockState(pos, state.with(MOISTURE, moisture - 1), 2);
             }
-        } else if (i < 7) {
+        } else if (moisture < 7) {
             worldIn.setBlockState(pos, state.with(MOISTURE, 7), 2);
-        } else if (i == 7) {
+        } else if (moisture == 7) {
             BlockState plant = worldIn.getBlockState(pos.up());
             if (plant.getBlock() instanceof TallFlowerBlock) {
 				return;

--- a/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
@@ -52,7 +52,7 @@ public class RopeBlock extends PaneBlock
 				BlockState blockStateAbove = worldIn.getBlockState(blockpos$mutable);
 				Block blockAbove = blockStateAbove.getBlock();
 				if (blockAbove == Blocks.BELL) {
-					((BellBlock)blockAbove).ring(worldIn, blockpos$mutable, blockStateAbove.get(BellBlock.HORIZONTAL_FACING).rotateY());
+					((BellBlock) blockAbove).ring(worldIn, blockpos$mutable, blockStateAbove.get(BellBlock.HORIZONTAL_FACING).rotateY());
 					return ActionResultType.SUCCESS;
 				} else if (blockAbove == ModBlocks.ROPE.get()) {
 					blockpos$mutable.move(Direction.UP);

--- a/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
@@ -37,6 +37,7 @@ public class RopeBlock extends PaneBlock
 		return true;
 	}
 
+	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		IBlockReader world = context.getWorld();
 		BlockPos posAbove = context.getPos().up();
@@ -44,6 +45,7 @@ public class RopeBlock extends PaneBlock
 		return state != null ? state.with(TIED_TO_BELL, world.getBlockState(posAbove).getBlock() == Blocks.BELL) : null;
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		if (player.getHeldItem(handIn).isEmpty()) {
 			BlockPos.Mutable blockpos$mutable = pos.toMutable().move(Direction.UP);

--- a/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RopeBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.PlayerEntity;
@@ -9,7 +8,9 @@ import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.pathfinding.PathType;
 import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.StateContainer;
-import net.minecraft.util.*;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Direction;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -21,17 +22,13 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import vectorwing.farmersdelight.registry.ModBlocks;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
 public class RopeBlock extends PaneBlock
 {
 	public static final BooleanProperty TIED_TO_BELL = BooleanProperty.create("tied_to_bell");
 
 	public RopeBlock() {
-		super(Properties.create(Material.CARPET).doesNotBlockMovement().notSolid().hardnessAndResistance(0.1F).sound(SoundType.CLOTH));
+		super(Properties.create(Material.CARPET).doesNotBlockMovement().notSolid().hardnessAndResistance(0.2F).sound(SoundType.CLOTH));
 		this.setDefaultState(this.stateContainer.getBaseState().with(TIED_TO_BELL, false));
 	}
 
@@ -41,10 +38,10 @@ public class RopeBlock extends PaneBlock
 	}
 
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		IBlockReader iblockreader = context.getWorld();
+		IBlockReader world = context.getWorld();
 		BlockPos posAbove = context.getPos().up();
 		BlockState state = super.getStateForPlacement(context);
-		return state != null ? state.with(TIED_TO_BELL, iblockreader.getBlockState(posAbove).getBlock() == Blocks.BELL) : null;
+		return state != null ? state.with(TIED_TO_BELL, world.getBlockState(posAbove).getBlock() == Blocks.BELL) : null;
 	}
 
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
@@ -68,14 +65,17 @@ public class RopeBlock extends PaneBlock
 		return ActionResultType.PASS;
 	}
 
+	@Override
 	public VoxelShape getCollisionShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return VoxelShapes.empty();
 	}
 
+	@Override
 	public boolean isReplaceable(BlockState state, BlockItemUseContext useContext) {
 		return useContext.getItem().getItem() == this.asItem();
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		if (stateIn.get(WATERLOGGED)) {
 			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
@@ -91,6 +91,7 @@ public class RopeBlock extends PaneBlock
 				: super.updatePostPlacement(stateIn.with(TIED_TO_BELL, tiedToBell), facing, facingState, worldIn, currentPos, facingPos);
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(NORTH, EAST, WEST, SOUTH, WATERLOGGED, TIED_TO_BELL);
 	}
@@ -99,5 +100,4 @@ public class RopeBlock extends PaneBlock
 	public boolean isLadder(BlockState state, IWorldReader world, BlockPos pos, net.minecraft.entity.LivingEntity entity) {
 		return true;
 	}
-
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/SafetyNetBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/SafetyNetBlock.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.IWaterLoggable;
@@ -24,12 +23,10 @@ import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 @SuppressWarnings("deprecation")
-public class SafetyNetBlock extends Block implements IWaterLoggable {
+public class SafetyNetBlock extends Block implements IWaterLoggable
+{
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(0.0D, 8.0D, 0.0D, 16.0D, 9.0D, 16.0D);
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
@@ -45,8 +42,8 @@ public class SafetyNetBlock extends Block implements IWaterLoggable {
 
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		FluidState ifluidstate = context.getWorld().getFluidState(context.getPos());
-		return this.getDefaultState().with(WATERLOGGED, ifluidstate.getFluid() == Fluids.WATER);
+		FluidState fluid = context.getWorld().getFluidState(context.getPos());
+		return this.getDefaultState().with(WATERLOGGED, fluid.getFluid() == Fluids.WATER);
 	}
 
 	@Override
@@ -58,29 +55,30 @@ public class SafetyNetBlock extends Block implements IWaterLoggable {
 		return super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
 	}
 
+	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
 		return SHAPE;
 	}
 
+	@Override
 	public void onFallenUpon(World worldIn, BlockPos pos, Entity entityIn, float fallDistance) {
 		if (entityIn.isSuppressingBounce()) {
 			super.onFallenUpon(worldIn, pos, entityIn, fallDistance);
-		}
-		else {
+		} else {
 			entityIn.onLivingFall(fallDistance, 0.0F);
 		}
-
 	}
 
+	@Override
 	public void onLanded(IBlockReader worldIn, Entity entityIn) {
 		if (entityIn.isSuppressingBounce()) {
 			super.onLanded(worldIn, entityIn);
-		}
-		else {
+		} else {
 			this.bounceEntity(entityIn);
 		}
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/SafetyNetBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/SafetyNetBlock.java
@@ -27,8 +27,8 @@ import javax.annotation.Nullable;
 @SuppressWarnings("deprecation")
 public class SafetyNetBlock extends Block implements IWaterLoggable
 {
-	protected static final VoxelShape SHAPE = Block.makeCuboidShape(0.0D, 8.0D, 0.0D, 16.0D, 9.0D, 16.0D);
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	protected static final VoxelShape SHAPE = Block.makeCuboidShape(0.0D, 8.0D, 0.0D, 16.0D, 9.0D, 16.0D);
 
 	public SafetyNetBlock() {
 		super(Block.Properties.create(Material.CARPET).hardnessAndResistance(0.2F).sound(SoundType.CLOTH));

--- a/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
@@ -60,8 +60,7 @@ public class StoveBlock extends Block
 					if (usedItem instanceof ShovelItem) {
 						extinguish(state, worldIn, pos);
 						return ActionResultType.SUCCESS;
-					}
-					else if (usedItem == Items.WATER_BUCKET) {
+					} else if (usedItem == Items.WATER_BUCKET) {
 						extinguish(state, worldIn, pos);
 						player.setHeldItem(handIn, new ItemStack(Items.BUCKET));
 						return ActionResultType.SUCCESS;

--- a/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StoveBlock.java
@@ -1,8 +1,6 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.*;
-import net.minecraft.block.material.Material;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -30,34 +28,27 @@ import vectorwing.farmersdelight.tile.StoveTileEntity;
 import vectorwing.farmersdelight.utils.MathUtils;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Optional;
 import java.util.Random;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 @SuppressWarnings("deprecation")
-public class StoveBlock extends Block {
+public class StoveBlock extends Block
+{
 	public static final BooleanProperty LIT = BlockStateProperties.LIT;
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
-
-	public StoveBlock() {
-		super(Properties.create(Material.ROCK)
-				.hardnessAndResistance(2.0F, 6.0F)
-				.sound(SoundType.STONE));
-	}
 
 	public StoveBlock(AbstractBlock.Properties builder) {
 		super(builder);
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		ItemStack itemstack = player.getHeldItem(handIn);
 		Item usedItem = itemstack.getItem();
 		if (state.get(LIT)) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof StoveTileEntity) {
-				StoveTileEntity stovetileentity = (StoveTileEntity) tileentity;
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof StoveTileEntity) {
+				StoveTileEntity stovetileentity = (StoveTileEntity) tile;
 				Optional<CampfireCookingRecipe> optional = stovetileentity.findMatchingRecipe(itemstack);
 				if (optional.isPresent()) {
 					if (!worldIn.isRemote && !stovetileentity.isStoveBlockedAbove() && stovetileentity.addItem(player.abilities.isCreativeMode ? itemstack.copy() : itemstack, optional.get().getCookTime())) {
@@ -65,8 +56,7 @@ public class StoveBlock extends Block {
 						return ActionResultType.SUCCESS;
 					}
 					return ActionResultType.CONSUME;
-				}
-				else {
+				} else {
 					if (usedItem instanceof ShovelItem) {
 						extinguish(state, worldIn, pos);
 						return ActionResultType.SUCCESS;
@@ -78,8 +68,7 @@ public class StoveBlock extends Block {
 					}
 				}
 			}
-		}
-		else {
+		} else {
 			if (itemstack.getItem() instanceof FlintAndSteelItem) {
 				worldIn.playSound(player, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.BLOCKS, 1.0F, MathUtils.RAND.nextFloat() * 0.4F + 0.8F);
 				worldIn.setBlockState(pos, state.with(BlockStateProperties.LIT, Boolean.TRUE), 11);
@@ -102,10 +91,10 @@ public class StoveBlock extends Block {
 
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return this.getDefaultState().with(FACING, context.getPlacementHorizontalFacing().getOpposite())
-				.with(LIT, true);
+		return this.getDefaultState().with(FACING, context.getPlacementHorizontalFacing().getOpposite()).with(LIT, true);
 	}
 
+	@Override
 	public void onEntityWalk(World worldIn, BlockPos pos, Entity entityIn) {
 		boolean isLit = worldIn.getBlockState(pos).get(StoveBlock.LIT);
 		if (isLit && !entityIn.isImmuneToFire() && entityIn instanceof LivingEntity && !EnchantmentHelper.hasFrostWalker((LivingEntity) entityIn)) {
@@ -115,11 +104,12 @@ public class StoveBlock extends Block {
 		super.onEntityWalk(worldIn, pos, entityIn);
 	}
 
+	@Override
 	public void onReplaced(BlockState state, World worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (state.getBlock() != newState.getBlock()) {
-			TileEntity tileentity = worldIn.getTileEntity(pos);
-			if (tileentity instanceof StoveTileEntity) {
-				InventoryHelper.dropItems(worldIn, pos, ((StoveTileEntity) tileentity).getInventory());
+			TileEntity tile = worldIn.getTileEntity(pos);
+			if (tile instanceof StoveTileEntity) {
+				InventoryHelper.dropItems(worldIn, pos, ((StoveTileEntity) tile).getInventory());
 			}
 
 			super.onReplaced(state, worldIn, pos, newState, isMoving);

--- a/src/main/java/vectorwing/farmersdelight/blocks/TatamiBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TatamiBlock.java
@@ -17,7 +17,9 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 
-public class TatamiBlock extends Block {
+@SuppressWarnings("deprecation")
+public class TatamiBlock extends Block
+{
 	public static final DirectionProperty FACING = BlockStateProperties.FACING;
 	public static final BooleanProperty PAIRED = BooleanProperty.create("paired");
 
@@ -40,21 +42,21 @@ public class TatamiBlock extends Block {
 		return this.getDefaultState().with(FACING, context.getFace().getOpposite()).with(PAIRED, pairing);
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		super.onBlockPlacedBy(worldIn, pos, state, placer, stack);
 		if (!worldIn.isRemote) {
 			if (placer != null && placer.isSneaking()) {
 				return;
 			}
-			BlockPos blockpos = pos.offset(state.get(FACING));
-			BlockState blockstate = worldIn.getBlockState(blockpos);
-			if (blockstate.getBlock() == this && !blockstate.get(PAIRED)) {
-				worldIn.setBlockState(blockpos, state.with(FACING, state.get(FACING).getOpposite()).with(PAIRED, true), 3);
+			BlockPos facingPos = pos.offset(state.get(FACING));
+			BlockState facingState = worldIn.getBlockState(facingPos);
+			if (facingState.getBlock() == this && !facingState.get(PAIRED)) {
+				worldIn.setBlockState(facingPos, state.with(FACING, state.get(FACING).getOpposite()).with(PAIRED, true), 3);
 				worldIn.func_230547_a_(pos, Blocks.AIR);
 				state.updateNeighbours(worldIn, pos, 3);
 			}
 		}
-
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/blocks/TatamiHalfMatBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TatamiHalfMatBlock.java
@@ -9,7 +9,9 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 
-public class TatamiHalfMatBlock extends Block {
+@SuppressWarnings("deprecation")
+public class TatamiHalfMatBlock extends Block
+{
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D);
 
 	public TatamiHalfMatBlock() {

--- a/src/main/java/vectorwing/farmersdelight/blocks/TatamiHalfMatBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TatamiHalfMatBlock.java
@@ -1,6 +1,8 @@
 package vectorwing.farmersdelight.blocks;
 
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;

--- a/src/main/java/vectorwing/farmersdelight/blocks/TatamiMatBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TatamiMatBlock.java
@@ -32,6 +32,10 @@ public class TatamiMatBlock extends HorizontalBlock
 		this.setDefaultState(this.getStateContainer().getBaseState().with(PART, BedPart.FOOT));
 	}
 
+	private static Direction getDirectionToOther(BedPart part, Direction direction) {
+		return part == BedPart.FOOT ? direction : direction.getOpposite();
+	}
+
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(HORIZONTAL_FACING, PART);
@@ -59,10 +63,6 @@ public class TatamiMatBlock extends HorizontalBlock
 	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		return !worldIn.isAirBlock(pos.down());
-	}
-
-	private static Direction getDirectionToOther(BedPart part, Direction direction) {
-		return part == BedPart.FOOT ? direction : direction.getOpposite();
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/blocks/TatamiMatBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TatamiMatBlock.java
@@ -10,8 +10,6 @@ import net.minecraft.state.EnumProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BedPart;
 import net.minecraft.state.properties.BlockStateProperties;
-import net.minecraft.stats.Stats;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -23,7 +21,9 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 
-public class TatamiMatBlock extends HorizontalBlock {
+@SuppressWarnings("deprecation")
+public class TatamiMatBlock extends HorizontalBlock
+{
 	public static final EnumProperty<BedPart> PART = BlockStateProperties.BED_PART;
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D);
 
@@ -65,21 +65,16 @@ public class TatamiMatBlock extends HorizontalBlock {
 		return part == BedPart.FOOT ? direction : direction.getOpposite();
 	}
 
-//	@Override
-//	public void harvestBlock(World worldIn, PlayerEntity player, BlockPos pos, BlockState state, @Nullable TileEntity te, ItemStack stack) {
-//		super.harvestBlock(worldIn, player, pos, Blocks.AIR.getDefaultState(), te, stack);
-//	}
-
 	@Override
 	public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
 		if (!worldIn.isRemote && player.isCreative()) {
-			BedPart bedpart = state.get(PART);
-			if (bedpart == BedPart.FOOT) {
-				BlockPos blockpos = pos.offset(getDirectionToOther(bedpart, state.get(HORIZONTAL_FACING)));
-				BlockState blockstate = worldIn.getBlockState(blockpos);
-				if (blockstate.getBlock() == this && blockstate.get(PART) == BedPart.HEAD) {
-					worldIn.setBlockState(blockpos, Blocks.AIR.getDefaultState(), 35);
-					worldIn.playEvent(player, 2001, blockpos, Block.getStateId(blockstate));
+			BedPart part = state.get(PART);
+			if (part == BedPart.FOOT) {
+				BlockPos pairPos = pos.offset(getDirectionToOther(part, state.get(HORIZONTAL_FACING)));
+				BlockState pairState = worldIn.getBlockState(pairPos);
+				if (pairState.getBlock() == this && pairState.get(PART) == BedPart.HEAD) {
+					worldIn.setBlockState(pairPos, Blocks.AIR.getDefaultState(), 35);
+					worldIn.playEvent(player, 2001, pairPos, Block.getStateId(pairState));
 				}
 			}
 		}
@@ -96,8 +91,8 @@ public class TatamiMatBlock extends HorizontalBlock {
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		super.onBlockPlacedBy(worldIn, pos, state, placer, stack);
 		if (!worldIn.isRemote) {
-			BlockPos blockpos = pos.offset(state.get(HORIZONTAL_FACING));
-			worldIn.setBlockState(blockpos, state.with(PART, BedPart.HEAD), 3);
+			BlockPos facingPos = pos.offset(state.get(HORIZONTAL_FACING));
+			worldIn.setBlockState(facingPos, state.with(PART, BedPart.HEAD), 3);
 			worldIn.func_230547_a_(pos, Blocks.AIR);
 			state.updateNeighbours(worldIn, pos, 3);
 		}
@@ -106,9 +101,9 @@ public class TatamiMatBlock extends HorizontalBlock {
 	@Override
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		Direction direction = context.getPlacementHorizontalFacing();
-		BlockPos blockpos = context.getPos();
-		BlockPos blockpos1 = blockpos.offset(direction);
-		return context.getWorld().getBlockState(blockpos1).isReplaceable(context) ? this.getDefaultState().with(HORIZONTAL_FACING, direction) : null;
+		Direction facing = context.getPlacementHorizontalFacing();
+		BlockPos pos = context.getPos();
+		BlockPos pairPos = pos.offset(facing);
+		return context.getWorld().getBlockState(pairPos).isReplaceable(context) ? this.getDefaultState().with(HORIZONTAL_FACING, facing) : null;
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/TomatoesBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TomatoesBlock.java
@@ -1,7 +1,5 @@
 package vectorwing.farmersdelight.blocks;
 
-
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BushBlock;
@@ -29,13 +27,11 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import vectorwing.farmersdelight.registry.ModItems;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Random;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 @SuppressWarnings("deprecation")
-public class TomatoesBlock extends BushBlock implements IGrowable {
+public class TomatoesBlock extends BushBlock implements IGrowable
+{
 	private static final int TOMATO_BEARING_AGE = 7;
 	public static final IntegerProperty AGE = BlockStateProperties.AGE_0_7;
 	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
@@ -74,14 +70,16 @@ public class TomatoesBlock extends BushBlock implements IGrowable {
 		return SHAPE_BY_AGE[state.get(AGE)];
 	}
 
+	@Override
 	public ItemStack getItem(IBlockReader worldIn, BlockPos pos, BlockState state) {
 		return new ItemStack(ModItems.TOMATO_SEEDS.get());
 	}
 
+	@Override
 	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random rand) {
 		super.tick(state, worldIn, pos, rand);
 		if (!worldIn.isAreaLoaded(pos, 1))
-			return; // Forge: prevent loading unloaded chunks when checking neighbor's light
+			return;
 		if (worldIn.getLightSubtracted(pos, 0) >= 9) {
 			int i = this.getAge(state);
 			if (i < this.getMaxAge()) {
@@ -106,15 +104,16 @@ public class TomatoesBlock extends BushBlock implements IGrowable {
 
 	@Override
 	public void grow(ServerWorld worldIn, Random rand, BlockPos pos, BlockState state) {
-		int i = this.getAge(state) + this.getBonemealAgeIncrease(worldIn);
-		int j = this.getMaxAge();
-		if (i > j) {
-			i = j;
+		int newAge = this.getAge(state) + this.getBonemealAgeIncrease(worldIn);
+		int maxAge = this.getMaxAge();
+		if (newAge > maxAge) {
+			newAge = maxAge;
 		}
 
-		worldIn.setBlockState(pos, this.withAge(i), 2);
+		worldIn.setBlockState(pos, this.withAge(newAge), 2);
 	}
 
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) {
 		int i = state.get(AGE);
 		boolean flag = i == TOMATO_BEARING_AGE;
@@ -131,10 +130,12 @@ public class TomatoesBlock extends BushBlock implements IGrowable {
 		}
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		return (worldIn.getLightSubtracted(pos, 0) >= 8 || worldIn.canSeeSky(pos)) && super.isValidPosition(state, worldIn, pos);
 	}
 
+	@Override
 	public void onEntityCollision(BlockState state, World worldIn, BlockPos pos, Entity entityIn) {
 		if (entityIn instanceof RavagerEntity && net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(worldIn, entityIn)) {
 			worldIn.destroyBlock(pos, true, entityIn);
@@ -143,21 +144,22 @@ public class TomatoesBlock extends BushBlock implements IGrowable {
 		super.onEntityCollision(state, worldIn, pos, entityIn);
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(AGE);
 	}
 
 	protected static float getGrowthChance(Block blockIn, IBlockReader worldIn, BlockPos pos) {
 		float f = 1.0F;
-		BlockPos blockpos = pos.down();
+		BlockPos floorPos = pos.down();
 
 		for (int i = -1; i <= 1; ++i) {
 			for (int j = -1; j <= 1; ++j) {
 				float f1 = 0.0F;
-				BlockState blockstate = worldIn.getBlockState(blockpos.add(i, 0, j));
-				if (blockstate.canSustainPlant(worldIn, blockpos.add(i, 0, j), net.minecraft.util.Direction.UP, (net.minecraftforge.common.IPlantable) blockIn)) {
+				BlockState blockstate = worldIn.getBlockState(floorPos.add(i, 0, j));
+				if (blockstate.canSustainPlant(worldIn, floorPos.add(i, 0, j), net.minecraft.util.Direction.UP, (net.minecraftforge.common.IPlantable) blockIn)) {
 					f1 = 1.0F;
-					if (blockstate.isFertile(worldIn, blockpos.add(i, 0, j))) {
+					if (blockstate.isFertile(worldIn, floorPos.add(i, 0, j))) {
 						f1 = 3.0F;
 					}
 				}
@@ -170,17 +172,17 @@ public class TomatoesBlock extends BushBlock implements IGrowable {
 			}
 		}
 
-		BlockPos blockpos1 = pos.north();
-		BlockPos blockpos2 = pos.south();
-		BlockPos blockpos3 = pos.west();
-		BlockPos blockpos4 = pos.east();
-		boolean flag = blockIn == worldIn.getBlockState(blockpos3).getBlock() || blockIn == worldIn.getBlockState(blockpos4).getBlock();
-		boolean flag1 = blockIn == worldIn.getBlockState(blockpos1).getBlock() || blockIn == worldIn.getBlockState(blockpos2).getBlock();
-		if (flag && flag1) {
+		BlockPos northPos = pos.north();
+		BlockPos southPos = pos.south();
+		BlockPos westPos = pos.west();
+		BlockPos eastPos = pos.east();
+		boolean isMatchedWestEast = blockIn == worldIn.getBlockState(westPos).getBlock() || blockIn == worldIn.getBlockState(eastPos).getBlock();
+		boolean isMatchedNorthSouth = blockIn == worldIn.getBlockState(northPos).getBlock() || blockIn == worldIn.getBlockState(southPos).getBlock();
+		if (isMatchedWestEast && isMatchedNorthSouth) {
 			f /= 2.0F;
 		}
 		else {
-			boolean flag2 = blockIn == worldIn.getBlockState(blockpos3.north()).getBlock() || blockIn == worldIn.getBlockState(blockpos4.north()).getBlock() || blockIn == worldIn.getBlockState(blockpos4.south()).getBlock() || blockIn == worldIn.getBlockState(blockpos3.south()).getBlock();
+			boolean flag2 = blockIn == worldIn.getBlockState(westPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.south()).getBlock() || blockIn == worldIn.getBlockState(westPos.south()).getBlock();
 			if (flag2) {
 				f /= 2.0F;
 			}

--- a/src/main/java/vectorwing/farmersdelight/blocks/TomatoesBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/TomatoesBlock.java
@@ -32,8 +32,8 @@ import java.util.Random;
 @SuppressWarnings("deprecation")
 public class TomatoesBlock extends BushBlock implements IGrowable
 {
-	private static final int TOMATO_BEARING_AGE = 7;
 	public static final IntegerProperty AGE = BlockStateProperties.AGE_0_7;
+	private static final int TOMATO_BEARING_AGE = 7;
 	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 6.0D, 16.0D),
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 6.0D, 16.0D),
@@ -49,9 +49,54 @@ public class TomatoesBlock extends BushBlock implements IGrowable
 		this.setDefaultState(this.stateContainer.getBaseState().with(AGE, 0));
 	}
 
-	public int getMaxAge() { return 7; }
+	protected static float getGrowthChance(Block blockIn, IBlockReader worldIn, BlockPos pos) {
+		float f = 1.0F;
+		BlockPos floorPos = pos.down();
 
-	protected int getAge(BlockState state) { return state.get(AGE); }
+		for (int i = -1; i <= 1; ++i) {
+			for (int j = -1; j <= 1; ++j) {
+				float f1 = 0.0F;
+				BlockState blockstate = worldIn.getBlockState(floorPos.add(i, 0, j));
+				if (blockstate.canSustainPlant(worldIn, floorPos.add(i, 0, j), net.minecraft.util.Direction.UP, (net.minecraftforge.common.IPlantable) blockIn)) {
+					f1 = 1.0F;
+					if (blockstate.isFertile(worldIn, floorPos.add(i, 0, j))) {
+						f1 = 3.0F;
+					}
+				}
+
+				if (i != 0 || j != 0) {
+					f1 /= 4.0F;
+				}
+
+				f += f1;
+			}
+		}
+
+		BlockPos northPos = pos.north();
+		BlockPos southPos = pos.south();
+		BlockPos westPos = pos.west();
+		BlockPos eastPos = pos.east();
+		boolean isMatchedWestEast = blockIn == worldIn.getBlockState(westPos).getBlock() || blockIn == worldIn.getBlockState(eastPos).getBlock();
+		boolean isMatchedNorthSouth = blockIn == worldIn.getBlockState(northPos).getBlock() || blockIn == worldIn.getBlockState(southPos).getBlock();
+		if (isMatchedWestEast && isMatchedNorthSouth) {
+			f /= 2.0F;
+		} else {
+			boolean flag2 = blockIn == worldIn.getBlockState(westPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.south()).getBlock() || blockIn == worldIn.getBlockState(westPos.south()).getBlock();
+			if (flag2) {
+				f /= 2.0F;
+			}
+		}
+
+		return f;
+	}
+
+	public int getMaxAge() {
+		return 7;
+	}
+
+	protected int getAge(BlockState state) {
+		return state.get(AGE);
+	}
 
 	public BlockState withAge(int age) {
 		return this.getDefaultState().with(AGE, age);
@@ -147,47 +192,5 @@ public class TomatoesBlock extends BushBlock implements IGrowable
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(AGE);
-	}
-
-	protected static float getGrowthChance(Block blockIn, IBlockReader worldIn, BlockPos pos) {
-		float f = 1.0F;
-		BlockPos floorPos = pos.down();
-
-		for (int i = -1; i <= 1; ++i) {
-			for (int j = -1; j <= 1; ++j) {
-				float f1 = 0.0F;
-				BlockState blockstate = worldIn.getBlockState(floorPos.add(i, 0, j));
-				if (blockstate.canSustainPlant(worldIn, floorPos.add(i, 0, j), net.minecraft.util.Direction.UP, (net.minecraftforge.common.IPlantable) blockIn)) {
-					f1 = 1.0F;
-					if (blockstate.isFertile(worldIn, floorPos.add(i, 0, j))) {
-						f1 = 3.0F;
-					}
-				}
-
-				if (i != 0 || j != 0) {
-					f1 /= 4.0F;
-				}
-
-				f += f1;
-			}
-		}
-
-		BlockPos northPos = pos.north();
-		BlockPos southPos = pos.south();
-		BlockPos westPos = pos.west();
-		BlockPos eastPos = pos.east();
-		boolean isMatchedWestEast = blockIn == worldIn.getBlockState(westPos).getBlock() || blockIn == worldIn.getBlockState(eastPos).getBlock();
-		boolean isMatchedNorthSouth = blockIn == worldIn.getBlockState(northPos).getBlock() || blockIn == worldIn.getBlockState(southPos).getBlock();
-		if (isMatchedWestEast && isMatchedNorthSouth) {
-			f /= 2.0F;
-		}
-		else {
-			boolean flag2 = blockIn == worldIn.getBlockState(westPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.north()).getBlock() || blockIn == worldIn.getBlockState(eastPos.south()).getBlock() || blockIn == worldIn.getBlockState(westPos.south()).getBlock();
-			if (flag2) {
-				f /= 2.0F;
-			}
-		}
-
-		return f;
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildCropsBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildCropsBlock.java
@@ -1,10 +1,12 @@
 package vectorwing.farmersdelight.blocks;
 
-public class WildCropsBlock extends WildPatchBlock {
+public class WildCropsBlock extends WildPatchBlock
+{
 	public WildCropsBlock(Properties properties) {
 		super(properties);
 	}
 
+	@Override
 	public OffsetType getOffsetType() {
 		return OffsetType.NONE;
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
@@ -15,9 +15,9 @@ public class WildPatchBlock extends BushBlock
 {
 	protected static final VoxelShape SHAPE = Block.makeCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 13.0D, 14.0D);
 
-    public WildPatchBlock(Properties properties) {
-        super(properties);
-    }
+	public WildPatchBlock(Properties properties) {
+		super(properties);
+	}
 
 	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
@@ -25,9 +25,9 @@ public class WildPatchBlock extends BushBlock
 	}
 
 	@Override
-    protected boolean isValidGround(BlockState state, IBlockReader worldIn, BlockPos pos) {
-        return state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS_BLOCK || state.getBlock() == Blocks.SAND || state.getBlock() == Blocks.RED_SAND;
-    }
+	protected boolean isValidGround(BlockState state, IBlockReader worldIn, BlockPos pos) {
+		return state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS_BLOCK || state.getBlock() == Blocks.SAND || state.getBlock() == Blocks.RED_SAND;
+	}
 
 	@Override
 	public Block.OffsetType getOffsetType() {

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
@@ -1,17 +1,15 @@
 package vectorwing.farmersdelight.blocks;
 
-import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.BushBlock;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 @SuppressWarnings("deprecation")
 public class WildPatchBlock extends BushBlock
 {
@@ -26,14 +24,17 @@ public class WildPatchBlock extends BushBlock
 		return SHAPE;
 	}
 
+	@Override
     protected boolean isValidGround(BlockState state, IBlockReader worldIn, BlockPos pos) {
         return state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS_BLOCK || state.getBlock() == Blocks.SAND || state.getBlock() == Blocks.RED_SAND;
     }
 
+	@Override
 	public Block.OffsetType getOffsetType() {
 		return OffsetType.XZ;
 	}
 
+	@Override
 	public boolean isReplaceable(BlockState state, BlockItemUseContext useContext) {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
@@ -23,8 +23,8 @@ import vectorwing.farmersdelight.registry.ModBlocks;
 import javax.annotation.Nullable;
 
 @SuppressWarnings("deprecation")
-public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable {
-
+public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
+{
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
 
 	public WildRiceBlock(Properties properties) {
@@ -84,7 +84,7 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable {
 	}
 
 	@Override
-	public boolean canContainFluid(IBlockReader worldIn, BlockPos pos, BlockState state, Fluid fluidIn)	{
+	public boolean canContainFluid(IBlockReader worldIn, BlockPos pos, BlockState state, Fluid fluidIn) {
 		return state.get(HALF) == DoubleBlockHalf.LOWER;
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
@@ -32,10 +32,12 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, true).with(HALF, DoubleBlockHalf.LOWER));
 	}
 
+	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
 		builder.add(HALF, WATERLOGGED);
 	}
 
+	@Override
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
 		FluidState fluid = worldIn.getFluidState(pos);
 		BlockPos floorPos = pos.down();
@@ -45,10 +47,12 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
 		return super.isValidPosition(state, worldIn, pos) && worldIn.getBlockState(pos.down()).getBlock() == ModBlocks.WILD_RICE.get();
 	}
 
+	@Override
 	public boolean isReplaceable(BlockState state, BlockItemUseContext useContext) {
 		return false;
 	}
 
+	@Override
 	public void onBlockPlacedBy(World worldIn, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
 		worldIn.setBlockState(pos.up(), this.getDefaultState().with(WATERLOGGED, false).with(HALF, DoubleBlockHalf.UPPER), 3);
 	}
@@ -59,6 +63,7 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
 		worldIn.setBlockState(pos.up(), this.getDefaultState().with(WATERLOGGED, false).with(HALF, DoubleBlockHalf.UPPER), flags);
 	}
 
+	@Override
 	public BlockState updatePostPlacement(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
 		BlockState blockstate = super.updatePostPlacement(stateIn, facing, facingState, worldIn, currentPos, facingPos);
 		DoubleBlockHalf half = stateIn.get(HALF);
@@ -72,6 +77,7 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
 		}
 	}
 
+	@Override
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		BlockPos pos = context.getPos();
@@ -88,6 +94,7 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable
 		return state.get(HALF) == DoubleBlockHalf.LOWER;
 	}
 
+	@Override
 	public FluidState getFluidState(BlockState state) {
 		return state.get(HALF) == DoubleBlockHalf.LOWER
 				? Fluids.WATER.getStillFluidState(false)

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildRiceBlock.java
@@ -2,8 +2,6 @@ package vectorwing.farmersdelight.blocks;
 
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.monster.piglin.PiglinTasks;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
@@ -13,9 +11,7 @@ import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.state.properties.DoubleBlockHalf;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
@@ -26,6 +22,7 @@ import vectorwing.farmersdelight.registry.ModBlocks;
 
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation")
 public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable {
 
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -40,10 +37,10 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable {
 	}
 
 	public boolean isValidPosition(BlockState state, IWorldReader worldIn, BlockPos pos) {
-		FluidState ifluidstate = worldIn.getFluidState(pos);
+		FluidState fluid = worldIn.getFluidState(pos);
 		BlockPos floorPos = pos.down();
 		if (state.get(DoublePlantBlock.HALF) == DoubleBlockHalf.LOWER) {
-			return super.isValidPosition(state, worldIn, pos) && this.isValidGround(worldIn.getBlockState(floorPos), worldIn, floorPos) && ifluidstate.isTagged(FluidTags.WATER) && ifluidstate.getLevel() == 8;
+			return super.isValidPosition(state, worldIn, pos) && this.isValidGround(worldIn.getBlockState(floorPos), worldIn, floorPos) && fluid.isTagged(FluidTags.WATER) && fluid.getLevel() == 8;
 		}
 		return super.isValidPosition(state, worldIn, pos) && worldIn.getBlockState(pos.down()).getBlock() == ModBlocks.WILD_RICE.get();
 	}
@@ -77,12 +74,12 @@ public class WildRiceBlock extends DoublePlantBlock implements IWaterLoggable {
 
 	@Nullable
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		BlockPos blockpos = context.getPos();
-		FluidState ifluidstate = context.getWorld().getFluidState(context.getPos());
-		return blockpos.getY() < context.getWorld().getHeight() - 1
-				&& ifluidstate.isTagged(FluidTags.WATER)
-				&& ifluidstate.getLevel() == 8
-				&& context.getWorld().getBlockState(blockpos.up()).isAir(context.getWorld(), blockpos.up())
+		BlockPos pos = context.getPos();
+		FluidState fluid = context.getWorld().getFluidState(context.getPos());
+		return pos.getY() < context.getWorld().getHeight() - 1
+				&& fluid.isTagged(FluidTags.WATER)
+				&& fluid.getLevel() == 8
+				&& context.getWorld().getBlockState(pos.up()).isAir(context.getWorld(), pos.up())
 				? super.getStateForPlacement(context) : null;
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/blocks/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package vectorwing.farmersdelight.blocks;
+
+import mcp.MethodsReturnNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/vectorwing/farmersdelight/blocks/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/package-info.java
@@ -3,4 +3,5 @@
 package vectorwing.farmersdelight.blocks;
 
 import mcp.MethodsReturnNonnullByDefault;
+
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotScreen.java
+++ b/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotScreen.java
@@ -18,70 +18,71 @@ import java.util.ArrayList;
 import java.util.List;
 
 @ParametersAreNonnullByDefault
-public class CookingPotScreen extends ContainerScreen<CookingPotContainer> {
-    private static final ResourceLocation BACKGROUND_TEXTURE = new ResourceLocation(FarmersDelight.MODID, "textures/gui/cooking_pot.png");
+public class CookingPotScreen extends ContainerScreen<CookingPotContainer>
+{
+	private static final ResourceLocation BACKGROUND_TEXTURE = new ResourceLocation(FarmersDelight.MODID, "textures/gui/cooking_pot.png");
 
-    public CookingPotScreen(CookingPotContainer screenContainer, PlayerInventory inv, ITextComponent titleIn) {
-        super(screenContainer, inv, titleIn);
-        this.guiLeft = 0;
-        this.guiTop = 0;
-        this.xSize = 176;
-        this.ySize = 166;
-        this.titleX = 28;
-    }
+	public CookingPotScreen(CookingPotContainer screenContainer, PlayerInventory inv, ITextComponent titleIn) {
+		super(screenContainer, inv, titleIn);
+		this.guiLeft = 0;
+		this.guiTop = 0;
+		this.xSize = 176;
+		this.ySize = 166;
+		this.titleX = 28;
+	}
 
-    @Override
-    public void render(MatrixStack ms, final int mouseX, final int mouseY, float partialTicks) {
-        this.renderBackground(ms);
-        super.render(ms, mouseX, mouseY, partialTicks);
-        this.renderHoveredToolTip(ms, mouseX, mouseY);
-    }
+	@Override
+	public void render(MatrixStack ms, final int mouseX, final int mouseY, float partialTicks) {
+		this.renderBackground(ms);
+		super.render(ms, mouseX, mouseY, partialTicks);
+		this.renderHoveredToolTip(ms, mouseX, mouseY);
+	}
 
-    protected void renderHoveredToolTip(MatrixStack ms, int mouseX, int mouseY) {
-        if (this.minecraft != null && this.minecraft.player != null && this.minecraft.player.inventory.getItemStack().isEmpty() && this.hoveredSlot != null && this.hoveredSlot.getHasStack()) {
-            if (this.hoveredSlot.slotNumber == 6) {
-                List<ITextComponent> tooltip = new ArrayList<>();
+	protected void renderHoveredToolTip(MatrixStack ms, int mouseX, int mouseY) {
+		if (this.minecraft != null && this.minecraft.player != null && this.minecraft.player.inventory.getItemStack().isEmpty() && this.hoveredSlot != null && this.hoveredSlot.getHasStack()) {
+			if (this.hoveredSlot.slotNumber == 6) {
+				List<ITextComponent> tooltip = new ArrayList<>();
 
-                ItemStack meal = this.hoveredSlot.getStack();
-                tooltip.add(((IFormattableTextComponent) meal.getItem().getName()).mergeStyle(meal.getRarity().color));
+				ItemStack meal = this.hoveredSlot.getStack();
+				tooltip.add(((IFormattableTextComponent) meal.getItem().getName()).mergeStyle(meal.getRarity().color));
 
 				ItemStack containerItem = this.container.tileEntity.getContainer();
 				String container = !containerItem.isEmpty() ? containerItem.getItem().getName().getString() : "";
 
-                tooltip.add(TextUtils.getTranslation("container.cooking_pot.served_on", container).mergeStyle(TextFormatting.GRAY));
+				tooltip.add(TextUtils.getTranslation("container.cooking_pot.served_on", container).mergeStyle(TextFormatting.GRAY));
 
-                this.func_243308_b(ms, tooltip, mouseX, mouseY);
-            } else {
-                this.renderTooltip(ms, this.hoveredSlot.getStack(), mouseX, mouseY);
-            }
-        }
-    }
+				this.func_243308_b(ms, tooltip, mouseX, mouseY);
+			} else {
+				this.renderTooltip(ms, this.hoveredSlot.getStack(), mouseX, mouseY);
+			}
+		}
+	}
 
-    @Override
-    protected void drawGuiContainerForegroundLayer(MatrixStack ms, int mouseX, int mouseY) {
-        super.drawGuiContainerForegroundLayer(ms, mouseX, mouseY);
-        this.font.drawString(ms, this.playerInventory.getDisplayName().getString(), 8.0f, (float) (this.ySize - 96 + 2), 4210752);
-    }
+	@Override
+	protected void drawGuiContainerForegroundLayer(MatrixStack ms, int mouseX, int mouseY) {
+		super.drawGuiContainerForegroundLayer(ms, mouseX, mouseY);
+		this.font.drawString(ms, this.playerInventory.getDisplayName().getString(), 8.0f, (float) (this.ySize - 96 + 2), 4210752);
+	}
 
-    @Override
-    protected void drawGuiContainerBackgroundLayer(MatrixStack ms, float partialTicks, int mouseX, int mouseY) {
-        // Render UI background
-        RenderSystem.color4f(1.0f, 1.0f, 1.0f, 1.0f);
-        if (this.minecraft == null)
-            return;
+	@Override
+	protected void drawGuiContainerBackgroundLayer(MatrixStack ms, float partialTicks, int mouseX, int mouseY) {
+		// Render UI background
+		RenderSystem.color4f(1.0f, 1.0f, 1.0f, 1.0f);
+		if (this.minecraft == null)
+			return;
 
-        this.minecraft.getTextureManager().bindTexture(BACKGROUND_TEXTURE);
-        int x = (this.width - this.xSize) / 2;
-        int y = (this.height - this.ySize) / 2;
-        this.blit(ms, x, y, 0, 0, this.xSize, this.ySize);
+		this.minecraft.getTextureManager().bindTexture(BACKGROUND_TEXTURE);
+		int x = (this.width - this.xSize) / 2;
+		int y = (this.height - this.ySize) / 2;
+		this.blit(ms, x, y, 0, 0, this.xSize, this.ySize);
 
-        // Render heat indicator
-        if (this.container.isHeated()) {
-            this.blit(ms, x + 47, y + 55, 176, 0, 17, 15);
-        }
+		// Render heat indicator
+		if (this.container.isHeated()) {
+			this.blit(ms, x + 47, y + 55, 176, 0, 17, 15);
+		}
 
-        // Render progress arrow
-        int l = this.container.getCookProgressionScaled();
-        this.blit(ms, this.guiLeft + 89, this.guiTop + 25, 176, 15, l + 1, 17);
-    }
+		// Render progress arrow
+		int l = this.container.getCookProgressionScaled();
+		this.blit(ms, this.guiLeft + 89, this.guiTop + 25, 176, 15, l + 1, 17);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/client/gui/NourishedHungerOverlay.java
+++ b/src/main/java/vectorwing/farmersdelight/client/gui/NourishedHungerOverlay.java
@@ -1,7 +1,6 @@
 package vectorwing.farmersdelight.client.gui;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.entity.player.PlayerEntity;
@@ -26,8 +25,8 @@ import vectorwing.farmersdelight.setup.Configuration;
  */
 
 @OnlyIn(Dist.CLIENT)
-public class NourishedHungerOverlay {
-
+public class NourishedHungerOverlay
+{
 	protected int foodIconsOffset;
 	private static final ResourceLocation modIcons = new ResourceLocation(FarmersDelight.MODID, "textures/gui/nourished.png");
 
@@ -48,7 +47,7 @@ public class NourishedHungerOverlay {
 	}
 
 	@SubscribeEvent(priority = EventPriority.NORMAL)
-	public void onRender(RenderGameOverlayEvent.Post event)	{
+	public void onRender(RenderGameOverlayEvent.Post event) {
 		if (!Configuration.NOURISHED_HUNGER_OVERLAY.get())
 			return;
 		if (event.getType() != RenderGameOverlayEvent.ElementType.FOOD)
@@ -74,12 +73,10 @@ public class NourishedHungerOverlay {
 		}
 	}
 
-	public static void drawNourishedOverlay(int foodLevel, Minecraft mc, MatrixStack matrixStack, int left, int top, boolean naturalHealing)
-	{
+	public static void drawNourishedOverlay(int foodLevel, Minecraft mc, MatrixStack matrixStack, int left, int top, boolean naturalHealing) {
 		mc.getTextureManager().bindTexture(modIcons);
 
-		for (int j = 0; j < 10; ++j)
-		{
+		for (int j = 0; j < 10; ++j) {
 			int x = left - j * 8 - 9;
 			int y = top;
 

--- a/src/main/java/vectorwing/farmersdelight/client/particles/StarParticle.java
+++ b/src/main/java/vectorwing/farmersdelight/client/particles/StarParticle.java
@@ -26,10 +26,12 @@ public class StarParticle extends SpriteTexturedParticle
 		return IParticleRenderType.PARTICLE_SHEET_OPAQUE;
 	}
 
+	@Override
 	public float getScale(float scaleFactor) {
 		return this.particleScale * MathHelper.clamp(((float) this.age + scaleFactor) / (float) this.maxAge * 32.0F, 0.0F, 1.0F);
 	}
 
+	@Override
 	public void tick() {
 		this.prevPosX = this.posX;
 		this.prevPosY = this.posY;
@@ -63,6 +65,7 @@ public class StarParticle extends SpriteTexturedParticle
 			this.spriteSet = sprite;
 		}
 
+		@Override
 		public Particle makeParticle(BasicParticleType typeIn, ClientWorld worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
 			StarParticle particle = new StarParticle(worldIn, x, y + 0.3D, z);
 			particle.selectSpriteRandomly(this.spriteSet);

--- a/src/main/java/vectorwing/farmersdelight/client/particles/StarParticle.java
+++ b/src/main/java/vectorwing/farmersdelight/client/particles/StarParticle.java
@@ -4,17 +4,17 @@ import net.minecraft.client.particle.*;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.particles.BasicParticleType;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
-public class StarParticle extends SpriteTexturedParticle {
+public class StarParticle extends SpriteTexturedParticle
+{
 	protected StarParticle(ClientWorld world, double posX, double posY, double posZ) {
 		super(world, posX, posY, posZ, 0.0D, 0.0D, 0.0D);
-		this.motionX *= (double)0.01F;
-		this.motionY *= (double)0.01F;
-		this.motionZ *= (double)0.01F;
+		this.motionX *= (double) 0.01F;
+		this.motionY *= (double) 0.01F;
+		this.motionZ *= (double) 0.01F;
 		this.motionY += 0.1D;
 		this.particleScale *= 1.5F;
 		this.maxAge = 16;
@@ -27,7 +27,7 @@ public class StarParticle extends SpriteTexturedParticle {
 	}
 
 	public float getScale(float scaleFactor) {
-		return this.particleScale * MathHelper.clamp(((float)this.age + scaleFactor) / (float)this.maxAge * 32.0F, 0.0F, 1.0F);
+		return this.particleScale * MathHelper.clamp(((float) this.age + scaleFactor) / (float) this.maxAge * 32.0F, 0.0F, 1.0F);
 	}
 
 	public void tick() {
@@ -43,19 +43,20 @@ public class StarParticle extends SpriteTexturedParticle {
 				this.motionZ *= 1.1D;
 			}
 
-			this.motionX *= (double)0.86F;
-			this.motionY *= (double)0.86F;
-			this.motionZ *= (double)0.86F;
+			this.motionX *= (double) 0.86F;
+			this.motionY *= (double) 0.86F;
+			this.motionZ *= (double) 0.86F;
 			if (this.onGround) {
-				this.motionX *= (double)0.7F;
-				this.motionZ *= (double)0.7F;
+				this.motionX *= (double) 0.7F;
+				this.motionZ *= (double) 0.7F;
 			}
 
 		}
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public static class Factory implements IParticleFactory<BasicParticleType> {
+	public static class Factory implements IParticleFactory<BasicParticleType>
+	{
 		private final IAnimatedSprite spriteSet;
 
 		public Factory(IAnimatedSprite sprite) {

--- a/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/CuttingBoardTileEntityRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/CuttingBoardTileEntityRenderer.java
@@ -15,7 +15,8 @@ import net.minecraft.util.math.vector.Vector3f;
 import vectorwing.farmersdelight.blocks.CuttingBoardBlock;
 import vectorwing.farmersdelight.tile.CuttingBoardTileEntity;
 
-public class CuttingBoardTileEntityRenderer extends TileEntityRenderer<CuttingBoardTileEntity> {
+public class CuttingBoardTileEntityRenderer extends TileEntityRenderer<CuttingBoardTileEntity>
+{
 	public CuttingBoardTileEntityRenderer(TileEntityRendererDispatcher rendererDispatcherIn) {
 		super(rendererDispatcherIn);
 	}
@@ -35,11 +36,9 @@ public class CuttingBoardTileEntityRenderer extends TileEntityRenderer<CuttingBo
 
 			if (tileEntityIn.getIsItemCarvingBoard()) {
 				renderItemCarved(matrixStackIn, direction, itemStack);
-			}
-			else if (blockItem) {
+			} else if (blockItem) {
 				renderBlock(matrixStackIn, direction);
-			}
-			else {
+			} else {
 				renderItemLayingDown(matrixStackIn, direction);
 			}
 

--- a/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
@@ -20,7 +20,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity> {
+public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity>
+{
 	private static final Minecraft MC = Minecraft.getInstance();
 
 	public StoveTileEntityRenderer(TileEntityRendererDispatcher rendererDispatcher) {

--- a/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
+++ b/src/main/java/vectorwing/farmersdelight/client/tileentity/renderer/StoveTileEntityRenderer.java
@@ -28,6 +28,7 @@ public class StoveTileEntityRenderer extends TileEntityRenderer<StoveTileEntity>
 		super(rendererDispatcher);
 	}
 
+	@Override
 	public void render(StoveTileEntity tileEntityIn, float partialTicks, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int combinedLightIn, int combinedOverlayIn) {
 		Direction direction = tileEntityIn.getBlockState().get(StoveBlock.FACING).getOpposite();
 		NonNullList<ItemStack> nonnulllist = tileEntityIn.getInventory();

--- a/src/main/java/vectorwing/farmersdelight/crafting/CookingPotRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/crafting/CookingPotRecipe.java
@@ -13,8 +13,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.ForgeRegistryEntry;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import vectorwing.farmersdelight.FarmersDelight;
 
 import javax.annotation.Nullable;
@@ -24,8 +22,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class CookingPotRecipe implements IRecipe<IInventory>
 {
-	private static final Logger LOGGER = LogManager.getLogger();
-
 	public static IRecipeType<CookingPotRecipe> TYPE = IRecipeType.register(FarmersDelight.MODID + ":cooking");
 	public static final Serializer SERIALIZER = new Serializer();
 	public static final int INPUT_SLOTS = 6;
@@ -95,7 +91,6 @@ public class CookingPotRecipe implements IRecipe<IInventory>
 
 	@Override
 	public boolean matches(IInventory inv, World worldIn) {
-		RecipeItemHelper recipeitemhelper = new RecipeItemHelper();
 		java.util.List<ItemStack> inputs = new java.util.ArrayList<>();
 		int i = 0;
 

--- a/src/main/java/vectorwing/farmersdelight/crafting/CookingPotRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/crafting/CookingPotRecipe.java
@@ -22,7 +22,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class CookingPotRecipe implements IRecipe<IInventory> {
+public class CookingPotRecipe implements IRecipe<IInventory>
+{
 	private static final Logger LOGGER = LogManager.getLogger();
 
 	public static IRecipeType<CookingPotRecipe> TYPE = IRecipeType.register(FarmersDelight.MODID + ":cooking");
@@ -45,11 +46,9 @@ public class CookingPotRecipe implements IRecipe<IInventory> {
 
 		if (!container.isEmpty()) {
 			this.container = container;
-		}
-		else if (!output.getContainerItem().isEmpty()) {
+		} else if (!output.getContainerItem().isEmpty()) {
 			this.container = output.getContainerItem();
-		}
-		else {
+		} else {
 			this.container = ItemStack.EMPTY;
 		}
 
@@ -125,8 +124,8 @@ public class CookingPotRecipe implements IRecipe<IInventory> {
 		return CookingPotRecipe.TYPE;
 	}
 
-	private static class Serializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<CookingPotRecipe> {
-
+	private static class Serializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<CookingPotRecipe>
+	{
 		Serializer() {
 			this.setRegistryName(new ResourceLocation(FarmersDelight.MODID, "cooking"));
 		}
@@ -137,11 +136,9 @@ public class CookingPotRecipe implements IRecipe<IInventory> {
 			final NonNullList<Ingredient> inputItemsIn = readIngredients(JSONUtils.getJsonArray(json, "ingredients"));
 			if (inputItemsIn.isEmpty()) {
 				throw new JsonParseException("No ingredients for cooking recipe");
-			}
-			else if (inputItemsIn.size() > CookingPotRecipe.INPUT_SLOTS) {
+			} else if (inputItemsIn.size() > CookingPotRecipe.INPUT_SLOTS) {
 				throw new JsonParseException("Too many ingredients for cooking recipe! The max is " + CookingPotRecipe.INPUT_SLOTS);
-			}
-			else {
+			} else {
 				final ItemStack outputIn = ShapedRecipe.deserializeItem(JSONUtils.getJsonObject(json, "result"));
 				ItemStack container = JSONUtils.hasField(json, "container") ? ShapedRecipe.deserializeItem(JSONUtils.getJsonObject(json, "container")) : ItemStack.EMPTY;
 				final float experienceIn = JSONUtils.getFloat(json, "experience", 0.0F);

--- a/src/main/java/vectorwing/farmersdelight/crafting/CuttingBoardRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/crafting/CuttingBoardRecipe.java
@@ -17,7 +17,8 @@ import vectorwing.farmersdelight.FarmersDelight;
 
 import javax.annotation.Nullable;
 
-public class CuttingBoardRecipe implements IRecipe<RecipeWrapper> {
+public class CuttingBoardRecipe implements IRecipe<RecipeWrapper>
+{
 	public static IRecipeType<CuttingBoardRecipe> TYPE = IRecipeType.register(FarmersDelight.MODID + ":cutting");
 	public static final CuttingBoardRecipe.Serializer SERIALIZER = new CuttingBoardRecipe.Serializer();
 
@@ -115,8 +116,8 @@ public class CuttingBoardRecipe implements IRecipe<RecipeWrapper> {
 		return CuttingBoardRecipe.TYPE;
 	}
 
-	private static class Serializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<CuttingBoardRecipe> {
-
+	private static class Serializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<CuttingBoardRecipe>
+	{
 		Serializer() {
 			this.setRegistryName(new ResourceLocation(FarmersDelight.MODID, "cutting"));
 		}
@@ -128,14 +129,11 @@ public class CuttingBoardRecipe implements IRecipe<RecipeWrapper> {
 			final Ingredient toolIn = Ingredient.deserialize(JSONUtils.getJsonObject(json, "tool"));
 			if (inputItemsIn.isEmpty()) {
 				throw new JsonParseException("No ingredients for cutting recipe");
-			}
-			else if (toolIn.hasNoMatchingItems()) {
+			} else if (toolIn.hasNoMatchingItems()) {
 				throw new JsonParseException("No tool for cutting recipe");
-			}
-			else if (inputItemsIn.size() > 1) {
+			} else if (inputItemsIn.size() > 1) {
 				throw new JsonParseException("Too many ingredients for cutting recipe! Please define only one ingredient.");
-			}
-			else {
+			} else {
 				final NonNullList<ItemStack> results = readResults(JSONUtils.getJsonArray(json, "result"));
 				final String soundID = JSONUtils.getString(json, "sound", "");
 				final int effortIn = JSONUtils.getInt(json, "effort", 1);

--- a/src/main/java/vectorwing/farmersdelight/crafting/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/crafting/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package vectorwing.farmersdelight.crafting;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/vectorwing/farmersdelight/data/Advancements.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Advancements.java
@@ -43,6 +43,7 @@ public class Advancements extends AdvancementProvider
 		PATH = generatorIn.getOutputFolder();
 	}
 
+	@Override
 	public void act(DirectoryCache cache) {
 		Set<ResourceLocation> set = Sets.newHashSet();
 		Consumer<Advancement> consumer = (advancement) -> {
@@ -69,6 +70,7 @@ public class Advancements extends AdvancementProvider
 
 	public static class FarmersDelightAdvancements implements Consumer<Consumer<Advancement>>
 	{
+		@Override
 		public void accept(Consumer<Advancement> consumer) {
 			Advancement farmersDelight = Advancement.Builder.builder()
 					.withDisplay(ModItems.COOKING_POT.get(),

--- a/src/main/java/vectorwing/farmersdelight/data/Advancements.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Advancements.java
@@ -71,6 +71,7 @@ public class Advancements extends AdvancementProvider
 	public static class FarmersDelightAdvancements implements Consumer<Consumer<Advancement>>
 	{
 		@Override
+		@SuppressWarnings("unused")
 		public void accept(Consumer<Advancement> consumer) {
 			Advancement farmersDelight = Advancement.Builder.builder()
 					.withDisplay(ModItems.COOKING_POT.get(),

--- a/src/main/java/vectorwing/farmersdelight/data/Advancements.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Advancements.java
@@ -33,7 +33,8 @@ import java.util.function.Consumer;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class Advancements extends AdvancementProvider {
+public class Advancements extends AdvancementProvider
+{
 	private final Path PATH;
 	public static final Logger LOGGER = LogManager.getLogger();
 
@@ -47,8 +48,7 @@ public class Advancements extends AdvancementProvider {
 		Consumer<Advancement> consumer = (advancement) -> {
 			if (!set.add(advancement.getId())) {
 				throw new IllegalStateException("Duplicate advancement " + advancement.getId());
-			}
-			else {
+			} else {
 				Path path1 = getPath(PATH, advancement);
 
 				try {
@@ -67,7 +67,8 @@ public class Advancements extends AdvancementProvider {
 		return pathIn.resolve("data/" + advancementIn.getId().getNamespace() + "/advancements/" + advancementIn.getId().getPath() + ".json");
 	}
 
-	public static class FarmersDelightAdvancements implements Consumer<Consumer<Advancement>> {
+	public static class FarmersDelightAdvancements implements Consumer<Consumer<Advancement>>
+	{
 		public void accept(Consumer<Advancement> consumer) {
 			Advancement farmersDelight = Advancement.Builder.builder()
 					.withDisplay(ModItems.COOKING_POT.get(),

--- a/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
@@ -15,7 +15,12 @@ public class BlockTags extends BlockTagsProvider
 
 	@Override
 	protected void registerTags() {
-		// Minecraft Tags
+		this.registerMinecraftTags();
+		this.registerForgeTags();
+		this.registerModTags();
+	}
+
+	protected void registerMinecraftTags() {
 		getOrCreateBuilder(net.minecraft.tags.BlockTags.BAMBOO_PLANTABLE_ON).add(
 				ModBlocks.RICH_SOIL.get());
 		getOrCreateBuilder(net.minecraft.tags.BlockTags.MUSHROOM_GROW_BLOCK).add(
@@ -37,12 +42,14 @@ public class BlockTags extends BlockTagsProvider
 				ModBlocks.WILD_ONIONS.get(),
 				ModBlocks.WILD_POTATOES.get(),
 				ModBlocks.WILD_TOMATOES.get());
+	}
 
-		// Forge Tags
+	protected void registerForgeTags() {
 		getOrCreateBuilder(Tags.Blocks.DIRT).add(
 				ModBlocks.RICH_SOIL.get());
+	}
 
-		// Mod Tags
+	protected void registerModTags() {
 		getOrCreateBuilder(ModTags.TRAY_HEAT_SOURCES).add(
 				Blocks.CAMPFIRE,
 				Blocks.SOUL_CAMPFIRE,

--- a/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
@@ -1,18 +1,14 @@
 package vectorwing.farmersdelight.data;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.data.BlockTagsProvider;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.data.ItemTagsProvider;
-import net.minecraft.item.Items;
 import net.minecraftforge.common.Tags;
 import vectorwing.farmersdelight.registry.ModBlocks;
-import vectorwing.farmersdelight.registry.ModItems;
-import vectorwing.farmersdelight.utils.tags.ForgeTags;
 import vectorwing.farmersdelight.utils.tags.ModTags;
 
-public class BlockTags extends BlockTagsProvider {
+public class BlockTags extends BlockTagsProvider
+{
 	public BlockTags(DataGenerator generatorIn) {
 		super(generatorIn);
 	}

--- a/src/main/java/vectorwing/farmersdelight/data/DataGenerators.java
+++ b/src/main/java/vectorwing/farmersdelight/data/DataGenerators.java
@@ -7,7 +7,8 @@ import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 import vectorwing.farmersdelight.FarmersDelight;
 
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
-public class DataGenerators {
+public class DataGenerators
+{
 	@SubscribeEvent
 	public static void gatherData(GatherDataEvent event) {
 		DataGenerator generator = event.getGenerator();
@@ -19,7 +20,7 @@ public class DataGenerators {
 			generator.addProvider(new Advancements(generator));
 		}
 		//if (event.includeClient()) {
-			//generator.addProvider(new Items(generator, event.getExistingFileHelper()));
+		//generator.addProvider(new Items(generator, event.getExistingFileHelper()));
 		//}
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/data/DataGenerators.java
+++ b/src/main/java/vectorwing/farmersdelight/data/DataGenerators.java
@@ -6,6 +6,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 import vectorwing.farmersdelight.FarmersDelight;
 
+@SuppressWarnings("unused")
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class DataGenerators
 {
@@ -19,8 +20,5 @@ public class DataGenerators
 			generator.addProvider(new Recipes(generator));
 			generator.addProvider(new Advancements(generator));
 		}
-		//if (event.includeClient()) {
-		//generator.addProvider(new Items(generator, event.getExistingFileHelper()));
-		//}
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/data/ItemTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/ItemTags.java
@@ -3,14 +3,14 @@ package vectorwing.farmersdelight.data;
 import net.minecraft.data.BlockTagsProvider;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.ItemTagsProvider;
+import net.minecraft.item.Items;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.util.ResourceLocation;
 import vectorwing.farmersdelight.registry.ModItems;
 import vectorwing.farmersdelight.utils.tags.ForgeTags;
 import vectorwing.farmersdelight.utils.tags.ModTags;
-import net.minecraft.item.Items;
 
-public class ItemTags extends ItemTagsProvider {
+public class ItemTags extends ItemTagsProvider
+{
 	public ItemTags(DataGenerator generatorIn, BlockTagsProvider blockTagProvider) {
 		super(generatorIn, blockTagProvider);
 	}

--- a/src/main/java/vectorwing/farmersdelight/data/Items.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Items.java
@@ -2,12 +2,13 @@ package vectorwing.farmersdelight.data;
 
 import net.minecraft.data.DataGenerator;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.client.model.generators.ItemModelProvider;
+import net.minecraftforge.common.data.ExistingFileHelper;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.registry.ModItems;
 
-public class Items extends ItemModelProvider {
+public class Items extends ItemModelProvider
+{
 
 	public Items(DataGenerator generator, ExistingFileHelper existingFileHelper) {
 		super(generator, FarmersDelight.MODID, existingFileHelper);

--- a/src/main/java/vectorwing/farmersdelight/data/Items.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Items.java
@@ -9,7 +9,6 @@ import vectorwing.farmersdelight.registry.ModItems;
 
 public class Items extends ItemModelProvider
 {
-
 	public Items(DataGenerator generator, ExistingFileHelper existingFileHelper) {
 		super(generator, FarmersDelight.MODID, existingFileHelper);
 	}

--- a/src/main/java/vectorwing/farmersdelight/data/Recipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/Recipes.java
@@ -1,20 +1,18 @@
 package vectorwing.farmersdelight.data;
 
 import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.advancements.criterion.InventoryChangeTrigger;
+import net.minecraft.block.Blocks;
+import net.minecraft.data.*;
+import net.minecraft.item.Items;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.data.recipes.CuttingRecipes;
 import vectorwing.farmersdelight.data.recipes.SmeltingRecipes;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
-import net.minecraft.advancements.criterion.InventoryChangeTrigger;
-import net.minecraft.block.Blocks;
-import net.minecraft.data.*;
-import net.minecraft.item.Items;
-import net.minecraft.item.crafting.IRecipeSerializer;
-import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.util.IItemProvider;
-import net.minecraft.util.ResourceLocation;
 import vectorwing.farmersdelight.utils.tags.ForgeTags;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -22,7 +20,8 @@ import java.util.function.Consumer;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class Recipes extends RecipeProvider {
+public class Recipes extends RecipeProvider
+{
 	public Recipes(DataGenerator generator) {
 		super(generator);
 	}

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -21,7 +21,8 @@ import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class CuttingBoardRecipeBuilder {
+public class CuttingBoardRecipeBuilder
+{
 	private final Map<Item, Integer> results = new LinkedHashMap<Item, Integer>(4);
 	private final Ingredient ingredient;
 	private final Ingredient tool;
@@ -70,8 +71,7 @@ public class CuttingBoardRecipeBuilder {
 		ResourceLocation resourcelocation = Registry.ITEM.getKey(this.ingredient.getMatchingStacks()[0].getItem());
 		if ((new ResourceLocation(save)).equals(resourcelocation)) {
 			throw new IllegalStateException("Shapeless Recipe " + save + " should remove its 'save' argument");
-		}
-		else {
+		} else {
 			this.build(consumerIn, new ResourceLocation(save));
 		}
 	}
@@ -80,7 +80,8 @@ public class CuttingBoardRecipeBuilder {
 		consumerIn.accept(new CuttingBoardRecipeBuilder.Result(id, this.ingredient, this.tool, this.results, this.soundEventID == null ? "" : this.soundEventID));
 	}
 
-	public static class Result implements IFinishedRecipe {
+	public static class Result implements IFinishedRecipe
+	{
 		private final ResourceLocation id;
 		private final Ingredient ingredient;
 		private final Ingredient tool;

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -9,7 +9,7 @@ import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.Registry;
+import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
 
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 @ParametersAreNonnullByDefault
 public class CuttingBoardRecipeBuilder
 {
-	private final Map<Item, Integer> results = new LinkedHashMap<Item, Integer>(4);
+	private final Map<Item, Integer> results = new LinkedHashMap<>(4);
 	private final Ingredient ingredient;
 	private final Ingredient tool;
 	private String soundEventID;
@@ -63,12 +63,12 @@ public class CuttingBoardRecipeBuilder
 	}
 
 	public void build(Consumer<IFinishedRecipe> consumerIn) {
-		ResourceLocation location = Registry.ITEM.getKey(this.ingredient.getMatchingStacks()[0].getItem());
+		ResourceLocation location = ForgeRegistries.ITEMS.getKey(this.ingredient.getMatchingStacks()[0].getItem());
 		this.build(consumerIn, FarmersDelight.MODID + ":cutting/" + location.getPath());
 	}
 
 	public void build(Consumer<IFinishedRecipe> consumerIn, String save) {
-		ResourceLocation resourcelocation = Registry.ITEM.getKey(this.ingredient.getMatchingStacks()[0].getItem());
+		ResourceLocation resourcelocation = ForgeRegistries.ITEMS.getKey(this.ingredient.getMatchingStacks()[0].getItem());
 		if ((new ResourceLocation(save)).equals(resourcelocation)) {
 			throw new IllegalStateException("Shapeless Recipe " + save + " should remove its 'save' argument");
 		} else {
@@ -108,7 +108,7 @@ public class CuttingBoardRecipeBuilder
 			JsonArray arrayResults = new JsonArray();
 			for (Map.Entry<Item, Integer> result : this.results.entrySet()) {
 				JsonObject jsonobject = new JsonObject();
-				jsonobject.addProperty("item", Registry.ITEM.getKey(result.getKey()).toString());
+				jsonobject.addProperty("item", ForgeRegistries.ITEMS.getKey(result.getKey()).toString());
 				if (result.getValue() > 1) {
 					jsonobject.addProperty("count", result.getValue());
 				}

--- a/src/main/java/vectorwing/farmersdelight/data/recipes/CuttingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipes/CuttingRecipes.java
@@ -11,7 +11,8 @@ import vectorwing.farmersdelight.utils.tags.ForgeTags;
 
 import java.util.function.Consumer;
 
-public class CuttingRecipes {
+public class CuttingRecipes
+{
 
 	public static void register(Consumer<IFinishedRecipe> consumer) {
 		// Knife

--- a/src/main/java/vectorwing/farmersdelight/data/recipes/CuttingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipes/CuttingRecipes.java
@@ -13,7 +13,6 @@ import java.util.function.Consumer;
 
 public class CuttingRecipes
 {
-
 	public static void register(Consumer<IFinishedRecipe> consumer) {
 		// Knife
 		chopMeats(consumer);

--- a/src/main/java/vectorwing/farmersdelight/data/recipes/SmeltingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipes/SmeltingRecipes.java
@@ -13,7 +13,8 @@ import vectorwing.farmersdelight.registry.ModItems;
 
 import java.util.function.Consumer;
 
-public class SmeltingRecipes {
+public class SmeltingRecipes
+{
 	public static void register(Consumer<IFinishedRecipe> consumer) {
 		foodSmeltingRecipes("fried_egg", Items.EGG, ModItems.FRIED_EGG.get(), 0.35F, consumer);
 		foodSmeltingRecipes("beef_patty", ModItems.MINCED_BEEF.get(), ModItems.BEEF_PATTY.get(), 0.35F, consumer);

--- a/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
@@ -53,8 +53,8 @@ public class ComfortEffect extends Effect
 		}
 	}
 
+	@Override
 	public boolean isReady(int duration, int amplifier) {
 		return true;
 	}
-
 }

--- a/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
@@ -15,6 +15,7 @@ import vectorwing.farmersdelight.registry.ModEffects;
 
 import java.util.Set;
 
+@SuppressWarnings("unused")
 public class ComfortEffect extends Effect
 {
 	public static final Set<Effect> COMFORT_IMMUNITIES = Sets.newHashSet(Effects.SLOWNESS, Effects.WEAKNESS, Effects.HUNGER);

--- a/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/effects/ComfortEffect.java
@@ -15,7 +15,8 @@ import vectorwing.farmersdelight.registry.ModEffects;
 
 import java.util.Set;
 
-public class ComfortEffect extends Effect {
+public class ComfortEffect extends Effect
+{
 	public static final Set<Effect> COMFORT_IMMUNITIES = Sets.newHashSet(Effects.SLOWNESS, Effects.WEAKNESS, Effects.HUNGER);
 
 	/**
@@ -29,7 +30,8 @@ public class ComfortEffect extends Effect {
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-	public static class ComfortEvent {
+	public static class ComfortEvent
+	{
 		@SubscribeEvent
 		public static void onComfortDuration(PotionEvent.PotionApplicableEvent event) {
 			EffectInstance effect = event.getPotionEffect();

--- a/src/main/java/vectorwing/farmersdelight/effects/NourishedEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/effects/NourishedEffect.java
@@ -39,8 +39,8 @@ public class NourishedEffect extends Effect
 		}
 	}
 
+	@Override
 	public boolean isReady(int duration, int amplifier) {
 		return true;
 	}
-
 }

--- a/src/main/java/vectorwing/farmersdelight/effects/NourishedEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/effects/NourishedEffect.java
@@ -7,7 +7,8 @@ import net.minecraft.potion.EffectType;
 import net.minecraft.util.FoodStats;
 import net.minecraft.world.GameRules;
 
-public class NourishedEffect extends Effect {
+public class NourishedEffect extends Effect
+{
 	/**
 	 * This effect makes the player immune to accumulating food exhaustion. It is useless to all other entities.
 	 * Normal exhausting actions such as running, jumping and attacking will not drain hunger or saturation.

--- a/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
+++ b/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
@@ -24,18 +24,22 @@ public class BackstabbingEnchantment extends Enchantment
 		super(rarityIn, typeIn, slots);
 	}
 
+	@Override
 	public int getMinLevel() {
 		return 1;
 	}
 
+	@Override
 	public int getMaxLevel() {
 		return 3;
 	}
 
+	@Override
 	public int getMinEnchantability(int enchantmentLevel) {
 		return 15 + (enchantmentLevel - 1) * 9;
 	}
 
+	@Override
 	public int getMaxEnchantability(int enchantmentLevel) {
 		return super.getMinEnchantability(enchantmentLevel) + 50;
 	}

--- a/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
+++ b/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
@@ -66,6 +66,7 @@ public class BackstabbingEnchantment extends Enchantment
 	public static class BackstabbingEvent
 	{
 		@SubscribeEvent
+		@SuppressWarnings("unused")
 		public static void onKnifeBackstab(LivingHurtEvent event) {
 			Entity attacker = event.getSource().getTrueSource();
 			if (attacker instanceof PlayerEntity) {

--- a/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
+++ b/src/main/java/vectorwing/farmersdelight/enchantments/BackstabbingEnchantment.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.enchantments;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.EnchantmentType;
@@ -9,7 +8,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
-import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.vector.Vector3d;
@@ -20,7 +18,8 @@ import net.minecraftforge.fml.common.Mod;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.registry.ModEnchantments;
 
-public class BackstabbingEnchantment extends Enchantment {
+public class BackstabbingEnchantment extends Enchantment
+{
 	public BackstabbingEnchantment(Rarity rarityIn, EnchantmentType typeIn, EquipmentSlotType... slots) {
 		super(rarityIn, typeIn, slots);
 	}
@@ -60,7 +59,8 @@ public class BackstabbingEnchantment extends Enchantment {
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-	public static class BackstabbingEvent {
+	public static class BackstabbingEvent
+	{
 		@SubscribeEvent
 		public static void onKnifeBackstab(LivingHurtEvent event) {
 			Entity attacker = event.getSource().getTrueSource();

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -17,7 +17,6 @@ import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.integration.jei.cooking.CookingRecipeCategory;
 import vectorwing.farmersdelight.integration.jei.cutting.CuttingRecipeCategory;
 import vectorwing.farmersdelight.registry.ModItems;
-import vectorwing.farmersdelight.integration.jei.cooking.CookingRecipeCategory;
 import vectorwing.farmersdelight.tile.container.CookingPotContainer;
 
 import java.util.List;
@@ -26,7 +25,8 @@ import java.util.stream.Collectors;
 @JeiPlugin
 @MethodsReturnNonnullByDefault
 @SuppressWarnings("unused")
-public class JEIPlugin implements IModPlugin {
+public class JEIPlugin implements IModPlugin
+{
 	private static final ResourceLocation ID = new ResourceLocation(FarmersDelight.MODID, "jei_plugin");
 	private static final Minecraft MC = Minecraft.getInstance();
 
@@ -69,5 +69,7 @@ public class JEIPlugin implements IModPlugin {
 	}
 
 	@Override
-	public ResourceLocation getPluginUid() { return ID;	}
+	public ResourceLocation getPluginUid() {
+		return ID;
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -1,8 +1,8 @@
 package vectorwing.farmersdelight.integration.jei;
 
+import mcp.MethodsReturnNonnullByDefault;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
-import mezz.jei.api.MethodsReturnNonnullByDefault;
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
 import mezz.jei.api.registration.*;
 import net.minecraft.client.Minecraft;
@@ -19,10 +19,12 @@ import vectorwing.farmersdelight.integration.jei.cutting.CuttingRecipeCategory;
 import vectorwing.farmersdelight.registry.ModItems;
 import vectorwing.farmersdelight.tile.container.CookingPotContainer;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @JeiPlugin
+@ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 @SuppressWarnings("unused")
 public class JEIPlugin implements IModPlugin

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/cooking/CookingRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/cooking/CookingRecipeCategory.java
@@ -26,7 +26,8 @@ import java.util.List;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CookingRecipeCategory implements IRecipeCategory<CookingPotRecipe> {
+public class CookingRecipeCategory implements IRecipeCategory<CookingPotRecipe>
+{
 	public static final ResourceLocation UID = new ResourceLocation(FarmersDelight.MODID, "cooking");
 	protected final IDrawable heatIndicator;
 	protected final IDrawableAnimated arrow;
@@ -70,8 +71,7 @@ public class CookingRecipeCategory implements IRecipeCategory<CookingPotRecipe> 
 	}
 
 	@Override
-	public void setIngredients(CookingPotRecipe cookingPotRecipe, IIngredients ingredients)
-	{
+	public void setIngredients(CookingPotRecipe cookingPotRecipe, IIngredients ingredients) {
 		List<Ingredient> inputAndContainer = new ArrayList<>(cookingPotRecipe.getIngredients());
 		inputAndContainer.add(Ingredient.fromStacks(cookingPotRecipe.getOutputContainer()));
 

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingBoardModel.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingBoardModel.java
@@ -2,21 +2,22 @@ package vectorwing.farmersdelight.integration.jei.cutting;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+import mcp.MethodsReturnNonnullByDefault;
 import mezz.jei.api.gui.drawable.IDrawable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.World;
 import vectorwing.farmersdelight.utils.ClientRenderUtils;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Supplier;
 
 @ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@SuppressWarnings("deprecation")
 public class CuttingBoardModel implements IDrawable
 {
 	private final Supplier<ItemStack> supplier;
@@ -53,7 +54,7 @@ public class CuttingBoardModel implements IDrawable
 		Minecraft minecraft = Minecraft.getInstance();
 		ItemRenderer itemRenderer = minecraft.getItemRenderer();
 		itemRenderer.zLevel += 50.0F;
-		IBakedModel bakedmodel = itemRenderer.getItemModelWithOverrides(stack, (World) null, (LivingEntity) null);
+		IBakedModel bakedmodel = itemRenderer.getItemModelWithOverrides(stack, null, null);
 		TextureManager textureManager = Minecraft.getInstance().textureManager;
 		ClientRenderUtils.renderItemIntoGUIScalable(stack, 48, 48, bakedmodel, itemRenderer, textureManager);
 		itemRenderer.zLevel -= 50.0F;

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingBoardModel.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingBoardModel.java
@@ -17,7 +17,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Supplier;
 
 @ParametersAreNonnullByDefault
-public class CuttingBoardModel implements IDrawable {
+public class CuttingBoardModel implements IDrawable
+{
 	private final Supplier<ItemStack> supplier;
 	private ItemStack stack;
 

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingRecipeCategory.java
@@ -19,7 +19,8 @@ import vectorwing.farmersdelight.registry.ModItems;
 
 import java.util.Arrays;
 
-public class CuttingRecipeCategory implements IRecipeCategory<CuttingBoardRecipe> {
+public class CuttingRecipeCategory implements IRecipeCategory<CuttingBoardRecipe>
+{
 	public static final ResourceLocation UID = new ResourceLocation(FarmersDelight.MODID, "cutting");
 	private final String title;
 	private final IDrawable background;

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingRecipeCategory.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/cutting/CuttingRecipeCategory.java
@@ -1,6 +1,7 @@
 package vectorwing.farmersdelight.integration.jei.cutting;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+import mcp.MethodsReturnNonnullByDefault;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -17,8 +18,11 @@ import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModItems;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Arrays;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class CuttingRecipeCategory implements IRecipeCategory<CuttingBoardRecipe>
 {
 	public static final ResourceLocation UID = new ResourceLocation(FarmersDelight.MODID, "cutting");

--- a/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
@@ -43,7 +43,8 @@ public class DogFoodItem extends MealItem
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-	public static class DogFoodEvent {
+	public static class DogFoodEvent
+	{
 		@SubscribeEvent
 		public static void onDogFoodApplied(PlayerInteractEvent.EntityInteract event) {
 			PlayerEntity player = event.getPlayer();
@@ -51,15 +52,15 @@ public class DogFoodItem extends MealItem
 			ItemStack itemStack = event.getItemStack();
 
 			if (target instanceof WolfEntity) {
-				WolfEntity wolf = (WolfEntity)target;
+				WolfEntity wolf = (WolfEntity) target;
 				if (wolf.isAlive() && wolf.isTamed() && itemStack.getItem().equals(ModItems.DOG_FOOD.get())) {
 					wolf.setHealth(wolf.getMaxHealth());
-					for(EffectInstance effect : EFFECTS) {
+					for (EffectInstance effect : EFFECTS) {
 						wolf.addPotionEffect(new EffectInstance(effect));
 					}
 					wolf.world.playSound(null, target.getPosition(), SoundEvents.ENTITY_GENERIC_EAT, SoundCategory.PLAYERS, 0.8F, 0.8F);
 
-					for(int i = 0; i < 5; ++i) {
+					for (int i = 0; i < 5; ++i) {
 						double d0 = MathUtils.RAND.nextGaussian() * 0.02D;
 						double d1 = MathUtils.RAND.nextGaussian() * 0.02D;
 						double d2 = MathUtils.RAND.nextGaussian() * 0.02D;
@@ -105,7 +106,7 @@ public class DogFoodItem extends MealItem
 	@Override
 	public ActionResultType itemInteractionForEntity(ItemStack stack, PlayerEntity playerIn, LivingEntity target, Hand hand) {
 		if (target instanceof WolfEntity) {
-			WolfEntity wolf = (WolfEntity)target;
+			WolfEntity wolf = (WolfEntity) target;
 			if (wolf.isAlive() && wolf.isTamed()) {
 				return ActionResultType.SUCCESS;
 			}

--- a/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
@@ -46,6 +46,7 @@ public class DogFoodItem extends MealItem
 	public static class DogFoodEvent
 	{
 		@SubscribeEvent
+		@SuppressWarnings("unused")
 		public static void onDogFoodApplied(PlayerInteractEvent.EntityInteract event) {
 			PlayerEntity player = event.getPlayer();
 			Entity target = event.getTarget();

--- a/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/DogFoodItem.java
@@ -1,18 +1,20 @@
 package vectorwing.farmersdelight.items;
 
 import com.google.common.collect.Lists;
-import com.mojang.datafixers.util.Pair;
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.ai.attributes.Attribute;
-import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.passive.WolfEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.potion.*;
-import net.minecraft.util.*;
+import net.minecraft.potion.Effect;
+import net.minecraft.potion.EffectInstance;
+import net.minecraft.potion.EffectUtils;
+import net.minecraft.potion.Effects;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.util.text.*;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
@@ -27,13 +29,8 @@ import vectorwing.farmersdelight.utils.MathUtils;
 import vectorwing.farmersdelight.utils.TextUtils;
 
 import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
-@MethodsReturnNonnullByDefault
-@ParametersAreNonnullByDefault
 public class DogFoodItem extends MealItem
 {
 	public static final List<EffectInstance> EFFECTS = Lists.newArrayList(
@@ -41,8 +38,8 @@ public class DogFoodItem extends MealItem
 			new EffectInstance(Effects.STRENGTH, 6000, 0),
 			new EffectInstance(Effects.RESISTANCE, 6000, 0));
 
-	public DogFoodItem(Properties builder) {
-		super(builder);
+	public DogFoodItem(Properties properties) {
+		super(properties);
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -81,26 +78,17 @@ public class DogFoodItem extends MealItem
 		}
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {
 		IFormattableTextComponent whenFeeding = TextUtils.getTranslation("tooltip.dog_food.when_feeding");
 		tooltip.add(whenFeeding.mergeStyle(TextFormatting.GRAY));
 
-		List<Pair<Attribute, AttributeModifier>> list1 = Lists.newArrayList();
-
-		for(EffectInstance effectinstance : EFFECTS) {
+		for (EffectInstance effectinstance : EFFECTS) {
 			IFormattableTextComponent effectDescription = new StringTextComponent(" ");
 			IFormattableTextComponent effectName = new TranslationTextComponent(effectinstance.getEffectName());
 			effectDescription.append(effectName);
 			Effect effect = effectinstance.getPotion();
-			Map<Attribute, AttributeModifier> map = effect.getAttributeModifierMap();
-			if (!map.isEmpty()) {
-				for(Entry<Attribute, AttributeModifier> entry : map.entrySet()) {
-					AttributeModifier attributemodifier = entry.getValue();
-					AttributeModifier attributemodifier1 = new AttributeModifier(attributemodifier.getName(), effect.getAttributeModifierAmount(effectinstance.getAmplifier(), attributemodifier), attributemodifier.getOperation());
-					list1.add(new Pair<>(entry.getKey(), attributemodifier1));
-				}
-			}
 
 			if (effectinstance.getAmplifier() > 0) {
 				effectDescription.appendString(" ").append(new TranslationTextComponent("potion.potency." + effectinstance.getAmplifier()));
@@ -114,6 +102,7 @@ public class DogFoodItem extends MealItem
 		}
 	}
 
+	@Override
 	public ActionResultType itemInteractionForEntity(ItemStack stack, PlayerEntity playerIn, LivingEntity target, Hand hand) {
 		if (target instanceof WolfEntity) {
 			WolfEntity wolf = (WolfEntity)target;

--- a/src/main/java/vectorwing/farmersdelight/items/Foods.java
+++ b/src/main/java/vectorwing/farmersdelight/items/Foods.java
@@ -5,7 +5,8 @@ import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import vectorwing.farmersdelight.registry.ModEffects;
 
-public class Foods {
+public class Foods
+{
 	// Raw Crops
 	public static final Food CABBAGE = (new Food.Builder())
 			.hunger(2).saturation(0.4f).build();

--- a/src/main/java/vectorwing/farmersdelight/items/FuelBlockItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/FuelBlockItem.java
@@ -4,7 +4,8 @@ import net.minecraft.block.Block;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 
-public class FuelBlockItem extends BlockItem {
+public class FuelBlockItem extends BlockItem
+{
 	public final int burnTime;
 
 	public FuelBlockItem(Block blockIn, Properties properties) {

--- a/src/main/java/vectorwing/farmersdelight/items/FuelItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/FuelItem.java
@@ -3,7 +3,8 @@ package vectorwing.farmersdelight.items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-public class FuelItem extends Item {
+public class FuelItem extends Item
+{
 	public final int burnTime;
 
 	public FuelItem(Properties properties) {

--- a/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
@@ -41,7 +41,8 @@ public class HorseFeedItem extends MealItem
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
-	public static class HorseFeedEvent {
+	public static class HorseFeedEvent
+	{
 		@SubscribeEvent
 		public static void onHorseFeedApplied(PlayerInteractEvent.EntityInteract event) {
 			PlayerEntity player = event.getPlayer();
@@ -49,15 +50,15 @@ public class HorseFeedItem extends MealItem
 			ItemStack itemStack = event.getItemStack();
 
 			if (target instanceof AbstractHorseEntity) {
-				AbstractHorseEntity horse = (AbstractHorseEntity)target;
+				AbstractHorseEntity horse = (AbstractHorseEntity) target;
 				if (horse.isAlive() && horse.isTame() && itemStack.getItem().equals(ModItems.HORSE_FEED.get())) {
 					horse.setHealth(horse.getMaxHealth());
-					for(EffectInstance effect : EFFECTS) {
+					for (EffectInstance effect : EFFECTS) {
 						horse.addPotionEffect(new EffectInstance(effect));
 					}
 					horse.world.playSound(null, target.getPosition(), SoundEvents.ENTITY_HORSE_EAT, SoundCategory.PLAYERS, 0.8F, 0.8F);
 
-					for(int i = 0; i < 5; ++i) {
+					for (int i = 0; i < 5; ++i) {
 						double d0 = MathUtils.RAND.nextGaussian() * 0.02D;
 						double d1 = MathUtils.RAND.nextGaussian() * 0.02D;
 						double d2 = MathUtils.RAND.nextGaussian() * 0.02D;
@@ -81,7 +82,7 @@ public class HorseFeedItem extends MealItem
 		IFormattableTextComponent whenFeeding = TextUtils.getTranslation("tooltip.horse_feed.when_feeding");
 		tooltip.add(whenFeeding.mergeStyle(TextFormatting.GRAY));
 
-		for(EffectInstance effectinstance : EFFECTS) {
+		for (EffectInstance effectinstance : EFFECTS) {
 			IFormattableTextComponent effectDescription = new StringTextComponent(" ");
 			IFormattableTextComponent effectName = new TranslationTextComponent(effectinstance.getEffectName());
 			effectDescription.append(effectName);
@@ -102,7 +103,7 @@ public class HorseFeedItem extends MealItem
 	@Override
 	public ActionResultType itemInteractionForEntity(ItemStack stack, PlayerEntity playerIn, LivingEntity target, Hand hand) {
 		if (target instanceof HorseEntity) {
-			HorseEntity horse = (HorseEntity)target;
+			HorseEntity horse = (HorseEntity) target;
 			if (horse.isAlive() && horse.isTame()) {
 				return ActionResultType.SUCCESS;
 			}

--- a/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
@@ -44,6 +44,7 @@ public class HorseFeedItem extends MealItem
 	public static class HorseFeedEvent
 	{
 		@SubscribeEvent
+		@SuppressWarnings("unused")
 		public static void onHorseFeedApplied(PlayerInteractEvent.EntityInteract event) {
 			PlayerEntity player = event.getPlayer();
 			Entity target = event.getTarget();

--- a/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/HorseFeedItem.java
@@ -1,13 +1,9 @@
 package vectorwing.farmersdelight.items;
 
-import com.mojang.datafixers.util.Pair;
-import mcp.MethodsReturnNonnullByDefault;
 import com.google.common.collect.Lists;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.ai.attributes.Attribute;
-import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.passive.horse.AbstractHorseEntity;
 import net.minecraft.entity.passive.horse.HorseEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -16,7 +12,10 @@ import net.minecraft.potion.Effect;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.EffectUtils;
 import net.minecraft.potion.Effects;
-import net.minecraft.util.*;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
 import net.minecraft.util.text.*;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -30,20 +29,15 @@ import vectorwing.farmersdelight.utils.TextUtils;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
-import javax.annotation.ParametersAreNonnullByDefault;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 public class HorseFeedItem extends MealItem
 {
 	public static final List<EffectInstance> EFFECTS = Lists.newArrayList(
 			new EffectInstance(Effects.SPEED, 6000, 1),
 			new EffectInstance(Effects.JUMP_BOOST, 6000, 0));
 
-	public HorseFeedItem(Properties builder)
-	{
-		super(builder);
+	public HorseFeedItem(Properties properties) {
+		super(properties);
 	}
 
 	@Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -82,25 +76,16 @@ public class HorseFeedItem extends MealItem
 		}
 	}
 
+	@Override
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn) {
 		IFormattableTextComponent whenFeeding = TextUtils.getTranslation("tooltip.horse_feed.when_feeding");
 		tooltip.add(whenFeeding.mergeStyle(TextFormatting.GRAY));
-
-		List<Pair<Attribute, AttributeModifier>> list1 = Lists.newArrayList();
 
 		for(EffectInstance effectinstance : EFFECTS) {
 			IFormattableTextComponent effectDescription = new StringTextComponent(" ");
 			IFormattableTextComponent effectName = new TranslationTextComponent(effectinstance.getEffectName());
 			effectDescription.append(effectName);
 			Effect effect = effectinstance.getPotion();
-			Map<Attribute, AttributeModifier> map = effect.getAttributeModifierMap();
-			if (!map.isEmpty()) {
-				for(Map.Entry<Attribute, AttributeModifier> entry : map.entrySet()) {
-					AttributeModifier attributemodifier = entry.getValue();
-					AttributeModifier attributemodifier1 = new AttributeModifier(attributemodifier.getName(), effect.getAttributeModifierAmount(effectinstance.getAmplifier(), attributemodifier), attributemodifier.getOperation());
-					list1.add(new Pair<>(entry.getKey(), attributemodifier1));
-				}
-			}
 
 			if (effectinstance.getAmplifier() > 0) {
 				effectDescription.appendString(" ").append(new TranslationTextComponent("potion.potency." + effectinstance.getAmplifier()));
@@ -114,6 +99,7 @@ public class HorseFeedItem extends MealItem
 		}
 	}
 
+	@Override
 	public ActionResultType itemInteractionForEntity(ItemStack stack, PlayerEntity playerIn, LivingEntity target, Hand hand) {
 		if (target instanceof HorseEntity) {
 			HorseEntity horse = (HorseEntity)target;

--- a/src/main/java/vectorwing/farmersdelight/items/HotCocoaItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/HotCocoaItem.java
@@ -22,71 +22,71 @@ import java.util.Iterator;
 
 public class HotCocoaItem extends Item
 {
-    public HotCocoaItem(Properties builder) {
-        super(builder);
-    }
+	public HotCocoaItem(Properties builder) {
+		super(builder);
+	}
 
-    @Override
-    public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
-        PlayerEntity playerentity = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
+	@Override
+	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
+		PlayerEntity playerentity = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
 
-        if (!worldIn.isRemote) {
-            Iterator<EffectInstance> itr = entityLiving.getActivePotionEffects().iterator();
-            ArrayList<Effect> compatibleEffects = new ArrayList<>();
+		if (!worldIn.isRemote) {
+			Iterator<EffectInstance> itr = entityLiving.getActivePotionEffects().iterator();
+			ArrayList<Effect> compatibleEffects = new ArrayList<>();
 
-            // Select eligible effects
-            while (itr.hasNext()) {
-                EffectInstance effect = itr.next();
-                if (effect.getPotion().getEffectType().equals(EffectType.HARMFUL) && effect.isCurativeItem(new ItemStack(Items.MILK_BUCKET))) {
-                    compatibleEffects.add(effect.getPotion());
-                }
-            }
+			// Select eligible effects
+			while (itr.hasNext()) {
+				EffectInstance effect = itr.next();
+				if (effect.getPotion().getEffectType().equals(EffectType.HARMFUL) && effect.isCurativeItem(new ItemStack(Items.MILK_BUCKET))) {
+					compatibleEffects.add(effect.getPotion());
+				}
+			}
 
-            // Randomly pick one, then remove
-            if (compatibleEffects.size() > 0) {
-                EffectInstance selectedEffect = entityLiving.getActivePotionEffect(compatibleEffects.get(worldIn.rand.nextInt(compatibleEffects.size())));
-                if (selectedEffect != null && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionRemoveEvent(entityLiving, selectedEffect))) {
-                    entityLiving.removePotionEffect(selectedEffect.getPotion());
-                }
-            }
-        }
+			// Randomly pick one, then remove
+			if (compatibleEffects.size() > 0) {
+				EffectInstance selectedEffect = entityLiving.getActivePotionEffect(compatibleEffects.get(worldIn.rand.nextInt(compatibleEffects.size())));
+				if (selectedEffect != null && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionRemoveEvent(entityLiving, selectedEffect))) {
+					entityLiving.removePotionEffect(selectedEffect.getPotion());
+				}
+			}
+		}
 
-        if (playerentity instanceof ServerPlayerEntity) {
-            CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) playerentity, stack);
-        }
+		if (playerentity instanceof ServerPlayerEntity) {
+			CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) playerentity, stack);
+		}
 
-        if (playerentity != null) {
-            playerentity.addStat(Stats.ITEM_USED.get(this));
-            if (!playerentity.abilities.isCreativeMode) {
-                stack.shrink(1);
-            }
-        }
+		if (playerentity != null) {
+			playerentity.addStat(Stats.ITEM_USED.get(this));
+			if (!playerentity.abilities.isCreativeMode) {
+				stack.shrink(1);
+			}
+		}
 
-        if (playerentity == null || !playerentity.abilities.isCreativeMode) {
-            if (stack.isEmpty()) {
-                return new ItemStack(Items.GLASS_BOTTLE);
-            }
+		if (playerentity == null || !playerentity.abilities.isCreativeMode) {
+			if (stack.isEmpty()) {
+				return new ItemStack(Items.GLASS_BOTTLE);
+			}
 
-            if (playerentity != null) {
-                playerentity.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
-            }
-        }
+			if (playerentity != null) {
+				playerentity.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
+			}
+		}
 
-        return stack;
-    }
+		return stack;
+	}
 
-    @Override
-    public int getUseDuration(ItemStack stack) {
-        return 32;
-    }
+	@Override
+	public int getUseDuration(ItemStack stack) {
+		return 32;
+	}
 
-    @Override
-    public UseAction getUseAction(ItemStack stack) {
-        return UseAction.DRINK;
-    }
+	@Override
+	public UseAction getUseAction(ItemStack stack) {
+		return UseAction.DRINK;
+	}
 
-    @Override
-    public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
-        return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
-    }
+	@Override
+	public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
+		return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/items/HotCocoaItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/HotCocoaItem.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.items;
 
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -18,17 +17,16 @@ import net.minecraft.util.DrinkHelper;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
-public class HotCocoaItem extends Item {
+public class HotCocoaItem extends Item
+{
     public HotCocoaItem(Properties builder) {
         super(builder);
     }
 
+    @Override
     public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
         PlayerEntity playerentity = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
 
@@ -77,14 +75,17 @@ public class HotCocoaItem extends Item {
         return stack;
     }
 
+    @Override
     public int getUseDuration(ItemStack stack) {
         return 32;
     }
 
+    @Override
     public UseAction getUseAction(ItemStack stack) {
         return UseAction.DRINK;
     }
 
+    @Override
     public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
         return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
     }

--- a/src/main/java/vectorwing/farmersdelight/items/KnifeItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/KnifeItem.java
@@ -23,19 +23,19 @@ public class KnifeItem extends ToolItem
 {
 	private static final Set<Block> EFFECTIVE_ON = Sets.newHashSet(Blocks.HAY_BLOCK, ModBlocks.RICE_BALE.get());
 
-    public KnifeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties properties) {
-        super(attackDamageIn, attackSpeedIn, tier, EFFECTIVE_ON, properties);
-    }
+	public KnifeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties properties) {
+		super(attackDamageIn, attackSpeedIn, tier, EFFECTIVE_ON, properties);
+	}
 
 	@Override
 	public float getDestroySpeed(ItemStack stack, BlockState state) {
 		Material material = state.getMaterial();
 		if (EFFECTIVE_ON.contains(state.getBlock())) return this.efficiency;
 		return material != Material.WOOL
-			&& material != Material.CARPET
-			&& material != Material.CAKE
-			&& material != Material.WEB
-			&& material != Material.LEAVES ? super.getDestroySpeed(stack, state) : this.efficiency;
+				&& material != Material.CARPET
+				&& material != Material.CAKE
+				&& material != Material.WEB
+				&& material != Material.LEAVES ? super.getDestroySpeed(stack, state) : this.efficiency;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/items/KnifeItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/KnifeItem.java
@@ -1,7 +1,6 @@
 package vectorwing.farmersdelight.items;
 
 import com.google.common.collect.Sets;
-import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -11,26 +10,24 @@ import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
-import net.minecraft.item.*;
+import net.minecraft.item.IItemTier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ToolItem;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import vectorwing.farmersdelight.registry.ModBlocks;
-import vectorwing.farmersdelight.utils.MathUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Set;
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
 public class KnifeItem extends ToolItem
 {
 	private static final Set<Block> EFFECTIVE_ON = Sets.newHashSet(Blocks.HAY_BLOCK, ModBlocks.RICE_BALE.get());
 
-    public KnifeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties builder) {
-        super(attackDamageIn, attackSpeedIn, tier, EFFECTIVE_ON, builder);
+    public KnifeItem(IItemTier tier, float attackDamageIn, float attackSpeedIn, Properties properties) {
+        super(attackDamageIn, attackSpeedIn, tier, EFFECTIVE_ON, properties);
     }
 
+	@Override
 	public float getDestroySpeed(ItemStack stack, BlockState state) {
 		Material material = state.getMaterial();
 		if (EFFECTIVE_ON.contains(state.getBlock())) return this.efficiency;
@@ -41,20 +38,19 @@ public class KnifeItem extends ToolItem
 			&& material != Material.LEAVES ? super.getDestroySpeed(stack, state) : this.efficiency;
 	}
 
+	@Override
 	public boolean canPlayerBreakBlockWhileHolding(BlockState state, World worldIn, BlockPos pos, PlayerEntity player) {
 		return !player.isCreative();
 	}
 
+	@Override
 	public boolean hitEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
-		stack.damageItem(1, attacker, (user) -> {
-			user.sendBreakAnimation(EquipmentSlotType.MAINHAND);
-		});
+		stack.damageItem(1, attacker, (user) -> user.sendBreakAnimation(EquipmentSlotType.MAINHAND));
 		return true;
 	}
 
 	@Override
-	public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
-	{
+	public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment) {
 		Set<Enchantment> ALLOWED_ENCHANTMENTS = Sets.newHashSet(Enchantments.SHARPNESS, Enchantments.SMITE, Enchantments.BANE_OF_ARTHROPODS, Enchantments.KNOCKBACK, Enchantments.FIRE_ASPECT, Enchantments.LOOTING);
 		if (ALLOWED_ENCHANTMENTS.contains(enchantment)) {
 			return true;

--- a/src/main/java/vectorwing/farmersdelight/items/MealItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/MealItem.java
@@ -11,17 +11,19 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class MealItem extends Item {
+public class MealItem extends Item
+{
 	/**
 	 * Items that are foods, and need a container to be held.
 	 * When eaten, they deposit containers into the player's inventory, allowing them to set maximum stack sizes above 1.
 	 */
-	public MealItem(Item.Properties builder) {
-		super(builder);
+	public MealItem(Item.Properties properties) {
+		super(properties);
 	}
 
+	@Override
 	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
-		PlayerEntity playerentity = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
+		PlayerEntity player = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
 		ItemStack container = stack.getContainerItem();
 
 		ItemStack itemstack = super.onItemUseFinish(stack, worldIn, entityLiving);
@@ -29,13 +31,13 @@ public class MealItem extends Item {
 			return itemstack;
 		}
 
-		if (playerentity == null || !playerentity.abilities.isCreativeMode) {
+		if (player == null || !player.abilities.isCreativeMode) {
 			if (itemstack.isEmpty()) {
 				return container;
 			}
 
-			if (playerentity != null) {
-				playerentity.inventory.addItemStackToInventory(container);
+			if (player != null) {
+				player.inventory.addItemStackToInventory(container);
 			}
 		}
 		return stack;

--- a/src/main/java/vectorwing/farmersdelight/items/MilkBottleItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/MilkBottleItem.java
@@ -25,71 +25,71 @@ import java.util.Iterator;
 @MethodsReturnNonnullByDefault
 public class MilkBottleItem extends Item
 {
-    public MilkBottleItem(Item.Properties properties) {
-        super(properties);
-    }
+	public MilkBottleItem(Item.Properties properties) {
+		super(properties);
+	}
 
-    @Override
-    public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
-        PlayerEntity player = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
+	@Override
+	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
+		PlayerEntity player = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
 
-        if (!worldIn.isRemote) {
-            Iterator<EffectInstance> itr = entityLiving.getActivePotionEffects().iterator();
-            ArrayList<Effect> compatibleEffects = new ArrayList<>();
+		if (!worldIn.isRemote) {
+			Iterator<EffectInstance> itr = entityLiving.getActivePotionEffects().iterator();
+			ArrayList<Effect> compatibleEffects = new ArrayList<>();
 
-            // Select eligible effects
-            while (itr.hasNext()) {
-                EffectInstance effect = itr.next();
-                if (effect.isCurativeItem(new ItemStack(Items.MILK_BUCKET))) {
-                    compatibleEffects.add(effect.getPotion());
-                }
-            }
+			// Select eligible effects
+			while (itr.hasNext()) {
+				EffectInstance effect = itr.next();
+				if (effect.isCurativeItem(new ItemStack(Items.MILK_BUCKET))) {
+					compatibleEffects.add(effect.getPotion());
+				}
+			}
 
-            // Randomly pick one, then remove
-            if (compatibleEffects.size() > 0) {
-                EffectInstance selectedEffect = entityLiving.getActivePotionEffect(compatibleEffects.get(worldIn.rand.nextInt(compatibleEffects.size())));
-                if (selectedEffect != null && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionRemoveEvent(entityLiving, selectedEffect))) {
-                    entityLiving.removePotionEffect(selectedEffect.getPotion());
-                }
-            }
-        }
+			// Randomly pick one, then remove
+			if (compatibleEffects.size() > 0) {
+				EffectInstance selectedEffect = entityLiving.getActivePotionEffect(compatibleEffects.get(worldIn.rand.nextInt(compatibleEffects.size())));
+				if (selectedEffect != null && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.PotionEvent.PotionRemoveEvent(entityLiving, selectedEffect))) {
+					entityLiving.removePotionEffect(selectedEffect.getPotion());
+				}
+			}
+		}
 
-        if (player instanceof ServerPlayerEntity) {
-            CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) player, stack);
-        }
+		if (player instanceof ServerPlayerEntity) {
+			CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) player, stack);
+		}
 
-        if (player != null) {
-            player.addStat(Stats.ITEM_USED.get(this));
-            if (!player.abilities.isCreativeMode) {
-                stack.shrink(1);
-            }
-        }
+		if (player != null) {
+			player.addStat(Stats.ITEM_USED.get(this));
+			if (!player.abilities.isCreativeMode) {
+				stack.shrink(1);
+			}
+		}
 
-        if (player == null || !player.abilities.isCreativeMode) {
-            if (stack.isEmpty()) {
-                return new ItemStack(Items.GLASS_BOTTLE);
-            }
+		if (player == null || !player.abilities.isCreativeMode) {
+			if (stack.isEmpty()) {
+				return new ItemStack(Items.GLASS_BOTTLE);
+			}
 
-            if (player != null) {
-                player.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
-            }
-        }
+			if (player != null) {
+				player.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
+			}
+		}
 
-        return stack;
-    }
+		return stack;
+	}
 
-    @Override
-    public int getUseDuration(ItemStack stack) {
-        return 32;
-    }
+	@Override
+	public int getUseDuration(ItemStack stack) {
+		return 32;
+	}
 
-    @Override
-    public UseAction getUseAction(ItemStack stack) {
-        return UseAction.DRINK;
-    }
+	@Override
+	public UseAction getUseAction(ItemStack stack) {
+		return UseAction.DRINK;
+	}
 
-    @Override
-    public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
-        return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
-    }
+	@Override
+	public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
+		return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/items/MilkBottleItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/MilkBottleItem.java
@@ -23,13 +23,15 @@ import java.util.Iterator;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class MilkBottleItem extends Item {
-    public MilkBottleItem(Item.Properties builder) {
-        super(builder);
+public class MilkBottleItem extends Item
+{
+    public MilkBottleItem(Item.Properties properties) {
+        super(properties);
     }
 
+    @Override
     public ItemStack onItemUseFinish(ItemStack stack, World worldIn, LivingEntity entityLiving) {
-        PlayerEntity playerentity = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
+        PlayerEntity player = entityLiving instanceof PlayerEntity ? (PlayerEntity) entityLiving : null;
 
         if (!worldIn.isRemote) {
             Iterator<EffectInstance> itr = entityLiving.getActivePotionEffects().iterator();
@@ -52,38 +54,41 @@ public class MilkBottleItem extends Item {
             }
         }
 
-        if (playerentity instanceof ServerPlayerEntity) {
-            CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) playerentity, stack);
+        if (player instanceof ServerPlayerEntity) {
+            CriteriaTriggers.CONSUME_ITEM.trigger((ServerPlayerEntity) player, stack);
         }
 
-        if (playerentity != null) {
-            playerentity.addStat(Stats.ITEM_USED.get(this));
-            if (!playerentity.abilities.isCreativeMode) {
+        if (player != null) {
+            player.addStat(Stats.ITEM_USED.get(this));
+            if (!player.abilities.isCreativeMode) {
                 stack.shrink(1);
             }
         }
 
-        if (playerentity == null || !playerentity.abilities.isCreativeMode) {
+        if (player == null || !player.abilities.isCreativeMode) {
             if (stack.isEmpty()) {
                 return new ItemStack(Items.GLASS_BOTTLE);
             }
 
-            if (playerentity != null) {
-                playerentity.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
+            if (player != null) {
+                player.inventory.addItemStackToInventory(new ItemStack(Items.GLASS_BOTTLE));
             }
         }
 
         return stack;
     }
 
+    @Override
     public int getUseDuration(ItemStack stack) {
         return 32;
     }
 
+    @Override
     public UseAction getUseAction(ItemStack stack) {
         return UseAction.DRINK;
     }
 
+    @Override
     public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
         return DrinkHelper.startDrinking(worldIn, playerIn, handIn);
     }

--- a/src/main/java/vectorwing/farmersdelight/items/RopeItem.java
+++ b/src/main/java/vectorwing/farmersdelight/items/RopeItem.java
@@ -9,11 +9,13 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 
-public class RopeItem extends FuelBlockItem {
-	public RopeItem(Block blockIn, Properties builder) {
-		super(blockIn, builder, 200);
+public class RopeItem extends FuelBlockItem
+{
+	public RopeItem(Block blockIn, Properties properties) {
+		super(blockIn, properties, 200);
 	}
 
+	@Override
 	@Nullable
 	public BlockItemUseContext getBlockItemUseContext(BlockItemUseContext context) {
 		BlockPos blockpos = context.getPos();
@@ -23,13 +25,11 @@ public class RopeItem extends FuelBlockItem {
 
 		if (blockstate.getBlock() != block) {
 			return context;
-		}
-		else {
+		} else {
 			Direction direction;
 			if (context.hasSecondaryUseForPlayer()) {
 				direction = context.getFace();
-			}
-			else {
+			} else {
 				direction = Direction.DOWN;
 			}
 
@@ -57,6 +57,7 @@ public class RopeItem extends FuelBlockItem {
 		}
 	}
 
+	@Override
 	protected boolean checkPosition() {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/items/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/items/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package vectorwing.farmersdelight.items;
+
+import mcp.MethodsReturnNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/vectorwing/farmersdelight/items/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/items/package-info.java
@@ -3,4 +3,5 @@
 package vectorwing.farmersdelight.items;
 
 import mcp.MethodsReturnNonnullByDefault;
+
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/vectorwing/farmersdelight/loot/functions/CopyMealFunction.java
+++ b/src/main/java/vectorwing/farmersdelight/loot/functions/CopyMealFunction.java
@@ -15,12 +15,13 @@ import net.minecraft.util.ResourceLocation;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.tile.CookingPotTileEntity;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class CopyMealFunction extends LootFunction {
-
+public class CopyMealFunction extends LootFunction
+{
 	public static final ResourceLocation ID = new ResourceLocation(FarmersDelight.MODID, "copy_meal");
 
 	private CopyMealFunction(ILootCondition[] conditions) {
@@ -44,11 +45,13 @@ public class CopyMealFunction extends LootFunction {
 	}
 
 	@Override
+	@Nullable
 	public LootFunctionType getFunctionType() {
 		return null;
 	}
 
-	public static class Serializer extends LootFunction.Serializer<CopyMealFunction> {
+	public static class Serializer extends LootFunction.Serializer<CopyMealFunction>
+	{
 		@Override
 		public CopyMealFunction deserialize(JsonObject json, JsonDeserializationContext context, ILootCondition[] conditions) {
 			return new CopyMealFunction(conditions);

--- a/src/main/java/vectorwing/farmersdelight/loot/modifiers/CakeSliceLoot.java
+++ b/src/main/java/vectorwing/farmersdelight/loot/modifiers/CakeSliceLoot.java
@@ -15,9 +15,10 @@ import vectorwing.farmersdelight.registry.ModItems;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class CakeSliceLoot {
-	public static class CakeSliceSerializer extends GlobalLootModifierSerializer<CakeSliceModifier> {
-
+public class CakeSliceLoot
+{
+	public static class CakeSliceSerializer extends GlobalLootModifierSerializer<CakeSliceModifier>
+	{
 		@Override
 		public CakeSliceModifier read(ResourceLocation location, JsonObject object, ILootCondition[] ailootcondition) {
 			return new CakeSliceModifier(ailootcondition);
@@ -29,7 +30,8 @@ public class CakeSliceLoot {
 		}
 	}
 
-	private static class CakeSliceModifier extends LootModifier {
+	private static class CakeSliceModifier extends LootModifier
+	{
 		protected CakeSliceModifier(ILootCondition[] conditionsIn) {
 			super(conditionsIn);
 		}
@@ -38,7 +40,7 @@ public class CakeSliceLoot {
 		@Override
 		protected List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
 			BlockState state = context.get(LootParameters.BLOCK_STATE);
-			if (state.hasProperty(BlockStateProperties.BITES_0_6)) {
+			if (state != null && state.hasProperty(BlockStateProperties.BITES_0_6)) {
 				int bites = state.get(BlockStateProperties.BITES_0_6);
 				int TOTAL_SLICES = 7;
 				generatedLoot.add(new ItemStack(ModItems.CAKE_SLICE.get(), TOTAL_SLICES - bites));

--- a/src/main/java/vectorwing/farmersdelight/loot/modifiers/StrawHarvestingModifier.java
+++ b/src/main/java/vectorwing/farmersdelight/loot/modifiers/StrawHarvestingModifier.java
@@ -12,8 +12,10 @@ import vectorwing.farmersdelight.registry.ModItems;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class StrawHarvestingModifier {
-	public static class KnifeStrawSerializer extends GlobalLootModifierSerializer<StrawHarvestingModifier.KnifeStrawModifier> {
+public class StrawHarvestingModifier
+{
+	public static class KnifeStrawSerializer extends GlobalLootModifierSerializer<StrawHarvestingModifier.KnifeStrawModifier>
+	{
 		@Override
 		public StrawHarvestingModifier.KnifeStrawModifier read(ResourceLocation location, JsonObject object, ILootCondition[] ailootcondition) {
 			return new StrawHarvestingModifier.KnifeStrawModifier(ailootcondition);
@@ -25,8 +27,8 @@ public class StrawHarvestingModifier {
 		}
 	}
 
-	public static class KnifeStrawModifier extends LootModifier {
-
+	public static class KnifeStrawModifier extends LootModifier
+	{
 		protected KnifeStrawModifier(ILootCondition[] conditionsIn) {
 			super(conditionsIn);
 		}

--- a/src/main/java/vectorwing/farmersdelight/registry/ModAdvancements.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModAdvancements.java
@@ -3,10 +3,11 @@ package vectorwing.farmersdelight.registry;
 import net.minecraft.advancements.CriteriaTriggers;
 import vectorwing.farmersdelight.advancement.CuttingBoardTrigger;
 
-public class ModAdvancements {
+public class ModAdvancements
+{
 	public static CuttingBoardTrigger CUTTING_BOARD = new CuttingBoardTrigger();
 
 	public static void register() {
-		CUTTING_BOARD = CriteriaTriggers.register(CUTTING_BOARD);
+		CriteriaTriggers.register(CUTTING_BOARD);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/registry/ModBiomeFeatures.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModBiomeFeatures.java
@@ -8,7 +8,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.world.features.RiceCropFeature;
 
-public class ModBiomeFeatures {
+public class ModBiomeFeatures
+{
 	public static final DeferredRegister<Feature<?>> FEATURES = DeferredRegister.create(ForgeRegistries.FEATURES, FarmersDelight.MODID);
 
 	public static final RegistryObject<Feature<BlockClusterFeatureConfig>> RICE = FEATURES.register("rice", () -> new RiceCropFeature(BlockClusterFeatureConfig.field_236587_a_));

--- a/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
@@ -13,13 +13,12 @@ import vectorwing.farmersdelight.blocks.*;
 
 import java.util.function.ToIntFunction;
 
-public class ModBlocks {
+public class ModBlocks
+{
 	public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, FarmersDelight.MODID);
 
 	private static ToIntFunction<BlockState> getLightValueLit(int lightValue) {
-		return (state) -> {
-			return state.get(BlockStateProperties.LIT) ? lightValue : 0;
-		};
+		return (state) -> state.get(BlockStateProperties.LIT) ? lightValue : 0;
 	}
 
 	// FUNCTIONAL

--- a/src/main/java/vectorwing/farmersdelight/registry/ModContainerTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModContainerTypes.java
@@ -8,7 +8,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.tile.container.CookingPotContainer;
 
-public class ModContainerTypes {
+public class ModContainerTypes
+{
 	public static final DeferredRegister<ContainerType<?>> CONTAINER_TYPES = DeferredRegister.create(ForgeRegistries.CONTAINERS, FarmersDelight.MODID);
 
 	public static final RegistryObject<ContainerType<CookingPotContainer>> COOKING_POT = CONTAINER_TYPES

--- a/src/main/java/vectorwing/farmersdelight/registry/ModEffects.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModEffects.java
@@ -8,7 +8,8 @@ import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.effects.ComfortEffect;
 import vectorwing.farmersdelight.effects.NourishedEffect;
 
-public class ModEffects {
+public class ModEffects
+{
 	public static final DeferredRegister<Effect> EFFECTS = DeferredRegister.create(ForgeRegistries.POTIONS, FarmersDelight.MODID);
 
 	public static final RegistryObject<Effect> NOURISHED = EFFECTS.register("nourished", NourishedEffect::new);

--- a/src/main/java/vectorwing/farmersdelight/registry/ModEnchantments.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModEnchantments.java
@@ -10,7 +10,8 @@ import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.enchantments.BackstabbingEnchantment;
 import vectorwing.farmersdelight.items.KnifeItem;
 
-public class ModEnchantments {
+public class ModEnchantments
+{
 	public static final EnchantmentType KNIFE = EnchantmentType.create("knife", item -> item instanceof KnifeItem);
 
 	public static final DeferredRegister<Enchantment> ENCHANTMENTS = DeferredRegister.create(ForgeRegistries.ENCHANTMENTS, FarmersDelight.MODID);

--- a/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
@@ -52,7 +52,7 @@ public class ModItems {
 	public static final RegistryObject<Item> FULL_TATAMI_MAT = ITEMS.register("full_tatami_mat",
 			() -> new FuelBlockItem(ModBlocks.FULL_TATAMI_MAT.get(), new Item.Properties().group(FarmersDelight.ITEM_GROUP), 200));
 	public static final RegistryObject<Item> HALF_TATAMI_MAT = ITEMS.register("half_tatami_mat",
-			() -> new FuelBlockItem(ModBlocks.HALF_TATAMI_MAT.get(), new Item.Properties().group(FarmersDelight.ITEM_GROUP), 100));
+			() -> new FuelBlockItem(ModBlocks.HALF_TATAMI_MAT.get(), new Item.Properties().group(FarmersDelight.ITEM_GROUP)));
 	public static final RegistryObject<Item> ORGANIC_COMPOST = ITEMS.register("organic_compost",
 			() -> new BlockItem(ModBlocks.ORGANIC_COMPOST.get(), new Item.Properties().group(FarmersDelight.ITEM_GROUP)));
 	public static final RegistryObject<Item> RICH_SOIL = ITEMS.register("rich_soil",

--- a/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
@@ -9,7 +9,8 @@ import vectorwing.farmersdelight.items.Foods;
 import vectorwing.farmersdelight.items.*;
 
 @SuppressWarnings("unused")
-public class ModItems {
+public class ModItems
+{
 	public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, FarmersDelight.MODID);
 
 	// Blocks

--- a/src/main/java/vectorwing/farmersdelight/registry/ModParticleTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModParticleTypes.java
@@ -7,7 +7,8 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 
-public class ModParticleTypes {
+public class ModParticleTypes
+{
 	public static final DeferredRegister<ParticleType<?>> PARTICLE_TYPES = DeferredRegister.create(ForgeRegistries.PARTICLE_TYPES, FarmersDelight.MODID);
 
 	public static final RegistryObject<BasicParticleType> STAR_PARTICLE = PARTICLE_TYPES.register("star",

--- a/src/main/java/vectorwing/farmersdelight/registry/ModRecipeSerializers.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModRecipeSerializers.java
@@ -5,6 +5,7 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 
-public class ModRecipeSerializers {
+public class ModRecipeSerializers
+{
 	public static final DeferredRegister<IRecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, FarmersDelight.MODID);
 }

--- a/src/main/java/vectorwing/farmersdelight/registry/ModTileEntityTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModTileEntityTypes.java
@@ -7,7 +7,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.tile.*;
 
-public class ModTileEntityTypes {
+public class ModTileEntityTypes
+{
 	public static final DeferredRegister<TileEntityType<?>> TILES = DeferredRegister.create(ForgeRegistries.TILE_ENTITIES, FarmersDelight.MODID);
 
 	public static final RegistryObject<TileEntityType<StoveTileEntity>> STOVE_TILE = TILES.register("stove",

--- a/src/main/java/vectorwing/farmersdelight/setup/ClientEventHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/ClientEventHandler.java
@@ -36,7 +36,7 @@ public class ClientEventHandler
 		if (!stitching.equals(AtlasTexture.LOCATION_BLOCKS_TEXTURE)) {
 			return;
 		}
-		boolean added = event.addSprite(EMPTY_CONTAINER_SLOT_BOWL);
+		event.addSprite(EMPTY_CONTAINER_SLOT_BOWL);
 	}
 
 	public static void init(final FMLClientSetupEvent event) {

--- a/src/main/java/vectorwing/farmersdelight/setup/CommonEventHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/CommonEventHandler.java
@@ -24,7 +24,6 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.village.VillagerTradesEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import vectorwing.farmersdelight.FarmersDelight;
@@ -35,7 +34,6 @@ import vectorwing.farmersdelight.registry.ModEffects;
 import vectorwing.farmersdelight.registry.ModItems;
 import vectorwing.farmersdelight.tile.dispenser.CuttingBoardDispenseBehavior;
 import vectorwing.farmersdelight.utils.tags.ModTags;
-import vectorwing.farmersdelight.world.CropPatchGeneration;
 import vectorwing.farmersdelight.world.VillageStructures;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -54,10 +52,9 @@ public class CommonEventHandler
 			LootTables.CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE,
 			LootTables.CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE,
 			LootTables.CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE);
-	private static final String[] SCAVENGING_ENTITIES = new String[] { "cow", "chicken", "rabbit", "horse", "donkey", "mule", "llama", "shulker" };
+	private static final String[] SCAVENGING_ENTITIES = new String[]{"cow", "chicken", "rabbit", "horse", "donkey", "mule", "llama", "shulker"};
 
-	public static void init(final FMLCommonSetupEvent event)
-	{
+	public static void init(final FMLCommonSetupEvent event) {
 		registerCompostables();
 
 		ModAdvancements.register();
@@ -147,8 +144,7 @@ public class CommonEventHandler
 		Int2ObjectMap<List<VillagerTrades.ITrade>> trades = event.getTrades();
 		VillagerProfession profession = event.getType();
 		if (profession.getRegistryName() == null) return;
-		if (profession.getRegistryName().getPath().equals("farmer"))
-		{
+		if (profession.getRegistryName().getPath().equals("farmer")) {
 			trades.get(1).add(new EmeraldForItemsTrade(ModItems.ONION.get(), 26, 16, 2));
 			trades.get(1).add(new EmeraldForItemsTrade(ModItems.TOMATO.get(), 26, 16, 2));
 			trades.get(2).add(new EmeraldForItemsTrade(ModItems.CABBAGE.get(), 16, 16, 5));
@@ -172,7 +168,8 @@ public class CommonEventHandler
 		}
 	}
 
-	static class EmeraldForItemsTrade implements VillagerTrades.ITrade {
+	static class EmeraldForItemsTrade implements VillagerTrades.ITrade
+	{
 		private final Item tradeItem;
 		private final int count;
 		private final int maxUses;
@@ -208,8 +205,7 @@ public class CommonEventHandler
 	}
 
 	@SubscribeEvent
-	public static void onLootLoad(LootTableLoadEvent event)
-	{
+	public static void onLootLoad(LootTableLoadEvent event) {
 		for (String entity : SCAVENGING_ENTITIES) {
 			if (event.getName().equals(new ResourceLocation("minecraft", "entities/" + entity))) {
 				event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation(FarmersDelight.MODID, "inject/" + entity))).name(entity + "_fd_drops").build());

--- a/src/main/java/vectorwing/farmersdelight/setup/Configuration.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/Configuration.java
@@ -15,7 +15,7 @@ public class Configuration
 	public static final String CATEGORY_SETTINGS = "settings";
 	public static final String CATEGORY_OVERRIDES = "overrides";
 	public static final String CATEGORY_WORLD = "world";
-	
+
 	public static ForgeConfigSpec.BooleanValue FARMERS_BUY_FD_CROPS;
 	public static ForgeConfigSpec.BooleanValue COMFORT_FOOD_TAG_EFFECT;
 	public static ForgeConfigSpec.BooleanValue RABBIT_STEW_JUMP_BOOST;
@@ -37,12 +37,12 @@ public class Configuration
 	public static ForgeConfigSpec.IntValue CHANCE_WILD_TOMATOES;
 	public static ForgeConfigSpec.BooleanValue GENERATE_WILD_RICE;
 	public static ForgeConfigSpec.IntValue CHANCE_WILD_RICE;
-	
+
 	// CLIENT
 	public static final String CATEGORY_CLIENT = "client";
-	
+
 	public static ForgeConfigSpec.BooleanValue NOURISHED_HUNGER_OVERLAY;
-	
+
 	static {
 		ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
 

--- a/src/main/java/vectorwing/farmersdelight/setup/LootModifierHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/LootModifierHandler.java
@@ -9,7 +9,8 @@ import vectorwing.farmersdelight.loot.modifiers.CakeSliceLoot;
 import vectorwing.farmersdelight.loot.modifiers.StrawHarvestingModifier;
 
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
-public class LootModifierHandler {
+public class LootModifierHandler
+{
 	@SubscribeEvent
 	public static void registerModifiers(RegistryEvent.Register<GlobalLootModifierSerializer<?>> ev) {
 		ev.getRegistry().register(

--- a/src/main/java/vectorwing/farmersdelight/setup/RemappingHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/RemappingHandler.java
@@ -24,8 +24,8 @@ import vectorwing.farmersdelight.registry.ModItems;
  * Hopefully they work fine form the majority of cases. Always make backups!
  */
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID)
-public class RemappingHandler {
-
+public class RemappingHandler
+{
 	private static final Logger LOGGER = LogManager.getLogger();
 
 	// OLD NAMES
@@ -69,5 +69,4 @@ public class RemappingHandler {
 			}
 		}
 	}
-
 }

--- a/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
@@ -51,9 +51,6 @@ public class BasketTileEntity extends LockableLootTileEntity implements IBasket,
 	}
 
 	public static boolean pullItems(IBasket basket, int facingIndex) {
-		//Boolean ret = net.minecraftforge.items.VanillaInventoryCodeHooks.extractHook(basket);
-		//if (ret != null) return ret;
-
 		for (ItemEntity itementity : getCaptureItems(basket, facingIndex)) {
 			if (captureItem(basket, itementity)) {
 				return true;

--- a/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
@@ -143,6 +143,7 @@ public class BasketTileEntity extends LockableLootTileEntity implements IBasket,
 		return basket.getWorld() == null ? new ArrayList<>() : basket.getFacingCollectionArea(facingIndex).toBoundingBoxList().stream().flatMap((p_200110_1_) -> basket.getWorld().getEntitiesWithinAABB(ItemEntity.class, p_200110_1_.offset(basket.getXPos() - 0.5D, basket.getYPos() - 0.5D, basket.getZPos() - 0.5D), EntityPredicates.IS_ALIVE).stream()).collect(Collectors.toList());
 	}
 
+	@Override
 	public CompoundNBT write(CompoundNBT compound) {
 		super.write(compound);
 		if (!this.checkLootAndWrite(compound)) {
@@ -189,11 +190,13 @@ public class BasketTileEntity extends LockableLootTileEntity implements IBasket,
 		return ChestContainer.createGeneric9X3(id, player, this);
 	}
 
+	@Override
 	public ItemStack decrStackSize(int index, int count) {
 		this.fillWithLoot(null);
 		return ItemStackHelper.getAndSplit(this.getItems(), index, count);
 	}
 
+	@Override
 	public void setInventorySlotContents(int index, ItemStack stack) {
 		this.fillWithLoot(null);
 		this.getItems().set(index, stack);

--- a/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/BasketTileEntity.java
@@ -37,248 +37,249 @@ import java.util.stream.Collectors;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 @SuppressWarnings("deprecation")
-public class BasketTileEntity extends LockableLootTileEntity implements IBasket, ITickableTileEntity {
-    private NonNullList<ItemStack> basketContents = NonNullList.withSize(27, ItemStack.EMPTY);
-    private int transferCooldown = -1;
+public class BasketTileEntity extends LockableLootTileEntity implements IBasket, ITickableTileEntity
+{
+	private NonNullList<ItemStack> basketContents = NonNullList.withSize(27, ItemStack.EMPTY);
+	private int transferCooldown = -1;
 
-    protected BasketTileEntity(TileEntityType<?> typeIn) {
-        super(typeIn);
-    }
+	protected BasketTileEntity(TileEntityType<?> typeIn) {
+		super(typeIn);
+	}
 
-    public BasketTileEntity() {
-        this(ModTileEntityTypes.BASKET_TILE.get());
-    }
+	public BasketTileEntity() {
+		this(ModTileEntityTypes.BASKET_TILE.get());
+	}
 
-    public static boolean pullItems(IBasket basket, int facingIndex) {
-        //Boolean ret = net.minecraftforge.items.VanillaInventoryCodeHooks.extractHook(basket);
-        //if (ret != null) return ret;
+	public static boolean pullItems(IBasket basket, int facingIndex) {
+		//Boolean ret = net.minecraftforge.items.VanillaInventoryCodeHooks.extractHook(basket);
+		//if (ret != null) return ret;
 
-        for (ItemEntity itementity : getCaptureItems(basket, facingIndex)) {
-            if (captureItem(basket, itementity)) {
-                return true;
-            }
-        }
+		for (ItemEntity itementity : getCaptureItems(basket, facingIndex)) {
+			if (captureItem(basket, itementity)) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    public static ItemStack putStackInInventoryAllSlots(IInventory destination, ItemStack stack) {
-        int i = destination.getSizeInventory();
+	public static ItemStack putStackInInventoryAllSlots(IInventory destination, ItemStack stack) {
+		int i = destination.getSizeInventory();
 
-        for (int j = 0; j < i && !stack.isEmpty(); ++j) {
-            stack = insertStack(destination, stack, j);
-        }
+		for (int j = 0; j < i && !stack.isEmpty(); ++j) {
+			stack = insertStack(destination, stack, j);
+		}
 
-        return stack;
-    }
+		return stack;
+	}
 
-    private static boolean canInsertItemInSlot(IInventory inventoryIn, ItemStack stack, int index, @Nullable Direction side) {
-        if (!inventoryIn.isItemValidForSlot(index, stack)) {
-            return false;
-        } else {
-            return !(inventoryIn instanceof ISidedInventory) || ((ISidedInventory) inventoryIn).canInsertItem(index, stack, side);
-        }
-    }
+	private static boolean canInsertItemInSlot(IInventory inventoryIn, ItemStack stack, int index, @Nullable Direction side) {
+		if (!inventoryIn.isItemValidForSlot(index, stack)) {
+			return false;
+		} else {
+			return !(inventoryIn instanceof ISidedInventory) || ((ISidedInventory) inventoryIn).canInsertItem(index, stack, side);
+		}
+	}
 
-    private static boolean canCombine(ItemStack stack1, ItemStack stack2) {
-        if (stack1.getItem() != stack2.getItem()) {
-            return false;
-        } else if (stack1.getDamage() != stack2.getDamage()) {
-            return false;
-        } else if (stack1.getCount() > stack1.getMaxStackSize()) {
-            return false;
-        } else {
-            return ItemStack.areItemStackTagsEqual(stack1, stack2);
-        }
-    }
+	private static boolean canCombine(ItemStack stack1, ItemStack stack2) {
+		if (stack1.getItem() != stack2.getItem()) {
+			return false;
+		} else if (stack1.getDamage() != stack2.getDamage()) {
+			return false;
+		} else if (stack1.getCount() > stack1.getMaxStackSize()) {
+			return false;
+		} else {
+			return ItemStack.areItemStackTagsEqual(stack1, stack2);
+		}
+	}
 
-    private static ItemStack insertStack(IInventory destination, ItemStack stack, int index) {
-        ItemStack itemstack = destination.getStackInSlot(index);
-        if (canInsertItemInSlot(destination, stack, index, null)) {
-            boolean flag = false;
-            boolean isDestinationEmpty = destination.isEmpty();
-            if (itemstack.isEmpty()) {
-                destination.setInventorySlotContents(index, stack);
-                stack = ItemStack.EMPTY;
-                flag = true;
-            } else if (canCombine(itemstack, stack)) {
-                int i = stack.getMaxStackSize() - itemstack.getCount();
-                int j = Math.min(stack.getCount(), i);
-                stack.shrink(j);
-                itemstack.grow(j);
-                flag = j > 0;
-            }
+	private static ItemStack insertStack(IInventory destination, ItemStack stack, int index) {
+		ItemStack itemstack = destination.getStackInSlot(index);
+		if (canInsertItemInSlot(destination, stack, index, null)) {
+			boolean flag = false;
+			boolean isDestinationEmpty = destination.isEmpty();
+			if (itemstack.isEmpty()) {
+				destination.setInventorySlotContents(index, stack);
+				stack = ItemStack.EMPTY;
+				flag = true;
+			} else if (canCombine(itemstack, stack)) {
+				int i = stack.getMaxStackSize() - itemstack.getCount();
+				int j = Math.min(stack.getCount(), i);
+				stack.shrink(j);
+				itemstack.grow(j);
+				flag = j > 0;
+			}
 
-            if (flag) {
-                if (isDestinationEmpty && destination instanceof BasketTileEntity) {
-                    BasketTileEntity firstBasket = (BasketTileEntity) destination;
-                    if (!firstBasket.mayTransfer()) {
-                        int k = 0;
+			if (flag) {
+				if (isDestinationEmpty && destination instanceof BasketTileEntity) {
+					BasketTileEntity firstBasket = (BasketTileEntity) destination;
+					if (!firstBasket.mayTransfer()) {
+						int k = 0;
 
-                        firstBasket.setTransferCooldown(8 - k);
-                    }
-                }
+						firstBasket.setTransferCooldown(8 - k);
+					}
+				}
 
-                destination.markDirty();
-            }
-        }
+				destination.markDirty();
+			}
+		}
 
-        return stack;
-    }
+		return stack;
+	}
 
-    public static boolean captureItem(IInventory inventory, ItemEntity itemEntity) {
-        boolean flag = false;
-        ItemStack itemstack = itemEntity.getItem().copy();
-        ItemStack itemstack1 = putStackInInventoryAllSlots(inventory, itemstack);
-        if (itemstack1.isEmpty()) {
-            flag = true;
-            itemEntity.remove();
-        } else {
-            itemEntity.setItem(itemstack1);
-        }
+	public static boolean captureItem(IInventory inventory, ItemEntity itemEntity) {
+		boolean flag = false;
+		ItemStack itemstack = itemEntity.getItem().copy();
+		ItemStack itemstack1 = putStackInInventoryAllSlots(inventory, itemstack);
+		if (itemstack1.isEmpty()) {
+			flag = true;
+			itemEntity.remove();
+		} else {
+			itemEntity.setItem(itemstack1);
+		}
 
-        return flag;
-    }
+		return flag;
+	}
 
-    public static List<ItemEntity> getCaptureItems(IBasket basket, int facingIndex) {
+	public static List<ItemEntity> getCaptureItems(IBasket basket, int facingIndex) {
 
-        return basket.getWorld() == null ? new ArrayList<>() : basket.getFacingCollectionArea(facingIndex).toBoundingBoxList().stream().flatMap((p_200110_1_) -> basket.getWorld().getEntitiesWithinAABB(ItemEntity.class, p_200110_1_.offset(basket.getXPos() - 0.5D, basket.getYPos() - 0.5D, basket.getZPos() - 0.5D), EntityPredicates.IS_ALIVE).stream()).collect(Collectors.toList());
-    }
+		return basket.getWorld() == null ? new ArrayList<>() : basket.getFacingCollectionArea(facingIndex).toBoundingBoxList().stream().flatMap((p_200110_1_) -> basket.getWorld().getEntitiesWithinAABB(ItemEntity.class, p_200110_1_.offset(basket.getXPos() - 0.5D, basket.getYPos() - 0.5D, basket.getZPos() - 0.5D), EntityPredicates.IS_ALIVE).stream()).collect(Collectors.toList());
+	}
 
-    public CompoundNBT write(CompoundNBT compound) {
-        super.write(compound);
-        if (!this.checkLootAndWrite(compound)) {
-            ItemStackHelper.saveAllItems(compound, this.basketContents);
-        }
+	public CompoundNBT write(CompoundNBT compound) {
+		super.write(compound);
+		if (!this.checkLootAndWrite(compound)) {
+			ItemStackHelper.saveAllItems(compound, this.basketContents);
+		}
 
-        compound.putInt("TransferCooldown", this.transferCooldown);
-        return compound;
-    }
+		compound.putInt("TransferCooldown", this.transferCooldown);
+		return compound;
+	}
 
-    @Override
-    public void read(BlockState state, CompoundNBT compound) {
-        super.read(state, compound);
-        this.basketContents = NonNullList.withSize(this.getSizeInventory(), ItemStack.EMPTY);
-        if (!this.checkLootAndRead(compound)) {
-            ItemStackHelper.loadAllItems(compound, this.basketContents);
-        }
-        this.transferCooldown = compound.getInt("TransferCooldown");
-    }
+	@Override
+	public void read(BlockState state, CompoundNBT compound) {
+		super.read(state, compound);
+		this.basketContents = NonNullList.withSize(this.getSizeInventory(), ItemStack.EMPTY);
+		if (!this.checkLootAndRead(compound)) {
+			ItemStackHelper.loadAllItems(compound, this.basketContents);
+		}
+		this.transferCooldown = compound.getInt("TransferCooldown");
+	}
 
-    // -- STANDARD INVENTORY STUFF --
-    @Override
-    protected NonNullList<ItemStack> getItems() {
-        return this.basketContents;
-    }
+	// -- STANDARD INVENTORY STUFF --
+	@Override
+	protected NonNullList<ItemStack> getItems() {
+		return this.basketContents;
+	}
 
-    @Override
-    protected void setItems(NonNullList<ItemStack> itemsIn) {
-        this.basketContents = itemsIn;
-    }
+	@Override
+	protected void setItems(NonNullList<ItemStack> itemsIn) {
+		this.basketContents = itemsIn;
+	}
 
-    @Override
-    public int getSizeInventory() {
-        return this.basketContents.size();
-    }
+	@Override
+	public int getSizeInventory() {
+		return this.basketContents.size();
+	}
 
-    @Override
-    protected ITextComponent getDefaultName() {
-        return TextUtils.getTranslation("container.basket");
-    }
+	@Override
+	protected ITextComponent getDefaultName() {
+		return TextUtils.getTranslation("container.basket");
+	}
 
-    @Override
-    protected Container createMenu(int id, PlayerInventory player) {
-        return ChestContainer.createGeneric9X3(id, player, this);
-    }
+	@Override
+	protected Container createMenu(int id, PlayerInventory player) {
+		return ChestContainer.createGeneric9X3(id, player, this);
+	}
 
-    public ItemStack decrStackSize(int index, int count) {
-        this.fillWithLoot(null);
-        return ItemStackHelper.getAndSplit(this.getItems(), index, count);
-    }
+	public ItemStack decrStackSize(int index, int count) {
+		this.fillWithLoot(null);
+		return ItemStackHelper.getAndSplit(this.getItems(), index, count);
+	}
 
-    public void setInventorySlotContents(int index, ItemStack stack) {
-        this.fillWithLoot(null);
-        this.getItems().set(index, stack);
-        if (stack.getCount() > this.getInventoryStackLimit()) {
-            stack.setCount(this.getInventoryStackLimit());
-        }
-    }
+	public void setInventorySlotContents(int index, ItemStack stack) {
+		this.fillWithLoot(null);
+		this.getItems().set(index, stack);
+		if (stack.getCount() > this.getInventoryStackLimit()) {
+			stack.setCount(this.getInventoryStackLimit());
+		}
+	}
 
-    public void setTransferCooldown(int ticks) {
-        this.transferCooldown = ticks;
-    }
+	public void setTransferCooldown(int ticks) {
+		this.transferCooldown = ticks;
+	}
 
-    private boolean isOnTransferCooldown() {
-        return this.transferCooldown > 0;
-    }
+	private boolean isOnTransferCooldown() {
+		return this.transferCooldown > 0;
+	}
 
-    public boolean mayTransfer() {
-        return this.transferCooldown > 8;
-    }
+	public boolean mayTransfer() {
+		return this.transferCooldown > 8;
+	}
 
-    private boolean updateHopper(Supplier<Boolean> supplier) {
-        if (this.world != null && !this.world.isRemote) {
-            if (!this.isOnTransferCooldown() && this.getBlockState().get(BlockStateProperties.ENABLED)) {
-                boolean flag = false;
-                if (!this.isFull()) {
-                    flag = supplier.get();
-                }
+	private boolean updateHopper(Supplier<Boolean> supplier) {
+		if (this.world != null && !this.world.isRemote) {
+			if (!this.isOnTransferCooldown() && this.getBlockState().get(BlockStateProperties.ENABLED)) {
+				boolean flag = false;
+				if (!this.isFull()) {
+					flag = supplier.get();
+				}
 
-                if (flag) {
-                    this.setTransferCooldown(8);
-                    this.markDirty();
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+				if (flag) {
+					this.setTransferCooldown(8);
+					this.markDirty();
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
-    private boolean isFull() {
-        for (ItemStack itemstack : this.basketContents) {
-            if (itemstack.isEmpty() || itemstack.getCount() != itemstack.getMaxStackSize()) {
-                return false;
-            }
-        }
+	private boolean isFull() {
+		for (ItemStack itemstack : this.basketContents) {
+			if (itemstack.isEmpty() || itemstack.getCount() != itemstack.getMaxStackSize()) {
+				return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public void onEntityCollision(Entity entity) {
-        if (entity instanceof ItemEntity) {
-            BlockPos blockpos = this.getPos();
-            int facing = this.getBlockState().get(BasketBlock.FACING).getIndex();
-            if (VoxelShapes.compare(VoxelShapes.create(entity.getBoundingBox().offset(-blockpos.getX(), -blockpos.getY(), -blockpos.getZ())), this.getFacingCollectionArea(facing), IBooleanFunction.AND)) {
-                this.updateHopper(() -> captureItem(this, (ItemEntity) entity));
-            }
-        }
-    }
+	public void onEntityCollision(Entity entity) {
+		if (entity instanceof ItemEntity) {
+			BlockPos blockpos = this.getPos();
+			int facing = this.getBlockState().get(BasketBlock.FACING).getIndex();
+			if (VoxelShapes.compare(VoxelShapes.create(entity.getBoundingBox().offset(-blockpos.getX(), -blockpos.getY(), -blockpos.getZ())), this.getFacingCollectionArea(facing), IBooleanFunction.AND)) {
+				this.updateHopper(() -> captureItem(this, (ItemEntity) entity));
+			}
+		}
+	}
 
-    @Override
-    public double getXPos() {
-        return (double) this.pos.getX() + 0.5D;
-    }
+	@Override
+	public double getXPos() {
+		return (double) this.pos.getX() + 0.5D;
+	}
 
-    @Override
-    public double getYPos() {
-        return (double) this.pos.getY() + 0.5D;
-    }
+	@Override
+	public double getYPos() {
+		return (double) this.pos.getY() + 0.5D;
+	}
 
-    @Override
-    public double getZPos() {
-        return (double) this.pos.getZ() + 0.5D;
-    }
+	@Override
+	public double getZPos() {
+		return (double) this.pos.getZ() + 0.5D;
+	}
 
-    @Override
-    public void tick() {
-        if (this.world != null && !this.world.isRemote) {
-            --this.transferCooldown;
-            long tickedGameTime = this.world.getGameTime();
-            if (!this.isOnTransferCooldown()) {
-                this.setTransferCooldown(0);
-                int facing = this.getBlockState().get(BasketBlock.FACING).getIndex();
-                this.updateHopper(() -> pullItems(this, facing));
-            }
-        }
-    }
+	@Override
+	public void tick() {
+		if (this.world != null && !this.world.isRemote) {
+			--this.transferCooldown;
+			long tickedGameTime = this.world.getGameTime();
+			if (!this.isOnTransferCooldown()) {
+				this.setTransferCooldown(0);
+				int facing = this.getBlockState().get(BasketBlock.FACING).getIndex();
+				this.updateHopper(() -> pullItems(this, facing));
+			}
+		}
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
@@ -47,7 +47,8 @@ import java.util.Random;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class CookingPotTileEntity extends TileEntity implements INamedContainerProvider, ITickableTileEntity, INameable {
+public class CookingPotTileEntity extends TileEntity implements INamedContainerProvider, ITickableTileEntity, INameable
+{
 	public static final int MEAL_DISPLAY = 6;
 	public static final int CONTAINER_INPUT = 7;
 	public static final int FINAL_OUTPUT = 8;
@@ -62,7 +63,8 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	private int cookTime;
 	private int cookTimeTotal;
 	private ItemStack container;
-	protected final IIntArray cookingPotData = new IIntArray() {
+	protected final IIntArray cookingPotData = new IIntArray()
+	{
 		public int get(int index) {
 			switch (index) {
 				case 0:
@@ -194,12 +196,10 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 						this.cook(irecipe);
 						dirty = true;
 					}
-				}
-				else {
+				} else {
 					this.cookTime = 0;
 				}
-			}
-			else if (this.cookTime > 0) {
+			} else if (this.cookTime > 0) {
 				this.cookTime = MathHelper.clamp(this.cookTime - 2, 0, this.cookTimeTotal);
 			}
 
@@ -208,15 +208,13 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 				if (!this.doesMealHaveContainer(meal)) {
 					this.moveMealToOutput();
 					dirty = true;
-				}
-				else if (!itemHandler.getStackInSlot(CONTAINER_INPUT).isEmpty()) {
+				} else if (!itemHandler.getStackInSlot(CONTAINER_INPUT).isEmpty()) {
 					this.useStoredContainersOnMeal();
 					dirty = true;
 				}
 			}
 
-		}
-		else {
+		} else {
 			if (isHeated) {
 				this.animate();
 			}
@@ -238,8 +236,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	public ItemStack getContainer() {
 		if (!this.container.isEmpty()) {
 			return this.container;
-		}
-		else {
+		} else {
 			return this.getMeal().getContainerItem();
 		}
 	}
@@ -256,24 +253,19 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			ItemStack recipeOutput = recipeIn.getRecipeOutput();
 			if (recipeOutput.isEmpty()) {
 				return false;
-			}
-			else {
+			} else {
 				ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY);
 				if (currentOutput.isEmpty()) {
 					return true;
-				}
-				else if (!currentOutput.isItemEqual(recipeOutput)) {
+				} else if (!currentOutput.isItemEqual(recipeOutput)) {
 					return false;
-				}
-				else if (currentOutput.getCount() + recipeOutput.getCount() <= itemHandler.getSlotLimit(MEAL_DISPLAY)) {
+				} else if (currentOutput.getCount() + recipeOutput.getCount() <= itemHandler.getSlotLimit(MEAL_DISPLAY)) {
 					return true;
-				}
-				else {
+				} else {
 					return currentOutput.getCount() + recipeOutput.getCount() <= recipeOutput.getMaxStackSize();
 				}
 			}
-		}
-		else {
+		} else {
 			return false;
 		}
 	}
@@ -285,8 +277,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY);
 			if (currentOutput.isEmpty()) {
 				itemHandler.setStackInSlot(MEAL_DISPLAY, recipeOutput.copy());
-			}
-			else if (currentOutput.getItem() == recipeOutput.getItem()) {
+			} else if (currentOutput.getItem() == recipeOutput.getItem()) {
 				currentOutput.grow(recipeOutput.getCount());
 			}
 		}
@@ -368,8 +359,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		int mealCount = Math.min(mealDisplay.getCount(), mealDisplay.getMaxStackSize() - finalOutput.getCount());
 		if (finalOutput.isEmpty()) {
 			itemHandler.setStackInSlot(FINAL_OUTPUT, mealDisplay.split(mealCount));
-		}
-		else if (finalOutput.getItem() == mealDisplay.getItem()) {
+		} else if (finalOutput.getItem() == mealDisplay.getItem()) {
 			mealDisplay.shrink(mealCount);
 			finalOutput.grow(mealCount);
 		}
@@ -390,8 +380,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			if (finalOutput.isEmpty()) {
 				containerInput.shrink(mealCount);
 				itemHandler.setStackInSlot(FINAL_OUTPUT, mealDisplay.split(mealCount));
-			}
-			else if (finalOutput.getItem() == mealDisplay.getItem()) {
+			} else if (finalOutput.getItem() == mealDisplay.getItem()) {
 				mealDisplay.shrink(mealCount);
 				containerInput.shrink(mealCount);
 				finalOutput.grow(mealCount);
@@ -418,8 +407,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		if (containerItem.isEmpty()) return false;
 		if (!this.container.isEmpty()) {
 			return this.container.isItemEqual(containerItem);
-		}
-		else {
+		} else {
 			return this.getMeal().getContainerItem().isItemEqual(containerItem);
 		}
 	}
@@ -459,7 +447,8 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	// ======== CAPABILITIES ========
 
 	private ItemStackHandler createHandler() {
-		return new ItemStackHandler(INVENTORY_SIZE) {
+		return new ItemStackHandler(INVENTORY_SIZE)
+		{
 			@Override
 			protected void onContentsChanged(int slot) {
 				if (slot >= 0 && slot < MEAL_DISPLAY) {
@@ -475,8 +464,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		if (cap.equals(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)) {
 			if (side == null || side.equals(Direction.UP)) {
 				return handlerInput.cast();
-			}
-			else {
+			} else {
 				return handlerOutput.cast();
 			}
 		}

--- a/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
@@ -65,6 +65,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	private ItemStack container;
 	protected final IIntArray cookingPotData = new IIntArray()
 	{
+		@Override
 		public int get(int index) {
 			switch (index) {
 				case 0:
@@ -76,6 +77,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			}
 		}
 
+		@Override
 		public void set(int index, int value) {
 			switch (index) {
 				case 0:
@@ -87,6 +89,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			}
 		}
 
+		@Override
 		public int size() {
 			return 2;
 		}
@@ -106,11 +109,13 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 
 	// ======== NBT & NETWORKING ========
 
+	@Override
 	@Nullable
 	public SUpdateTileEntityPacket getUpdatePacket() {
 		return new SUpdateTileEntityPacket(this.pos, 1, this.getUpdateTag());
 	}
 
+	@Override
 	public CompoundNBT getUpdateTag() {
 		return this.writeItems(new CompoundNBT());
 	}
@@ -434,6 +439,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		return this.getName();
 	}
 
+	@Override
 	@Nullable
 	public ITextComponent getCustomName() {
 		return this.customName;

--- a/src/main/java/vectorwing/farmersdelight/tile/CuttingBoardTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/CuttingBoardTileEntity.java
@@ -35,7 +35,8 @@ import vectorwing.farmersdelight.registry.ModTileEntityTypes;
 
 import javax.annotation.Nullable;
 
-public class CuttingBoardTileEntity extends TileEntity {
+public class CuttingBoardTileEntity extends TileEntity
+{
 	private boolean isItemCarvingBoard;
 	private ItemStackHandler itemHandler = createHandler();
 	private LazyOptional<IItemHandler> handlerBoard = LazyOptional.of(() -> itemHandler);
@@ -114,8 +115,7 @@ public class CuttingBoardTileEntity extends TileEntity {
 				tool.damageItem(1, player, (user) -> {
 					user.sendBreakAnimation(EquipmentSlotType.MAINHAND);
 				});
-			}
-			else {
+			} else {
 				if (tool.attemptDamageItem(1, world.rand, (ServerPlayerEntity) null)) {
 					tool.setCount(0);
 				}
@@ -141,19 +141,15 @@ public class CuttingBoardTileEntity extends TileEntity {
 
 		if (sound != null) {
 			this.playSound(sound, 1.0F, 1.0F);
-		}
-		else if (tool instanceof ShearsItem) {
+		} else if (tool instanceof ShearsItem) {
 			this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1.0F, 1.0F);
-		}
-		else if (tool instanceof KnifeItem) {
+		} else if (tool instanceof KnifeItem) {
 			this.playSound(ModSounds.BLOCK_CUTTING_BOARD_KNIFE.get(), 0.8F, 1.0F);
-		}
-		else if (boardItem instanceof BlockItem) {
+		} else if (boardItem instanceof BlockItem) {
 			Block block = ((BlockItem) boardItem).getBlock();
 			SoundType soundType = block.getSoundType(block.getDefaultState());
 			this.playSound(soundType.getBreakSound(), 1.0F, 0.8F);
-		}
-		else {
+		} else {
 			this.playSound(SoundEvents.BLOCK_WOOD_BREAK, 1.0F, 0.8F);
 		}
 	}
@@ -214,7 +210,8 @@ public class CuttingBoardTileEntity extends TileEntity {
 	}
 
 	private ItemStackHandler createHandler() {
-		return new ItemStackHandler() {
+		return new ItemStackHandler()
+		{
 			@Override
 			public int getSlotLimit(int slot) {
 				return 1;

--- a/src/main/java/vectorwing/farmersdelight/tile/CuttingBoardTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/CuttingBoardTileEntity.java
@@ -67,19 +67,16 @@ public class CuttingBoardTileEntity extends TileEntity
 		return compound;
 	}
 
+	@Override
 	@Nullable
 	public SUpdateTileEntityPacket getUpdatePacket() {
 		return new SUpdateTileEntityPacket(this.pos, 1, this.getUpdateTag());
 	}
 
+	@Override
 	public CompoundNBT getUpdateTag() {
 		return this.write(new CompoundNBT());
 	}
-
-//	@Override
-//	public void handleUpdateTag(CompoundNBT tag) {
-//		this.read(tag);
-//	}
 
 	@Override
 	public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket pkt) {

--- a/src/main/java/vectorwing/farmersdelight/tile/IBasket.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/IBasket.java
@@ -7,7 +7,8 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 
-public interface IBasket extends IHopper {
+public interface IBasket extends IHopper
+{
 	VoxelShape[] COLLECTION_AREA_SHAPES = {
 			Block.makeCuboidShape(0.0D, -16.0D, 0.0D, 16.0D, 16.0D, 16.0D),    // down
 			Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 32.0D, 16.0D),        // up

--- a/src/main/java/vectorwing/farmersdelight/tile/PantryTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/PantryTileEntity.java
@@ -34,6 +34,7 @@ public class PantryTileEntity extends LockableLootTileEntity
 		this(ModTileEntityTypes.PANTRY_TILE.get());
 	}
 
+	@Override
 	public CompoundNBT write(CompoundNBT compound) {
 		super.write(compound);
 		if (!this.checkLootAndWrite(compound)) {
@@ -43,6 +44,7 @@ public class PantryTileEntity extends LockableLootTileEntity
 		return compound;
 	}
 
+	@Override
 	public void read(BlockState state, CompoundNBT compound) {
 		super.read(state, compound);
 		this.pantryContents = NonNullList.withSize(this.getSizeInventory(), ItemStack.EMPTY);
@@ -55,26 +57,32 @@ public class PantryTileEntity extends LockableLootTileEntity
 	/**
 	 * Returns the number of slots in the inventory.
 	 */
+	@Override
 	public int getSizeInventory() {
 		return 27;
 	}
 
+	@Override
 	protected NonNullList<ItemStack> getItems() {
 		return this.pantryContents;
 	}
 
+	@Override
 	protected void setItems(NonNullList<ItemStack> itemsIn) {
 		this.pantryContents = itemsIn;
 	}
 
+	@Override
 	protected ITextComponent getDefaultName() {
 		return TextUtils.getTranslation("container.pantry");
 	}
 
+	@Override
 	protected Container createMenu(int id, PlayerInventory player) {
 		return ChestContainer.createGeneric9X3(id, player, this);
 	}
 
+	@Override
 	public void openInventory(PlayerEntity player) {
 		if (!player.isSpectator()) {
 			if (this.numPlayersUsing < 0) {
@@ -121,6 +129,7 @@ public class PantryTileEntity extends LockableLootTileEntity
 
 	}
 
+	@Override
 	public void closeInventory(PlayerEntity player) {
 		if (!player.isSpectator()) {
 			--this.numPlayersUsing;

--- a/src/main/java/vectorwing/farmersdelight/tile/PantryTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/PantryTileEntity.java
@@ -21,7 +21,8 @@ import vectorwing.farmersdelight.blocks.PantryBlock;
 import vectorwing.farmersdelight.registry.ModTileEntityTypes;
 import vectorwing.farmersdelight.utils.TextUtils;
 
-public class PantryTileEntity extends LockableLootTileEntity {
+public class PantryTileEntity extends LockableLootTileEntity
+{
 	private NonNullList<ItemStack> pantryContents = NonNullList.withSize(27, ItemStack.EMPTY);
 	private int numPlayersUsing;
 
@@ -104,8 +105,7 @@ public class PantryTileEntity extends LockableLootTileEntity {
 		this.numPlayersUsing = ChestTileEntity.calculatePlayersUsing(this.world, this, i, j, k);
 		if (this.numPlayersUsing > 0) {
 			this.scheduleTick();
-		}
-		else {
+		} else {
 			BlockState blockstate = this.getBlockState();
 			if (!(blockstate.getBlock() instanceof PantryBlock)) {
 				this.remove();

--- a/src/main/java/vectorwing/farmersdelight/tile/StoveTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/StoveTileEntity.java
@@ -174,6 +174,7 @@ public class StoveTileEntity extends TileEntity implements IClearable, ITickable
 
 	}
 
+	@Override
 	public CompoundNBT write(CompoundNBT compound) {
 		this.writeItems(compound);
 		compound.putIntArray("CookingTimes", this.cookingTimes);
@@ -187,11 +188,13 @@ public class StoveTileEntity extends TileEntity implements IClearable, ITickable
 		return compound;
 	}
 
+	@Override
 	@Nullable
 	public SUpdateTileEntityPacket getUpdatePacket() {
 		return new SUpdateTileEntityPacket(this.pos, 1, this.getUpdateTag());
 	}
 
+	@Override
 	public CompoundNBT getUpdateTag() {
 		return this.writeItems(new CompoundNBT());
 	}
@@ -231,6 +234,7 @@ public class StoveTileEntity extends TileEntity implements IClearable, ITickable
 			this.world.notifyBlockUpdate(this.getPos(), this.getBlockState(), this.getBlockState(), Constants.BlockFlags.BLOCK_UPDATE);
 	}
 
+	@Override
 	public void clear() {
 		this.inventory.clear();
 	}

--- a/src/main/java/vectorwing/farmersdelight/tile/StoveTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/StoveTileEntity.java
@@ -3,11 +3,6 @@ package vectorwing.farmersdelight.tile;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.util.math.shapes.IBooleanFunction;
-import net.minecraft.util.math.shapes.VoxelShape;
-import net.minecraft.util.math.shapes.VoxelShapes;
-import vectorwing.farmersdelight.blocks.StoveBlock;
-import vectorwing.farmersdelight.registry.ModTileEntityTypes;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.inventory.*;
 import net.minecraft.item.ItemStack;
@@ -24,9 +19,14 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.shapes.IBooleanFunction;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.util.math.vector.Vector2f;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
+import vectorwing.farmersdelight.blocks.StoveBlock;
+import vectorwing.farmersdelight.registry.ModTileEntityTypes;
 import vectorwing.farmersdelight.utils.MathUtils;
 
 import javax.annotation.Nullable;
@@ -36,201 +36,202 @@ import java.util.Random;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class StoveTileEntity extends TileEntity implements IClearable, ITickableTileEntity {
-    private static final VoxelShape GRILLING_AREA = Block.makeCuboidShape(3.0F, 0.0F, 3.0F, 13.0F, 1.0F, 13.0F);
-    private final int MAX_STACK_SIZE = 6;
-    protected final NonNullList<ItemStack> inventory = NonNullList.withSize(MAX_STACK_SIZE, ItemStack.EMPTY);
-    private final int[] cookingTimes = new int[MAX_STACK_SIZE];
-    private final int[] cookingTotalTimes = new int[MAX_STACK_SIZE];
+public class StoveTileEntity extends TileEntity implements IClearable, ITickableTileEntity
+{
+	private static final VoxelShape GRILLING_AREA = Block.makeCuboidShape(3.0F, 0.0F, 3.0F, 13.0F, 1.0F, 13.0F);
+	private final int MAX_STACK_SIZE = 6;
+	protected final NonNullList<ItemStack> inventory = NonNullList.withSize(MAX_STACK_SIZE, ItemStack.EMPTY);
+	private final int[] cookingTimes = new int[MAX_STACK_SIZE];
+	private final int[] cookingTotalTimes = new int[MAX_STACK_SIZE];
 
-    public StoveTileEntity(TileEntityType<?> tileEntityTypeIn) {
-        super(tileEntityTypeIn);
-    }
+	public StoveTileEntity(TileEntityType<?> tileEntityTypeIn) {
+		super(tileEntityTypeIn);
+	}
 
-    public StoveTileEntity() {
-        this(ModTileEntityTypes.STOVE_TILE.get());
-    }
+	public StoveTileEntity() {
+		this(ModTileEntityTypes.STOVE_TILE.get());
+	}
 
-    @Override
-    public void tick() {
-        boolean isStoveLit = this.getBlockState().get(StoveBlock.LIT);
-        boolean isStoveBlocked = this.isStoveBlockedAbove();
-        if (world != null && this.world.isRemote) {
-            if (isStoveLit) {
-                this.addParticles();
-            }
-        } else {
-            if (world != null && isStoveBlocked) {
-                if (!this.inventory.isEmpty()) {
-                    InventoryHelper.dropItems(world, pos, this.getInventory());
-                    this.inventoryChanged();
-                }
-            }
-            if (isStoveLit && !isStoveBlocked) {
-                this.cookAndDrop();
-            } else {
-                for (int i = 0; i < this.inventory.size(); ++i) {
-                    if (this.cookingTimes[i] > 0) {
-                        this.cookingTimes[i] = MathHelper.clamp(this.cookingTimes[i] - 2, 0, this.cookingTotalTimes[i]);
-                    }
-                }
-            }
-        }
-    }
+	@Override
+	public void tick() {
+		boolean isStoveLit = this.getBlockState().get(StoveBlock.LIT);
+		boolean isStoveBlocked = this.isStoveBlockedAbove();
+		if (world != null && this.world.isRemote) {
+			if (isStoveLit) {
+				this.addParticles();
+			}
+		} else {
+			if (world != null && isStoveBlocked) {
+				if (!this.inventory.isEmpty()) {
+					InventoryHelper.dropItems(world, pos, this.getInventory());
+					this.inventoryChanged();
+				}
+			}
+			if (isStoveLit && !isStoveBlocked) {
+				this.cookAndDrop();
+			} else {
+				for (int i = 0; i < this.inventory.size(); ++i) {
+					if (this.cookingTimes[i] > 0) {
+						this.cookingTimes[i] = MathHelper.clamp(this.cookingTimes[i] - 2, 0, this.cookingTotalTimes[i]);
+					}
+				}
+			}
+		}
+	}
 
-    private void cookAndDrop() {
-        for (int i = 0; i < this.inventory.size(); ++i) {
-            ItemStack itemstack = this.inventory.get(i);
-            if (!itemstack.isEmpty()) {
-                ++this.cookingTimes[i];
-                if (this.cookingTimes[i] >= this.cookingTotalTimes[i]) {
-                    if (world != null) {
-                        IInventory iinventory = new Inventory(itemstack);
-                        ItemStack result = this.world.getRecipeManager().getRecipe(IRecipeType.CAMPFIRE_COOKING, iinventory, this.world).map((recipe) -> recipe.getCraftingResult(iinventory)).orElse(itemstack);
-                        if (!result.isEmpty()) {
-                            ItemEntity entity = new ItemEntity(world, pos.getX() + 0.5, pos.getY() + 1.0, pos.getZ() + 0.5, result.copy());
-                            entity.setMotion(MathUtils.RAND.nextGaussian() * (double) 0.01F, 0.1F, MathUtils.RAND.nextGaussian() * (double) 0.01F);
-                            world.addEntity(entity);
-                        }
-                    }
-                    this.inventory.set(i, ItemStack.EMPTY);
-                    this.inventoryChanged();
-                }
-            }
-        }
-    }
+	private void cookAndDrop() {
+		for (int i = 0; i < this.inventory.size(); ++i) {
+			ItemStack itemstack = this.inventory.get(i);
+			if (!itemstack.isEmpty()) {
+				++this.cookingTimes[i];
+				if (this.cookingTimes[i] >= this.cookingTotalTimes[i]) {
+					if (world != null) {
+						IInventory iinventory = new Inventory(itemstack);
+						ItemStack result = this.world.getRecipeManager().getRecipe(IRecipeType.CAMPFIRE_COOKING, iinventory, this.world).map((recipe) -> recipe.getCraftingResult(iinventory)).orElse(itemstack);
+						if (!result.isEmpty()) {
+							ItemEntity entity = new ItemEntity(world, pos.getX() + 0.5, pos.getY() + 1.0, pos.getZ() + 0.5, result.copy());
+							entity.setMotion(MathUtils.RAND.nextGaussian() * (double) 0.01F, 0.1F, MathUtils.RAND.nextGaussian() * (double) 0.01F);
+							world.addEntity(entity);
+						}
+					}
+					this.inventory.set(i, ItemStack.EMPTY);
+					this.inventoryChanged();
+				}
+			}
+		}
+	}
 
-    public boolean isStoveBlockedAbove() {
-        if (world != null) {
-            BlockState above = world.getBlockState(pos.up());
-            return VoxelShapes.compare(GRILLING_AREA, above.getShape(world, pos.up()), IBooleanFunction.AND);
-        }
-        return false;
-    }
+	public boolean isStoveBlockedAbove() {
+		if (world != null) {
+			BlockState above = world.getBlockState(pos.up());
+			return VoxelShapes.compare(GRILLING_AREA, above.getShape(world, pos.up()), IBooleanFunction.AND);
+		}
+		return false;
+	}
 
-    public Vector2f getStoveItemOffset(int index) {
-        final float X_OFFSET = 0.3F;
-        final float Y_OFFSET = 0.2F;
-        final Vector2f[] OFFSETS = {
-                new Vector2f(X_OFFSET, Y_OFFSET),
-                new Vector2f(0.0F, Y_OFFSET),
-                new Vector2f(-X_OFFSET, Y_OFFSET),
-                new Vector2f(X_OFFSET, -Y_OFFSET),
-                new Vector2f(0.0F, -Y_OFFSET),
-                new Vector2f(-X_OFFSET, -Y_OFFSET),
-        };
-        return OFFSETS[index];
-    }
+	public Vector2f getStoveItemOffset(int index) {
+		final float X_OFFSET = 0.3F;
+		final float Y_OFFSET = 0.2F;
+		final Vector2f[] OFFSETS = {
+				new Vector2f(X_OFFSET, Y_OFFSET),
+				new Vector2f(0.0F, Y_OFFSET),
+				new Vector2f(-X_OFFSET, Y_OFFSET),
+				new Vector2f(X_OFFSET, -Y_OFFSET),
+				new Vector2f(0.0F, -Y_OFFSET),
+				new Vector2f(-X_OFFSET, -Y_OFFSET),
+		};
+		return OFFSETS[index];
+	}
 
-    private void addParticles() {
-        World world = this.getWorld();
-        if (world != null) {
-            BlockPos blockpos = this.getPos();
-            Random random = world.rand;
+	private void addParticles() {
+		World world = this.getWorld();
+		if (world != null) {
+			BlockPos blockpos = this.getPos();
+			Random random = world.rand;
 
-            for (int j = 0; j < this.inventory.size(); ++j) {
-                if (!this.inventory.get(j).isEmpty() && random.nextFloat() < 0.2F) {
-                    double d0 = (double) blockpos.getX() + 0.5D;
-                    double d1 = (double) blockpos.getY() + 1.0D;
-                    double d2 = (double) blockpos.getZ() + 0.5D;
-                    Vector2f v1 = this.getStoveItemOffset(j);
+			for (int j = 0; j < this.inventory.size(); ++j) {
+				if (!this.inventory.get(j).isEmpty() && random.nextFloat() < 0.2F) {
+					double d0 = (double) blockpos.getX() + 0.5D;
+					double d1 = (double) blockpos.getY() + 1.0D;
+					double d2 = (double) blockpos.getZ() + 0.5D;
+					Vector2f v1 = this.getStoveItemOffset(j);
 
-                    Direction direction = this.getBlockState().get(StoveBlock.FACING);
-                    int directionIndex = direction.getHorizontalIndex();
-                    Vector2f offset = directionIndex % 2 == 0 ? v1 : new Vector2f(v1.y, v1.x);
+					Direction direction = this.getBlockState().get(StoveBlock.FACING);
+					int directionIndex = direction.getHorizontalIndex();
+					Vector2f offset = directionIndex % 2 == 0 ? v1 : new Vector2f(v1.y, v1.x);
 
-                    double d5 = d0 - (direction.getXOffset() * offset.x) + (direction.rotateY().getXOffset() * offset.x);
-                    double d7 = d2 - (direction.getZOffset() * offset.y) + (direction.rotateY().getZOffset() * offset.y);
+					double d5 = d0 - (direction.getXOffset() * offset.x) + (direction.rotateY().getXOffset() * offset.x);
+					double d7 = d2 - (direction.getZOffset() * offset.y) + (direction.rotateY().getZOffset() * offset.y);
 
-                    for (int k = 0; k < 3; ++k) {
-                        world.addParticle(ParticleTypes.SMOKE, d5, d1, d7, 0.0D, 5.0E-4D, 0.0D);
-                    }
-                }
-            }
+					for (int k = 0; k < 3; ++k) {
+						world.addParticle(ParticleTypes.SMOKE, d5, d1, d7, 0.0D, 5.0E-4D, 0.0D);
+					}
+				}
+			}
 
-        }
-    }
+		}
+	}
 
-    public NonNullList<ItemStack> getInventory() {
-        return this.inventory;
-    }
+	public NonNullList<ItemStack> getInventory() {
+		return this.inventory;
+	}
 
-    @Override
-    public void read(BlockState state, CompoundNBT compound) {
+	@Override
+	public void read(BlockState state, CompoundNBT compound) {
 
-        super.read(state, compound);
-        this.inventory.clear();
-        ItemStackHelper.loadAllItems(compound, this.inventory);
-        if (compound.contains("CookingTimes", 11)) {
-            int[] aint = compound.getIntArray("CookingTimes");
-            System.arraycopy(aint, 0, this.cookingTimes, 0, Math.min(this.cookingTotalTimes.length, aint.length));
-        }
+		super.read(state, compound);
+		this.inventory.clear();
+		ItemStackHelper.loadAllItems(compound, this.inventory);
+		if (compound.contains("CookingTimes", 11)) {
+			int[] aint = compound.getIntArray("CookingTimes");
+			System.arraycopy(aint, 0, this.cookingTimes, 0, Math.min(this.cookingTotalTimes.length, aint.length));
+		}
 
-        if (compound.contains("CookingTotalTimes", 11)) {
-            int[] aint1 = compound.getIntArray("CookingTotalTimes");
-            System.arraycopy(aint1, 0, this.cookingTotalTimes, 0, Math.min(this.cookingTotalTimes.length, aint1.length));
-        }
+		if (compound.contains("CookingTotalTimes", 11)) {
+			int[] aint1 = compound.getIntArray("CookingTotalTimes");
+			System.arraycopy(aint1, 0, this.cookingTotalTimes, 0, Math.min(this.cookingTotalTimes.length, aint1.length));
+		}
 
-    }
+	}
 
-    public CompoundNBT write(CompoundNBT compound) {
-        this.writeItems(compound);
-        compound.putIntArray("CookingTimes", this.cookingTimes);
-        compound.putIntArray("CookingTotalTimes", this.cookingTotalTimes);
-        return compound;
-    }
+	public CompoundNBT write(CompoundNBT compound) {
+		this.writeItems(compound);
+		compound.putIntArray("CookingTimes", this.cookingTimes);
+		compound.putIntArray("CookingTotalTimes", this.cookingTotalTimes);
+		return compound;
+	}
 
-    private CompoundNBT writeItems(CompoundNBT compound) {
-        super.write(compound);
-        ItemStackHelper.saveAllItems(compound, this.inventory, true);
-        return compound;
-    }
+	private CompoundNBT writeItems(CompoundNBT compound) {
+		super.write(compound);
+		ItemStackHelper.saveAllItems(compound, this.inventory, true);
+		return compound;
+	}
 
-    @Nullable
-    public SUpdateTileEntityPacket getUpdatePacket() {
-        return new SUpdateTileEntityPacket(this.pos, 1, this.getUpdateTag());
-    }
+	@Nullable
+	public SUpdateTileEntityPacket getUpdatePacket() {
+		return new SUpdateTileEntityPacket(this.pos, 1, this.getUpdateTag());
+	}
 
-    public CompoundNBT getUpdateTag() {
-        return this.writeItems(new CompoundNBT());
-    }
+	public CompoundNBT getUpdateTag() {
+		return this.writeItems(new CompoundNBT());
+	}
 
-    @Override
-    public void handleUpdateTag(BlockState state, CompoundNBT tag) {
-        this.read(state, tag);
-    }
+	@Override
+	public void handleUpdateTag(BlockState state, CompoundNBT tag) {
+		this.read(state, tag);
+	}
 
-    @Override
-    public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket pkt) {
-        this.read(this.getBlockState(), pkt.getNbtCompound());
-    }
+	@Override
+	public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket pkt) {
+		this.read(this.getBlockState(), pkt.getNbtCompound());
+	}
 
-    public Optional<CampfireCookingRecipe> findMatchingRecipe(ItemStack itemStackIn) {
-        return world == null || this.inventory.stream().noneMatch(ItemStack::isEmpty) ? Optional.empty() : this.world.getRecipeManager().getRecipe(IRecipeType.CAMPFIRE_COOKING, new Inventory(itemStackIn), this.world);
-    }
+	public Optional<CampfireCookingRecipe> findMatchingRecipe(ItemStack itemStackIn) {
+		return world == null || this.inventory.stream().noneMatch(ItemStack::isEmpty) ? Optional.empty() : this.world.getRecipeManager().getRecipe(IRecipeType.CAMPFIRE_COOKING, new Inventory(itemStackIn), this.world);
+	}
 
-    public boolean addItem(ItemStack itemStackIn, int cookTime) {
-        for (int i = 0; i < this.inventory.size(); ++i) {
-            ItemStack itemstack = this.inventory.get(i);
-            if (itemstack.isEmpty()) {
-                this.cookingTotalTimes[i] = cookTime;
-                this.cookingTimes[i] = 0;
-                this.inventory.set(i, itemStackIn.split(1));
-                this.inventoryChanged();
-                return true;
-            }
-        }
+	public boolean addItem(ItemStack itemStackIn, int cookTime) {
+		for (int i = 0; i < this.inventory.size(); ++i) {
+			ItemStack itemstack = this.inventory.get(i);
+			if (itemstack.isEmpty()) {
+				this.cookingTotalTimes[i] = cookTime;
+				this.cookingTimes[i] = 0;
+				this.inventory.set(i, itemStackIn.split(1));
+				this.inventoryChanged();
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private void inventoryChanged() {
-        super.markDirty();
-        if (world != null)
-            this.world.notifyBlockUpdate(this.getPos(), this.getBlockState(), this.getBlockState(), Constants.BlockFlags.BLOCK_UPDATE);
-    }
+	private void inventoryChanged() {
+		super.markDirty();
+		if (world != null)
+			this.world.notifyBlockUpdate(this.getPos(), this.getBlockState(), this.getBlockState(), Constants.BlockFlags.BLOCK_UPDATE);
+	}
 
-    public void clear() {
-        this.inventory.clear();
-    }
+	public void clear() {
+		this.inventory.clear();
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotContainer.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotContainer.java
@@ -60,7 +60,8 @@ public class CookingPotContainer extends Container
 		this.addSlot(new CookingPotMealSlot(inventoryHandler, 6, 124, 26));
 
 		// Bowl Input
-		this.addSlot(new SlotItemHandler(inventoryHandler, 7, 92, 55) {
+		this.addSlot(new SlotItemHandler(inventoryHandler, 7, 92, 55)
+		{
 			@OnlyIn(Dist.CLIENT)
 			public Pair<ResourceLocation, ResourceLocation> getBackground() {
 				return Pair.of(PlayerContainer.LOCATION_BLOCKS_TEXTURE, EMPTY_CONTAINER_SLOT_BOWL);
@@ -121,23 +122,19 @@ public class CookingPotContainer extends Container
 				if (!this.mergeItemStack(itemstack1, startPlayerInv, endPlayerInv, true)) {
 					return ItemStack.EMPTY;
 				}
-			}
-			else if (index > indexOutput) {
+			} else if (index > indexOutput) {
 				if (itemstack1.getItem() == Items.BOWL && !this.mergeItemStack(itemstack1, indexContainerInput, indexContainerInput + 1, false)) {
 					return ItemStack.EMPTY;
-				}
-				else if (!this.mergeItemStack(itemstack1, 0, indexOutput, false)) {
+				} else if (!this.mergeItemStack(itemstack1, 0, indexOutput, false)) {
 					return ItemStack.EMPTY;
 				}
-			}
-			else if (!this.mergeItemStack(itemstack1, startPlayerInv, endPlayerInv, false)) {
+			} else if (!this.mergeItemStack(itemstack1, startPlayerInv, endPlayerInv, false)) {
 				return ItemStack.EMPTY;
 			}
 
 			if (itemstack1.isEmpty()) {
 				slot.putStack(ItemStack.EMPTY);
-			}
-			else {
+			} else {
 				slot.onSlotChanged();
 			}
 

--- a/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotMealSlot.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotMealSlot.java
@@ -14,10 +14,12 @@ public class CookingPotMealSlot extends SlotItemHandler
 		super(inventoryIn, index, xPosition, yPosition);
 	}
 
+	@Override
 	public boolean isItemValid(ItemStack stack) {
 		return false;
 	}
 
+	@Override
 	public boolean canTakeStack(PlayerEntity playerIn) {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotMealSlot.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotMealSlot.java
@@ -8,7 +8,8 @@ import net.minecraftforge.items.SlotItemHandler;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class CookingPotMealSlot extends SlotItemHandler {
+public class CookingPotMealSlot extends SlotItemHandler
+{
 	public CookingPotMealSlot(IItemHandler inventoryIn, int index, int xPosition, int yPosition) {
 		super(inventoryIn, index, xPosition, yPosition);
 	}

--- a/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotResultSlot.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotResultSlot.java
@@ -13,6 +13,7 @@ public class CookingPotResultSlot extends SlotItemHandler
 		super(inventoryIn, index, xPosition, yPosition);
 	}
 
+	@Override
 	public boolean isItemValid(ItemStack stack) {
 		return false;
 	}

--- a/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotResultSlot.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/container/CookingPotResultSlot.java
@@ -7,7 +7,8 @@ import net.minecraftforge.items.SlotItemHandler;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class CookingPotResultSlot extends SlotItemHandler {
+public class CookingPotResultSlot extends SlotItemHandler
+{
 	public CookingPotResultSlot(IItemHandler inventoryIn, int index, int xPosition, int yPosition) {
 		super(inventoryIn, index, xPosition, yPosition);
 	}

--- a/src/main/java/vectorwing/farmersdelight/tile/dispenser/CuttingBoardDispenseBehavior.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/dispenser/CuttingBoardDispenseBehavior.java
@@ -24,7 +24,8 @@ import java.util.HashMap;
  */
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class CuttingBoardDispenseBehavior extends OptionalDispenseBehavior {
+public class CuttingBoardDispenseBehavior extends OptionalDispenseBehavior
+{
 	private static final DispenserLookup BEHAVIOUR_LOOKUP = new DispenserLookup();
 	private static final HashMap<Item, IDispenseItemBehavior> DISPENSE_ITEM_BEHAVIOR_HASH_MAP = new HashMap<>();
 
@@ -64,7 +65,8 @@ public class CuttingBoardDispenseBehavior extends OptionalDispenseBehavior {
 
 	@ParametersAreNonnullByDefault
 	@MethodsReturnNonnullByDefault
-	private static class DispenserLookup extends DispenserBlock {
+	private static class DispenserLookup extends DispenserBlock
+	{
 		protected DispenserLookup() {
 			super(Block.Properties.from(Blocks.DISPENSER));
 		}

--- a/src/main/java/vectorwing/farmersdelight/tile/dispenser/CuttingBoardDispenseBehavior.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/dispenser/CuttingBoardDispenseBehavior.java
@@ -71,6 +71,7 @@ public class CuttingBoardDispenseBehavior extends OptionalDispenseBehavior
 			super(Block.Properties.from(Blocks.DISPENSER));
 		}
 
+		@Override
 		public IDispenseItemBehavior getBehavior(ItemStack itemStack) {
 			return super.getBehavior(itemStack);
 		}

--- a/src/main/java/vectorwing/farmersdelight/tile/inventory/CookingPotItemHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/inventory/CookingPotItemHandler.java
@@ -7,7 +7,8 @@ import net.minecraftforge.items.IItemHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class CookingPotItemHandler implements IItemHandler {
+public class CookingPotItemHandler implements IItemHandler
+{
 	private static final int SLOTS_INPUT = 6;
 	private static final int SLOT_CONTAINER_INPUT = 7;
 	private static final int SLOT_MEAL_OUTPUT = 8;
@@ -40,8 +41,7 @@ public class CookingPotItemHandler implements IItemHandler {
 	public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
 		if (side == null || side.equals(Direction.UP)) {
 			return slot < SLOTS_INPUT ? itemHandler.insertItem(slot, stack, simulate) : stack;
-		}
-		else {
+		} else {
 			return slot == SLOT_CONTAINER_INPUT ? itemHandler.insertItem(slot, stack, simulate) : stack;
 		}
 	}
@@ -51,8 +51,7 @@ public class CookingPotItemHandler implements IItemHandler {
 	public ItemStack extractItem(int slot, int amount, boolean simulate) {
 		if (side == null || side.equals(Direction.UP)) {
 			return slot < SLOTS_INPUT ? itemHandler.extractItem(slot, amount, simulate) : ItemStack.EMPTY;
-		}
-		else {
+		} else {
 			return slot == SLOT_MEAL_OUTPUT ? itemHandler.extractItem(slot, amount, simulate) : ItemStack.EMPTY;
 		}
 	}

--- a/src/main/java/vectorwing/farmersdelight/utils/ClientRenderUtils.java
+++ b/src/main/java/vectorwing/farmersdelight/utils/ClientRenderUtils.java
@@ -18,7 +18,8 @@ import net.minecraft.item.ItemStack;
 /**
  * Util for helping with rendering elements across the mod, when vanilla methods don't expose enough to use.
  */
-public class ClientRenderUtils {
+public class ClientRenderUtils
+{
 	/**
 	 * Renders an Item into the GUI, allowing the size to be defined instead of hardcoded.
 	 * This function is ripped right from the game's rendering code. I am probably doing something stupid.

--- a/src/main/java/vectorwing/farmersdelight/utils/MathUtils.java
+++ b/src/main/java/vectorwing/farmersdelight/utils/MathUtils.java
@@ -9,7 +9,8 @@ import java.util.Random;
 /**
  * Util for providing and calculating math-related objects across the mod.
  */
-public class MathUtils {
+public class MathUtils
+{
 	public static final Random RAND = new Random();
 
 	/**
@@ -22,8 +23,7 @@ public class MathUtils {
 	public static int calcRedstoneFromItemHandler(@Nullable IItemHandlerModifiable handler) {
 		if (handler == null) {
 			return 0;
-		}
-		else {
+		} else {
 			int i = 0;
 			float f = 0.0F;
 

--- a/src/main/java/vectorwing/farmersdelight/utils/TextUtils.java
+++ b/src/main/java/vectorwing/farmersdelight/utils/TextUtils.java
@@ -8,7 +8,8 @@ import vectorwing.farmersdelight.FarmersDelight;
  * Util for obtaining and formatting ITextComponents for use across the mod.
  */
 
-public class TextUtils {
+public class TextUtils
+{
 	/**
 	 * Syntactic sugar for custom translation keys. Always prefixed with the mod's ID in lang files (e.g. farmersdelight.your.key.here).
 	 */

--- a/src/main/java/vectorwing/farmersdelight/utils/tags/ModTags.java
+++ b/src/main/java/vectorwing/farmersdelight/utils/tags/ModTags.java
@@ -11,7 +11,8 @@ import vectorwing.farmersdelight.FarmersDelight;
  * References to tags under the Farmer's Delight namespace.
  * These tags are used for mod mechanics.
  */
-public class ModTags {
+public class ModTags
+{
 	// Blocks that can heat up a Cooking Pot.
 	public static final ITag.INamedTag<Block> HEAT_SOURCES = modBlockTag("heat_sources");
 

--- a/src/main/java/vectorwing/farmersdelight/world/CropPatchGeneration.java
+++ b/src/main/java/vectorwing/farmersdelight/world/CropPatchGeneration.java
@@ -16,7 +16,8 @@ import vectorwing.farmersdelight.registry.ModBiomeFeatures;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.setup.Configuration;
 
-public class CropPatchGeneration {
+public class CropPatchGeneration
+{
 	public static final BlockClusterFeatureConfig CABBAGE_PATCH_CONFIG = (new BlockClusterFeatureConfig.Builder(
 			new SimpleBlockStateProvider(ModBlocks.WILD_CABBAGES.get().getDefaultState()), new SimpleBlockPlacer())).tries(64).xSpread(2).zSpread(2).whitelist(ImmutableSet.of(Blocks.SAND.getBlock())).func_227317_b_().build();
 	public static final BlockClusterFeatureConfig ONION_PATCH_CONFIG = (new BlockClusterFeatureConfig.Builder(

--- a/src/main/java/vectorwing/farmersdelight/world/VillageStructures.java
+++ b/src/main/java/vectorwing/farmersdelight/world/VillageStructures.java
@@ -6,7 +6,9 @@ import com.mojang.datafixers.util.Pair;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.WorldGenRegistries;
-import net.minecraft.world.gen.feature.jigsaw.*;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPattern;
+import net.minecraft.world.gen.feature.jigsaw.JigsawPiece;
+import net.minecraft.world.gen.feature.jigsaw.LegacySingleJigsawPiece;
 import net.minecraft.world.gen.feature.structure.*;
 import net.minecraft.world.gen.feature.template.ProcessorLists;
 import vectorwing.farmersdelight.FarmersDelight;
@@ -16,8 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class VillageStructures {
-
+public class VillageStructures
+{
 	public static void init() {
 		PlainsVillagePools.init();
 		SnowyVillagePools.init();
@@ -34,7 +36,7 @@ public class VillageStructures {
 				.build();
 
 		for (Map.Entry<String, Integer> biome : biomeChances.entrySet()) {
-			addToPool(new ResourceLocation("village/"+biome.getKey()+"/houses"),	new ResourceLocation(FarmersDelight.MODID, "village/houses/"+biome.getKey()+"_compost_pile"), biome.getValue());
+			addToPool(new ResourceLocation("village/" + biome.getKey() + "/houses"), new ResourceLocation(FarmersDelight.MODID, "village/houses/" + biome.getKey() + "_compost_pile"), biome.getValue());
 		}
 	}
 
@@ -42,8 +44,7 @@ public class VillageStructures {
 		JigsawPattern old = WorldGenRegistries.JIGSAW_POOL.getOrDefault(pool);
 		List<JigsawPiece> shuffled = old.getShuffledPieces(MathUtils.RAND);
 		List<Pair<JigsawPiece, Integer>> newPieces = new ArrayList<>();
-		for(JigsawPiece p : shuffled)
-		{
+		for (JigsawPiece p : shuffled) {
 			newPieces.add(new Pair<>(p, 1));
 		}
 		newPieces.add(new Pair<>(new LegacySingleJigsawPiece(Either.left(toAdd), () -> ProcessorLists.field_244101_a, JigsawPattern.PlacementBehaviour.RIGID), weight));

--- a/src/main/java/vectorwing/farmersdelight/world/features/RiceCropFeature.java
+++ b/src/main/java/vectorwing/farmersdelight/world/features/RiceCropFeature.java
@@ -6,18 +6,17 @@ import net.minecraft.block.Blocks;
 import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ISeedReader;
-import net.minecraft.world.IWorld;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.Heightmap;
 import net.minecraft.world.gen.feature.BlockClusterFeatureConfig;
 import net.minecraft.world.gen.feature.Feature;
-import net.minecraft.world.gen.feature.structure.StructureManager;
 import vectorwing.farmersdelight.blocks.WildRiceBlock;
 import vectorwing.farmersdelight.registry.ModBlocks;
 
 import java.util.Random;
 
-public class RiceCropFeature extends Feature<BlockClusterFeatureConfig> {
+public class RiceCropFeature extends Feature<BlockClusterFeatureConfig>
+{
 	public RiceCropFeature(Codec<BlockClusterFeatureConfig> configFactoryIn) {
 		super(configFactoryIn);
 	}
@@ -30,7 +29,7 @@ public class RiceCropFeature extends Feature<BlockClusterFeatureConfig> {
 		int i = 0;
 		BlockPos.Mutable blockpos$mutable = new BlockPos.Mutable();
 
-		for(int j = 0; j < config.tryCount; ++j) {
+		for (int j = 0; j < config.tryCount; ++j) {
 			blockpos$mutable.setPos(blockpos).move(
 					rand.nextInt(config.xSpread + 1) - rand.nextInt(config.xSpread + 1),
 					rand.nextInt(config.ySpread + 1) - rand.nextInt(config.ySpread + 1),
@@ -39,7 +38,7 @@ public class RiceCropFeature extends Feature<BlockClusterFeatureConfig> {
 			if (worldIn.getBlockState(blockpos$mutable).getBlock() == Blocks.WATER && worldIn.getBlockState(blockpos$mutable.up()).getBlock() == Blocks.AIR) {
 				BlockState bottomRiceState = ModBlocks.WILD_RICE.get().getDefaultState().with(WildRiceBlock.HALF, DoubleBlockHalf.LOWER);
 				if (bottomRiceState.isValidPosition(worldIn, blockpos$mutable)) {
-					((WildRiceBlock)bottomRiceState.getBlock()).placeAt(worldIn, blockpos$mutable, 2);
+					((WildRiceBlock) bottomRiceState.getBlock()).placeAt(worldIn, blockpos$mutable, 2);
 					++i;
 				}
 			}


### PR DESCRIPTION
- Make all .java files follow the same code formatting standard. Enough "winging it", it was a mess;
- Optimize imports now and then;
- Apply `package-info.java` to most packages, to simplify non-null annotations;
- Remove unused swathes of code from a time I didn't understand modding as much;
- Fix a few erroneous uses of vanilla registries.