### PR TITLE
Fix Organic Compost lighting check.

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
@@ -57,7 +57,7 @@ public class OrganicCompostBlock extends Block
 			if (neighborState.getFluidState().isTagged(FluidTags.WATER)) {
 				hasWater = true;
 			}
-			int light = worldIn.getLightSubtracted(pos.up(), 0);
+			int light = worldIn.getLightSubtracted(neighborPos.up(), 0);
 			if (light > maxLight) {
 				maxLight = light;
 			}

--- a/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/OrganicCompostBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.state.IntegerProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.LightType;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.api.distmarker.Dist;
@@ -57,7 +58,7 @@ public class OrganicCompostBlock extends Block
 			if (neighborState.getFluidState().isTagged(FluidTags.WATER)) {
 				hasWater = true;
 			}
-			int light = worldIn.getLightSubtracted(neighborPos.up(), 0);
+			int light = worldIn.getLightFor(LightType.SKY, neighborPos.up());
 			if (light > maxLight) {
 				maxLight = light;
 			}


### PR DESCRIPTION
Very tiny fix. The position of the compost was used instead of the neighbors position, so it wasn't correctly finding the greatest nearby light. It also no longer considers block light, as that seems closer to the [documented behavior](https://github.com/vectorwing/FarmersDelight/wiki/Rich-Soil#crafting).