### PR TITLE
Add smoked ham as a possible drop to pigs & hoglins

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/loot/functions/SmokerCookFunction.java
+++ b/src/main/java/vectorwing/farmersdelight/loot/functions/SmokerCookFunction.java
@@ -1,0 +1,58 @@
+package vectorwing.farmersdelight.loot.functions;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import mezz.jei.api.MethodsReturnNonnullByDefault;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.SmokingRecipe;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootFunction;
+import net.minecraft.loot.LootFunctionType;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.ResourceLocation;
+import vectorwing.farmersdelight.FarmersDelight;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Optional;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class SmokerCookFunction extends LootFunction {
+    public static final ResourceLocation ID = new ResourceLocation(FarmersDelight.MODID, "smoker_cook");
+
+    protected SmokerCookFunction(ILootCondition[] conditionsIn) {
+        super(conditionsIn);
+    }
+
+    @Override
+    protected ItemStack doApply(ItemStack stack, LootContext context) {
+        if (stack.isEmpty()) {
+            return stack;
+        } else {
+            Optional<SmokingRecipe> recipe = context.getWorld().getRecipeManager().getRecipesForType(IRecipeType.SMOKING).stream()
+                    .filter(r -> r.getIngredients().get(0).test(stack)).findFirst();
+            if (recipe.isPresent()) {
+                ItemStack result = recipe.get().getRecipeOutput().copy();
+                result.setCount(result.getCount() * stack.getCount());
+                return result;
+            } else {
+                return stack;
+            }
+        }
+    }
+
+    @Override
+    @Nullable
+    public LootFunctionType getFunctionType() {
+        return null;
+    }
+
+    public static class Serializer extends LootFunction.Serializer<SmokerCookFunction> {
+        @Override
+        public SmokerCookFunction deserialize(JsonObject _object, JsonDeserializationContext _context, ILootCondition[] conditionsIn) {
+            return new SmokerCookFunction(conditionsIn);
+        }
+    }
+}

--- a/src/main/java/vectorwing/farmersdelight/setup/CommonEventHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/setup/CommonEventHandler.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.crafting.conditions.VanillaCrateEnabledCondition;
 import vectorwing.farmersdelight.loot.functions.CopyMealFunction;
+import vectorwing.farmersdelight.loot.functions.SmokerCookFunction;
 import vectorwing.farmersdelight.registry.ModAdvancements;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.registry.ModEffects;
@@ -63,6 +64,7 @@ public class CommonEventHandler
 		ModAdvancements.register();
 
 		LootFunctionManager.func_237451_a_(CopyMealFunction.ID.toString(), new CopyMealFunction.Serializer());
+		LootFunctionManager.func_237451_a_(SmokerCookFunction.ID.toString(), new SmokerCookFunction.Serializer());
 
 		CraftingHelper.register(new VanillaCrateEnabledCondition.Serializer());
 

--- a/src/main/resources/data/farmersdelight/loot_tables/inject/hoglin.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/inject/hoglin.json
@@ -13,6 +13,20 @@
                 "min": 0.0,
                 "max": 1.0
               }
+            },
+            {
+              "function": "farmersdelight:smoker_cook",
+              "conditions": [
+                {
+                  "condition": "minecraft:entity_properties",
+                  "predicate": {
+                    "flags": {
+                      "is_on_fire": true
+                    }
+                  },
+                  "entity": "this"
+                }
+              ]
             }
           ],
           "name": "farmersdelight:ham"

--- a/src/main/resources/data/farmersdelight/loot_tables/inject/pig.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/inject/pig.json
@@ -6,7 +6,23 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "farmersdelight:ham"
+          "name": "farmersdelight:ham",
+          "functions": [
+            {
+              "function": "farmersdelight:smoker_cook",
+              "conditions": [
+                {
+                  "condition": "minecraft:entity_properties",
+                  "predicate": {
+                    "flags": {
+                      "is_on_fire": true
+                    }
+                  },
+                  "entity": "this"
+                }
+              ]
+            }
+          ]
         }
       ],
       "conditions": [


### PR DESCRIPTION
Properly now

Fixes #172

- Add "farmersdelight:smoker_cook" loot function that applies a SmokingRecipe to the drop, analogously to Vanilla's Smelt function
- Apply "farmersdelight:smoker_cook" to pig & hoglin drops when they're on fire