### PR TITLE
Separate biome features and biome events on load, closes #190

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -5,7 +5,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -20,7 +19,6 @@ import vectorwing.farmersdelight.registry.*;
 import vectorwing.farmersdelight.setup.ClientEventHandler;
 import vectorwing.farmersdelight.setup.CommonEventHandler;
 import vectorwing.farmersdelight.setup.Configuration;
-import vectorwing.farmersdelight.world.CropPatchGeneration;
 
 @Mod(FarmersDelight.MODID)
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -32,15 +30,14 @@ public class FarmersDelight
 	public static final FDItemGroup ITEM_GROUP = new FDItemGroup(FarmersDelight.MODID);
 
 	public FarmersDelight() {
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(CommonEventHandler::init);
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientEventHandler::init);
-		FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(IRecipeSerializer.class, this::registerRecipeSerializers);
-		MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, CropPatchGeneration::onBiomeLoad);
+		final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+		modEventBus.addListener(CommonEventHandler::init);
+		modEventBus.addListener(ClientEventHandler::init);
+		modEventBus.addGenericListener(IRecipeSerializer.class, this::registerRecipeSerializers);
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Configuration.COMMON_CONFIG);
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Configuration.CLIENT_CONFIG);
-
-		final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
 		ModParticleTypes.PARTICLE_TYPES.register(modEventBus);
 		ModEnchantments.ENCHANTMENTS.register(modEventBus);

