### PR TITLE
Add Configured and Catalogue Support

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,6 +15,8 @@ logoBlur=false
 credits="Chloe Dawn, Grimmauld, ConductiveFoam, simibubi, Jozufozu, bagel, Silk, SkySom, Eutro and many others!"
 authors="vectorwing"
 description="A lightweight farming and cooking expansion for Minecraft!"
+itemIcon="farmersdelight:cooking_pot"
+configBackground="minecraft:textures/block/bricks.png"
 
 [[dependencies.farmersdelight]]
     modId="forge"


### PR DESCRIPTION
Set the icon to the Cooking Pot when catalogue is installed, instead of the grass block, and set the background of Configured's config screen to bricks, since that's the main aesthetic of FD.

As far as I can tell, its literally a 2 line addition in order to add support for this. Lemme know if I missed something, or if you guys have better ideas for what the icons should be.