### PR TITLE
Big spruce trees no longer replace rich soil.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url='https://dist.creeper.host/Sponge/maven' }
         jcenter()
         mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
@@ -35,6 +37,7 @@ minecraft {
     runs {
         client {
             workingDirectory project.file('run')
+            arg '-mixin.config=farmersdelight.mixins.json'
 
             // Recommended logging data for a userdev environment
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
@@ -51,6 +54,7 @@ minecraft {
 
         server {
             workingDirectory project.file('run')
+            arg "-mixin.config=farmersdelight.mixins.json"
 
             // Recommended logging data for a userdev environment
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
@@ -143,7 +147,8 @@ jar {
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : "${version}",
                 "Implementation-Vendor"   : "vectorwing",
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+                "MixinConfigs"            : "farmersdelight.mixins.json"
         ])
     }
 }
@@ -165,4 +170,9 @@ publishing {
             url "file:///${project.projectDir}/mcmodsrepo"
         }
     }
+}
+
+apply plugin: 'org.spongepowered.mixin'
+mixin {
+    add sourceSets.main, "farmersdelight.refmap.json"
 }

--- a/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
+++ b/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
@@ -18,7 +18,7 @@ import java.util.Random;
 public class KeepRichSoilMixin {
 
     @Inject(cancellable = true, at = @At(value = "HEAD"), method = "isDirtAt")
-    private static void thing(IWorldGenerationBaseReader world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+    private static void keepRichSoil(IWorldGenerationBaseReader world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         if (world.hasBlockState(pos, state -> state.isIn(ModBlocks.RICH_SOIL.get()))) {
             cir.setReturnValue(false);
             cir.cancel();

--- a/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
+++ b/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
@@ -17,7 +17,7 @@ import java.util.Random;
 @Mixin(Feature.class)
 public class KeepRichSoilMixin {
 
-    @Inject(cancellable = true, at = @At(value = "HEAD"), method = "isDirtAt")
+    @Inject(cancellable = true, at = @At(value = "HEAD"), method = "isDirtAt(Lnet/minecraft/world/gen/IWorldGenerationBaseReader;Lnet/minecraft/util/math/BlockPos;)Z")
     private static void keepRichSoil(IWorldGenerationBaseReader world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         if (world.hasBlockState(pos, state -> state.isIn(ModBlocks.RICH_SOIL.get()))) {
             cir.setReturnValue(false);

--- a/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
+++ b/src/main/java/vectorwing/farmersdelight/mixin/KeepRichSoilMixin.java
@@ -1,0 +1,27 @@
+package vectorwing.farmersdelight.mixin;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.IWorldGenerationBaseReader;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.treedecorator.AlterGroundTreeDecorator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import vectorwing.farmersdelight.registry.ModBlocks;
+
+import java.util.Random;
+
+@Mixin(Feature.class)
+public class KeepRichSoilMixin {
+
+    @Inject(cancellable = true, at = @At(value = "HEAD"), method = "isDirtAt")
+    private static void thing(IWorldGenerationBaseReader world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if (world.hasBlockState(pos, state -> state.isIn(ModBlocks.RICH_SOIL.get()))) {
+            cir.setReturnValue(false);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/resources/farmersdelight.mixins.json
+++ b/src/main/resources/farmersdelight.mixins.json
@@ -1,0 +1,13 @@
+{
+    "required": true,
+    "package": "vectorwing.farmersdelight.mixin",
+    "compatibilityLevel": "JAVA_8",
+    "refmap": "farmersdelight.refmap.json",
+    "mixins": [
+        "KeepRichSoilMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    },
+    "minVersion": "0.8"
+}


### PR DESCRIPTION
A solution for #110.
`Feature.isDirtAt` is *only* used in `AlterGroundTreeDecorator`, and it was easier to use mixins with, so it seemed like a reasonable target.

As a side note, in order to see this change in your dev environment, you have to refresh gradle and run `genIntellijRuns`/`genEclipseRuns`.
