### PR TITLE
Make pantries retain name when broken

### DIFF
--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/acacia_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/acacia_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:acacia_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/birch_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/birch_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:birch_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/crimson_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/crimson_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:crimson_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/dark_oak_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/dark_oak_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:dark_oak_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/jungle_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/jungle_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:jungle_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/oak_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/oak_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:oak_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/spruce_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/spruce_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:spruce_pantry"
         }
       ],

--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/warped_pantry.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/warped_pantry.json
@@ -2,11 +2,16 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "pool1",
       "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "farmersdelight:warped_pantry"
         }
       ],


### PR DESCRIPTION
Small change that uses the `"minecraft:copy_name"` function within the loot table to make pantries retain their name when broken, if named via an anvil. Basically just works how the barrel loot table works.