### PR TITLE
Post-release fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.3-0.3.0'
+version = '1.16.3-0.3.1'
 group = 'vectorwing.farmersdelight' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'FarmersDelight'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+- Fix vanilla crop crates not having loot tables;
+- Fix Rice Bale, Straw Bale and Wild Crops not being flammable (more to come later);
+- Fix a visual glitch on Honey Glazed Ham's fourth serving model;
+- Fix Bowls of Stuffed Pumpkin not giving a bowl back;
+
 ## 0.3.0
 - Added Feasts!
   - Feasts are very large meals, made to be placed down as a block and shared with friends, or just to decorate a dinner table!
@@ -15,6 +21,7 @@
   - Storage Crates for vanilla crops: Carrot, Potato and Beetroot
     - These specific blocks can be disabled in the configs, in order to prevent recipe overlaps with Quark and Thermal Cultivation;
 - Added foods:
+  - Wheat Dough: A clumsy, but efficient way to get more bread from your wheat;
   - Bacon: The half-portion of a Porkchop!
     - Bacon Sandwich;
     - Usable in all Porkchop-related recipes;
@@ -27,12 +34,13 @@
 - Updated the Cutting Board:
   - Recipes can now specify a ToolType for axes, pickaxes and shovels instead of imaginary forge tags!
   - This should broaden cutting compatibility with every single modded tool under the sun, as far as we tested. (thank you, ConductiveFoam!)
-- Updates meals and foods:
+- Updated some meals and foods:
   - Steak and Potatoes and Grilled Salmon are now crafted, instead of cooked, since their ingredients are already cooked;
   - General hunger/saturation/effect tweaks here and there.
 - Updated Knives:
   - Knives can now slice a Cake on right-click;
   - Knives can now carve pumpkins like Shears;
+  - Spiders can now be scavenged to guarantee at least 1 String;
 - Updated Mushroom Colonies:
   - They can now be sheared whole at their highest age (5 caps), and planted back in any surface a Mushroom can be planted in;
   - They only grow more caps if planted in Rich Soil under sufficient darkness;

--- a/src/main/java/vectorwing/farmersdelight/blocks/RiceBaleBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/RiceBaleBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 
 @SuppressWarnings("deprecation")
@@ -31,6 +32,16 @@ public class RiceBaleBlock extends Block
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
 		return this.getDefaultState().with(FACING, context.getFace());