--- a/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/tile/CookingPotTileEntity.java
@@ -49,9 +49,9 @@ import java.util.Random;
 @ParametersAreNonnullByDefault
 public class CookingPotTileEntity extends TileEntity implements INamedContainerProvider, ITickableTileEntity, INameable
 {
-	public static final int MEAL_DISPLAY = 6;
-	public static final int CONTAINER_INPUT = 7;
-	public static final int FINAL_OUTPUT = 8;
+	public static final int MEAL_DISPLAY_SLOT = 6;
+	public static final int CONTAINER_SLOT = 7;
+	public static final int OUTPUT_SLOT = 8;
 	public static final int INVENTORY_SIZE = 9;
 
 	private ItemStackHandler itemHandler = createHandler();
@@ -167,7 +167,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 
 		ItemStackHandler drops = new ItemStackHandler(INVENTORY_SIZE);
 		for (int i = 0; i < INVENTORY_SIZE; ++i) {
-			drops.setStackInSlot(i, i == MEAL_DISPLAY ? itemHandler.getStackInSlot(i) : ItemStack.EMPTY);
+			drops.setStackInSlot(i, i == MEAL_DISPLAY_SLOT ? itemHandler.getStackInSlot(i) : ItemStack.EMPTY);
 		}
 		if (this.customName != null) {
 			compound.putString("CustomName", ITextComponent.Serializer.toJson(this.customName));
@@ -208,7 +208,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 				if (!this.doesMealHaveContainer(meal)) {
 					this.moveMealToOutput();
 					dirty = true;
-				} else if (!itemHandler.getStackInSlot(CONTAINER_INPUT).isEmpty()) {
+				} else if (!itemHandler.getStackInSlot(CONTAINER_SLOT).isEmpty()) {
 					this.useStoredContainersOnMeal();
 					dirty = true;
 				}
@@ -242,7 +242,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	}
 
 	private boolean hasInput() {
-		for (int i = 0; i < MEAL_DISPLAY; ++i) {
+		for (int i = 0; i < MEAL_DISPLAY_SLOT; ++i) {
 			if (!itemHandler.getStackInSlot(i).isEmpty()) return true;
 		}
 		return false;
@@ -254,12 +254,12 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 			if (recipeOutput.isEmpty()) {
 				return false;
 			} else {
-				ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY);
+				ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY_SLOT);
 				if (currentOutput.isEmpty()) {
 					return true;
 				} else if (!currentOutput.isItemEqual(recipeOutput)) {
 					return false;
-				} else if (currentOutput.getCount() + recipeOutput.getCount() <= itemHandler.getSlotLimit(MEAL_DISPLAY)) {
+				} else if (currentOutput.getCount() + recipeOutput.getCount() <= itemHandler.getSlotLimit(MEAL_DISPLAY_SLOT)) {
 					return true;
 				} else {
 					return currentOutput.getCount() + recipeOutput.getCount() <= recipeOutput.getMaxStackSize();
@@ -274,14 +274,14 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		if (recipe != null && this.canCook(recipe)) {
 			this.container = this.getRecipeContainer();
 			ItemStack recipeOutput = recipe.getRecipeOutput();
-			ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY);
+			ItemStack currentOutput = itemHandler.getStackInSlot(MEAL_DISPLAY_SLOT);
 			if (currentOutput.isEmpty()) {
-				itemHandler.setStackInSlot(MEAL_DISPLAY, recipeOutput.copy());
+				itemHandler.setStackInSlot(MEAL_DISPLAY_SLOT, recipeOutput.copy());
 			} else if (currentOutput.getItem() == recipeOutput.getItem()) {
 				currentOutput.grow(recipeOutput.getCount());
 			}
 		}
-		for (int i = 0; i < MEAL_DISPLAY; ++i) {
+		for (int i = 0; i < MEAL_DISPLAY_SLOT; ++i) {
 			if (itemHandler.getStackInSlot(i).hasContainerItem()) {
 				Direction direction = this.getBlockState().get(CookingPotBlock.FACING).rotateYCCW();
 				double dropX = pos.getX() + 0.5 + (direction.getXOffset() * 0.25);
@@ -317,7 +317,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	}
 
 	public ItemStack getMeal() {
-		return itemHandler.getStackInSlot(MEAL_DISPLAY);
+		return itemHandler.getStackInSlot(MEAL_DISPLAY_SLOT);
 	}
 
 	// ======== CUSTOM THINGS ========
@@ -344,7 +344,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	public NonNullList<ItemStack> getDroppableInventory() {
 		NonNullList<ItemStack> drops = NonNullList.create();
 		for (int i = 0; i < INVENTORY_SIZE; ++i) {
-			drops.add(i == MEAL_DISPLAY ? ItemStack.EMPTY : itemHandler.getStackInSlot(i));
+			drops.add(i == MEAL_DISPLAY_SLOT ? ItemStack.EMPTY : itemHandler.getStackInSlot(i));
 		}
 		return drops;
 	}
@@ -354,11 +354,11 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	 * Does NOT check if the meal has a container; this is done on tick.
 	 */
 	private void moveMealToOutput() {
-		ItemStack mealDisplay = itemHandler.getStackInSlot(MEAL_DISPLAY);
-		ItemStack finalOutput = itemHandler.getStackInSlot(FINAL_OUTPUT);
+		ItemStack mealDisplay = itemHandler.getStackInSlot(MEAL_DISPLAY_SLOT);
+		ItemStack finalOutput = itemHandler.getStackInSlot(OUTPUT_SLOT);
 		int mealCount = Math.min(mealDisplay.getCount(), mealDisplay.getMaxStackSize() - finalOutput.getCount());
 		if (finalOutput.isEmpty()) {
-			itemHandler.setStackInSlot(FINAL_OUTPUT, mealDisplay.split(mealCount));
+			itemHandler.setStackInSlot(OUTPUT_SLOT, mealDisplay.split(mealCount));
 		} else if (finalOutput.getItem() == mealDisplay.getItem()) {
 			mealDisplay.shrink(mealCount);
 			finalOutput.grow(mealCount);
@@ -370,16 +370,16 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 	 * If input and meal containers don't match, nothing happens.
 	 */
 	private void useStoredContainersOnMeal() {
-		ItemStack mealDisplay = itemHandler.getStackInSlot(MEAL_DISPLAY);
-		ItemStack containerInput = itemHandler.getStackInSlot(CONTAINER_INPUT);
-		ItemStack finalOutput = itemHandler.getStackInSlot(FINAL_OUTPUT);
+		ItemStack mealDisplay = itemHandler.getStackInSlot(MEAL_DISPLAY_SLOT);
+		ItemStack containerInput = itemHandler.getStackInSlot(CONTAINER_SLOT);
+		ItemStack finalOutput = itemHandler.getStackInSlot(OUTPUT_SLOT);
 
 		if (isContainerValid(containerInput) && finalOutput.getCount() < finalOutput.getMaxStackSize()) {
 			int smallerStack = Math.min(mealDisplay.getCount(), containerInput.getCount());
 			int mealCount = Math.min(smallerStack, mealDisplay.getMaxStackSize() - finalOutput.getCount());
 			if (finalOutput.isEmpty()) {
 				containerInput.shrink(mealCount);
-				itemHandler.setStackInSlot(FINAL_OUTPUT, mealDisplay.split(mealCount));
+				itemHandler.setStackInSlot(OUTPUT_SLOT, mealDisplay.split(mealCount));
 			} else if (finalOutput.getItem() == mealDisplay.getItem()) {
 				mealDisplay.shrink(mealCount);
 				containerInput.shrink(mealCount);
@@ -452,7 +452,7 @@ public class CookingPotTileEntity extends TileEntity implements INamedContainerP
 		{
 			@Override
 			protected void onContentsChanged(int slot) {
-				if (slot >= 0 && slot < MEAL_DISPLAY) {
+				if (slot >= 0 && slot < MEAL_DISPLAY_SLOT) {
 					cookTimeTotal = getCookTime();
 					inventoryChanged();
 				}

--- a/src/main/java/vectorwing/farmersdelight/world/CropPatchGeneration.java
+++ b/src/main/java/vectorwing/farmersdelight/world/CropPatchGeneration.java
@@ -4,14 +4,9 @@ import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.WorldGenRegistries;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.GenerationStage;
 import net.minecraft.world.gen.blockplacer.SimpleBlockPlacer;
 import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
 import net.minecraft.world.gen.feature.*;
-import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
-import net.minecraftforge.event.world.BiomeLoadingEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import vectorwing.farmersdelight.registry.ModBiomeFeatures;
 import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.setup.Configuration;
@@ -33,64 +28,32 @@ public class CropPatchGeneration
 	public static final BlockClusterFeatureConfig RICE_PATCH_CONFIG = (new BlockClusterFeatureConfig.Builder(
 			new SimpleBlockStateProvider(ModBlocks.WILD_RICE.get().getDefaultState()), new SimpleBlockPlacer())).tries(64).xSpread(4).zSpread(4).whitelist(ImmutableSet.of(Blocks.DIRT.getBlock())).func_227317_b_().build();
 
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_CABBAGES = register("patch_wild_cabbages", Feature.RANDOM_PATCH.withConfiguration(CABBAGE_PATCH_CONFIG)
-			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_CABBAGES.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_ONIONS = register("patch_wild_onions", Feature.RANDOM_PATCH.withConfiguration(ONION_PATCH_CONFIG)
-			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_ONIONS.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_TOMATOES = register("patch_wild_tomatoes", Feature.RANDOM_PATCH.withConfiguration(TOMATO_PATCH_CONFIG)
-			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_TOMATOES.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_CARROTS = register("patch_wild_carrots", Feature.RANDOM_PATCH.withConfiguration(CARROT_PATCH_CONFIG)
-			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_CARROTS.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_POTATOES = register("patch_wild_potatoes", Feature.RANDOM_PATCH.withConfiguration(POTATO_PATCH_CONFIG)
-			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_POTATOES.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_BEETROOTS = register("patch_wild_beetroots", Feature.RANDOM_PATCH.withConfiguration(BEETROOT_PATCH_CONFIG)
-			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_BEETROOTS.get()));
-	public static final ConfiguredFeature<?, ?> PATCH_WILD_RICE = register("patch_wild_rice", ModBiomeFeatures.RICE.get().withConfiguration(RICE_PATCH_CONFIG)
-			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_RICE.get()));
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_CABBAGES = Feature.RANDOM_PATCH.withConfiguration(CABBAGE_PATCH_CONFIG)
+			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_CABBAGES.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_ONIONS = Feature.RANDOM_PATCH.withConfiguration(ONION_PATCH_CONFIG)
+			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_ONIONS.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_TOMATOES = Feature.RANDOM_PATCH.withConfiguration(TOMATO_PATCH_CONFIG)
+			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_TOMATOES.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_CARROTS = Feature.RANDOM_PATCH.withConfiguration(CARROT_PATCH_CONFIG)
+			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_CARROTS.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_POTATOES = Feature.RANDOM_PATCH.withConfiguration(POTATO_PATCH_CONFIG)
+			.withPlacement(Features.Placements.PATCH_PLACEMENT).chance(Configuration.CHANCE_WILD_POTATOES.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_BEETROOTS = Feature.RANDOM_PATCH.withConfiguration(BEETROOT_PATCH_CONFIG)
+			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_BEETROOTS.get());
+	public static final ConfiguredFeature<?, ?> PATCH_WILD_RICE = ModBiomeFeatures.RICE.get().withConfiguration(RICE_PATCH_CONFIG)
+			.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT).chance(Configuration.CHANCE_WILD_RICE.get());
 
 	private static <FC extends IFeatureConfig> ConfiguredFeature<FC, ?> register(String key, ConfiguredFeature<FC, ?> configuredFeature) {
 		return Registry.register(WorldGenRegistries.CONFIGURED_FEATURE, key, configuredFeature);
 	}
 
-	@SubscribeEvent
-	public static void onBiomeLoad(BiomeLoadingEvent event) {
-		BiomeGenerationSettingsBuilder builder = event.getGeneration();
-		Biome.Climate climate = event.getClimate();
-
-		if (event.getName().getPath().equals("beach")) {
-			if (Configuration.GENERATE_WILD_BEETROOTS.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_BEETROOTS);
-			}
-			if (Configuration.GENERATE_WILD_CABBAGES.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_CABBAGES);
-			}
-		}
-
-		if (event.getCategory().equals(Biome.Category.SWAMP) || event.getCategory().equals(Biome.Category.JUNGLE)) {
-			if (Configuration.GENERATE_WILD_RICE.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_RICE);
-			}
-		}
-
-		if (climate.temperature >= 1.0F) {
-			if (Configuration.GENERATE_WILD_TOMATOES.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_TOMATOES);
-			}
-		}
-
-		if (climate.temperature > 0.3F && climate.temperature < 1.0F) {
-			if (Configuration.GENERATE_WILD_CARROTS.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_CARROTS);
-			}
-			if (Configuration.GENERATE_WILD_ONIONS.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_ONIONS);
-			}
-		}
-
-		if (climate.temperature > 0.0F && climate.temperature <= 0.3F) {
-			if (Configuration.GENERATE_WILD_POTATOES.get()) {
-				builder.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, PATCH_WILD_POTATOES);
-			}
-		}
+	public static void registerConfiguredFeatures() {
+		register("patch_wild_cabbages", PATCH_WILD_CABBAGES);
+		register("patch_wild_onions", PATCH_WILD_ONIONS);
+		register("patch_wild_tomatoes", PATCH_WILD_TOMATOES);
+		register("patch_wild_carrots", PATCH_WILD_CARROTS);
+		register("patch_wild_potatoes", PATCH_WILD_POTATOES);
+		register("patch_wild_beetroots", PATCH_WILD_BEETROOTS);
+		register("patch_wild_rice", PATCH_WILD_RICE);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/world/features/RiceCropFeature.java
+++ b/src/main/java/vectorwing/farmersdelight/world/features/RiceCropFeature.java
@@ -21,7 +21,6 @@ public class RiceCropFeature extends Feature<BlockClusterFeatureConfig>
 		super(configFactoryIn);
 	}
 
-
 	@Override
 	public boolean generate(ISeedReader worldIn, ChunkGenerator generator, Random rand, BlockPos pos, BlockClusterFeatureConfig config) {
 		BlockPos blockpos = worldIn.getHeight(Heightmap.Type.OCEAN_FLOOR_WG, pos);


### PR DESCRIPTION
This implements the enhancements/fixes proposed in #190, by moving the `onBiomeLoad` event outside the class where `ConfiguredFeature<?, ?>` is stored. It also enqueues their registration correctly.

@3TUSK and @ZekerZhayard, feel free to review this if you can, just to make sure this is what you meant. The changes work locally, but I could not test them with the OpenJ9 VM.