### PR TITLE
Added support for Just enought effects

### DIFF
--- a/src/main/resources/assets/farmersdelight/lang/en_us.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_us.json
@@ -140,6 +140,9 @@
 
   "effect.farmersdelight.nourished": "Nourished",
   "effect.farmersdelight.comfort": "Comfort",
+  
+  "effect.farmersdelight.nourished.0.desc": "sprinting or jumping wont consume any saturation",
+  "effect.farmersdelight.comfort.0.desc": "makes you immune to hunger, slowness and weakness",
 
   "enchantment.farmersdelight.backstabbing": "Backstabbing",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifies damage when striking a target from behind.",


### PR DESCRIPTION
Support for [Just enough effects](https://www.curseforge.com/minecraft/mc-mods/just-enough-effects) could be useful for modpack players or players in general that don't know what these effects do.
![JEE](https://user-images.githubusercontent.com/51972073/110330032-95c42a00-801d-11eb-882c-7a8674f49de2.png)
