### PR TITLE
Add support for modded campfires

### DIFF
--- a/src/generated/resources/data/farmersdelight/tags/blocks/compost_activators.json
+++ b/src/generated/resources/data/farmersdelight/tags/blocks/compost_activators.json
@@ -1,8 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:brown_mushroom",
-    "minecraft:red_mushroom",
+    "#forge:mushrooms",
     "minecraft:podzol",
     "minecraft:mycelium",
     "farmersdelight:organic_compost",

--- a/src/generated/resources/data/farmersdelight/tags/blocks/compost_activators.json
+++ b/src/generated/resources/data/farmersdelight/tags/blocks/compost_activators.json
@@ -1,7 +1,8 @@
 {
   "replace": false,
   "values": [
-    "#forge:mushrooms",
+    "minecraft:brown_mushroom",
+    "minecraft:red_mushroom",
     "minecraft:podzol",
     "minecraft:mycelium",
     "farmersdelight:organic_compost",

--- a/src/generated/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
+++ b/src/generated/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
@@ -2,8 +2,7 @@
   "replace": false,
   "values": [
     "#minecraft:campfires",
-    "minecraft:fire",
-    "minecraft:soul_fire",
+    "#minecraft:fire",
     "minecraft:lava"
   ]
 }

--- a/src/generated/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
+++ b/src/generated/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
@@ -1,8 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:campfire",
-    "minecraft:soul_campfire",
+    "#minecraft:campfires",
     "minecraft:fire",
     "minecraft:soul_fire",
     "minecraft:lava"

--- a/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
@@ -56,11 +56,9 @@ public class BlockTags extends BlockTagsProvider
 				ModBlocks.WILD_ONIONS.get(),
 				ModBlocks.WILD_RICE.get());
 		getOrCreateBuilder(ModTags.TRAY_HEAT_SOURCES).add(
-				Blocks.CAMPFIRE,
-				Blocks.SOUL_CAMPFIRE,
-				Blocks.FIRE,
-				Blocks.SOUL_FIRE,
-				Blocks.LAVA);
+				Blocks.LAVA)
+				.addTag(net.minecraft.tags.BlockTags.CAMPFIRES)
+				.addTag(net.minecraft.tags.BlockTags.FIRE);
 		getOrCreateBuilder(ModTags.HEAT_SOURCES).add(
 				Blocks.MAGMA_BLOCK,
 				ModBlocks.STOVE.get())


### PR DESCRIPTION
I only changed the block IDs to minecraft:campfires tag, so it allows campfires from other mods to be used under the cooking pot. 