+	}
+
+	@Override
+	public int getFireSpreadSpeed(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 60;
+	}
+
+	@Override
+	public int getFlammability(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 20;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/blocks/StrawBaleBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/StrawBaleBlock.java
@@ -1,0 +1,24 @@
+package vectorwing.farmersdelight.blocks;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.HayBlock;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+
+public class StrawBaleBlock extends HayBlock
+{
+	public StrawBaleBlock(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public int getFireSpreadSpeed(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 60;
+	}
+
+	@Override
+	public int getFlammability(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 20;
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/WildPatchBlock.java
@@ -2,6 +2,7 @@ package vectorwing.farmersdelight.blocks;
 
 import net.minecraft.block.*;
 import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -38,6 +39,16 @@ public class WildPatchBlock extends BushBlock implements IGrowable
 	@Override
 	public boolean isReplaceable(BlockState state, BlockItemUseContext useContext) {
 		return false;
+	}
+
+	@Override
+	public int getFireSpreadSpeed(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 60;
+	}
+
+	@Override
+	public int getFlammability(BlockState state, IBlockReader world, BlockPos pos, Direction face) {
+		return 100;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
@@ -45,7 +45,7 @@ public class ModBlocks
 	public static final RegistryObject<Block> RICE_BAG = BLOCKS.register("rice_bag",
 			() -> new Block(Block.Properties.from(Blocks.WHITE_WOOL).harvestTool(ToolType.HOE)));
 	public static final RegistryObject<Block> STRAW_BALE = BLOCKS.register("straw_bale",
-			() -> new HayBlock(Block.Properties.from(Blocks.HAY_BLOCK).harvestTool(ToolType.HOE)));
+			() -> new StrawBaleBlock(Block.Properties.from(Blocks.HAY_BLOCK).harvestTool(ToolType.HOE)));
 
 	// Building
 	public static final RegistryObject<Block> ROPE = BLOCKS.register("rope", RopeBlock::new);

--- a/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModItems.java
@@ -251,11 +251,11 @@ public class ModItems
 	public static final RegistryObject<Item> STUFFED_PUMPKIN_BLOCK = ITEMS.register("stuffed_pumpkin_block",
 			() -> new BlockItem(ModBlocks.STUFFED_PUMPKIN_BLOCK.get(), new Item.Properties().maxStackSize(1).group(FarmersDelight.ITEM_GROUP)));
 	public static final RegistryObject<Item> STUFFED_PUMPKIN = ITEMS.register("stuffed_pumpkin",
-			() -> new Item(new Item.Properties().food(Foods.STUFFED_PUMPKIN).maxStackSize(16).containerItem(Items.BOWL).group(FarmersDelight.ITEM_GROUP)));
+			() -> new ConsumableItem(new Item.Properties().food(Foods.STUFFED_PUMPKIN).maxStackSize(16).containerItem(Items.BOWL).group(FarmersDelight.ITEM_GROUP)));
 	public static final RegistryObject<Item> HONEY_GLAZED_HAM_BLOCK = ITEMS.register("honey_glazed_ham_block",
 			() -> new BlockItem(ModBlocks.HONEY_GLAZED_HAM_BLOCK.get(), new Item.Properties().maxStackSize(1).group(FarmersDelight.ITEM_GROUP)));
 	public static final RegistryObject<Item> HONEY_GLAZED_HAM = ITEMS.register("honey_glazed_ham",
-			() -> new ConsumableItem(new Item.Properties().food(Foods.HONEY_GLAZED_HAM).containerItem(Items.BOWL).maxStackSize(16).group(FarmersDelight.ITEM_GROUP)));
+			() -> new ConsumableItem(new Item.Properties().food(Foods.HONEY_GLAZED_HAM).maxStackSize(16).containerItem(Items.BOWL).group(FarmersDelight.ITEM_GROUP)));
 
 	public static final RegistryObject<Item> DOG_FOOD = ITEMS.register("dog_food",
 			() -> new DogFoodItem(new Item.Properties().food(Foods.DOG_FOOD).containerItem(Items.BOWL).maxStackSize(16).group(FarmersDelight.ITEM_GROUP)));

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license="MIT License"
 
 [[mods]]
 modId="farmersdelight"
-version="1.16.3-0.3.0"
+version="1.16.3-0.3.1"
 displayName="Farmer's Delight"
 # updateJSONURL=""
 displayURL="https://github.com/vectorwing/FarmersDelight"

--- a/src/main/resources/assets/farmersdelight/models/block/honey_glazed_ham_block_stage3.json
+++ b/src/main/resources/assets/farmersdelight/models/block/honey_glazed_ham_block_stage3.json
@@ -31,7 +31,7 @@
 			"faces": {
 				"north": {"uv": [8, 6, 16, 8], "rotation": 180, "texture": "#ham"},
 				"east": {"uv": [8, 8, 6, 16], "rotation": 90, "texture": "#ham"},
-				"south": {"uv": [8, 13, 16, 15], "texture": "#ham", "cullface": "down"},
+				"south": {"uv": [8, 13, 16, 15], "texture": "#ham"},
 				"west": {"uv": [6, 8, 8, 16], "rotation": 270, "texture": "#ham"},
 				"up": {"uv": [8, 8, 16, 16], "texture": "#ham"}
 			}

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/beetroot_crate.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/beetroot_crate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:beetroot_crate"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/carrot_crate.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/carrot_crate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:carrot_crate"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/potato_crate.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/potato_crate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:potato_crate"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Fix vanilla crop crates not having loot tables;
- Fix Rice Bale, Straw Bale and Wild Crops not being flammable (more to come later);
- Fix a visual glitch on Honey Glazed Ham's fourth serving model;
- Fix Bowls of Stuffed Pumpkin not giving a bowl back;