### PR TITLE
Update CraftTweaker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build
 eclipse
 run
 logs
+docsOut
 
 # Files from Forge MDK
 forge*changelog.txt

--- a/build.gradle
+++ b/build.gradle
@@ -106,11 +106,6 @@ repositories {
         url = "https://dvs1.progwml6.com/files/maven/"
     }
     maven {
-        // location of a maven mirror for JEI files, as a fallback
-        name = "ModMaven"
-        url = "https://modmaven.k-4u.nl"
-    }
-    maven {
         // CraftTweaker
         name = "BlameJared"
         url = "https://maven.blamejared.com/"
@@ -135,6 +130,11 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}")
 
     implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-${mc_version}:${crafttweaker_version}")
+
+    annotationProcessor "com.blamejared.crafttweaker:CraftTweaker-${mc_version}:${crafttweaker_version}"
+    annotationProcessor "com.blamejared.crafttweaker:Crafttweaker_Annotation_Processors-${mc_version}:${crafttweaker_annotations_version}"
+    annotationProcessor "org.reflections:reflections:0.9.10" // CT dep
+    annotationProcessor "com.google.code.gson:gson:2.8.7" // CT dep
 
     // Real examples
     // compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,12 @@ dependencies {
 
     implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-${mc_version}:${crafttweaker_version}")
 
+    /* CT documentation
     annotationProcessor "com.blamejared.crafttweaker:CraftTweaker-${mc_version}:${crafttweaker_version}"
     annotationProcessor "com.blamejared.crafttweaker:Crafttweaker_Annotation_Processors-${mc_version}:${crafttweaker_annotations_version}"
     annotationProcessor "org.reflections:reflections:0.9.10" // CT dep
     annotationProcessor "com.google.code.gson:gson:2.8.7" // CT dep
+     */
 
     // Real examples
     // compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,5 @@ forge_version=36.1.0
 
 # Dependency Info
 jei_version=7.6.4.88
-crafttweaker_version=7.1.0.216
+crafttweaker_version=7.1.0.354
+crafttweaker_annotations_version=1.0.0.354

--- a/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CookingPotRecipeHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CookingPotRecipeHandler.java
@@ -1,0 +1,56 @@
+package vectorwing.farmersdelight.integration.crafttweaker;
+
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
+import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
+import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
+import com.blamejared.crafttweaker.api.util.StringUtils;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+import vectorwing.farmersdelight.crafting.CookingPotRecipe;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@IRecipeHandler.For(CookingPotRecipe.class)
+public final class CookingPotRecipeHandler implements IRecipeHandler<CookingPotRecipe>
+{
+    @Override
+    public String dumpToCommandString(IRecipeManager manager, CookingPotRecipe recipe) {
+        return String.format(
+                "%s.addRecipe(%s, %s, %s, %s, %s, %s);",
+                manager.getCommandString(),
+                StringUtils.quoteAndEscape(recipe.getId()),
+                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                recipe.getIngredients().stream()
+                        .map(IIngredient::fromIngredient)
+                        .map(IIngredient::getCommandString)
+                        .collect(Collectors.joining(", ", "[", "]")),
+                new MCItemStackMutable(recipe.getOutputContainer()).getCommandString(),
+                recipe.getExperience(),
+                recipe.getCookTime()
+        );
+    }
+
+    @Override
+    public Optional<Function<ResourceLocation, CookingPotRecipe>> replaceIngredients(IRecipeManager manager, CookingPotRecipe recipe, List<IReplacementRule> rules) {
+        return ReplacementHandlerHelper.replaceNonNullIngredientList(
+                recipe.getIngredients(),
+                Ingredient.class,
+                recipe,
+                rules,
+                newIngredients -> id ->
+                        new CookingPotRecipe(id,
+                                recipe.getGroup(),
+                                newIngredients,
+                                recipe.getRecipeOutput(),
+                                recipe.getOutputContainer(),
+                                recipe.getExperience(),
+                                recipe.getCookTime())
+        );
+    }
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CookingPotRecipeManager.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CookingPotRecipeManager.java
@@ -7,6 +7,7 @@ import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.item.crafting.Ingredient;
@@ -16,10 +17,33 @@ import org.openzen.zencode.java.ZenCodeType;
 import vectorwing.farmersdelight.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.utils.ListUtils;
 
+/**
+ * Farmer's Delight Cooking Pot recipes.
+ *
+ * @docParam this <recipetype:farmersdelight:cooking>
+ */
+@Document("mods/farmersdelight/CookingPot")
 @ZenRegister
 @ZenCodeType.Name("mods.farmersdelight.CookingPot")
 public class CookingPotRecipeManager implements IRecipeManager
 {
+    /**
+     * Add a cooking pot recipe.
+     *
+     * @param name       Name of the recipe to add
+     * @param output     Output item
+     * @param inputs     Input ingredients
+     * @param container  Container item
+     * @param experience Experience granted
+     * @param cookTime   Cooking time
+     *
+     * @docParam name "cooking_pot_test"
+     * @docParam output <item:minecraft:enchanted_golden_apple>
+     * @docParam inputs [<item:minecraft:gold_block>]
+     * @docParam container <item:minecraft:apple>
+     * @docParam experience 100
+     * @docParam cookTime 400
+     */
     @ZenCodeType.Method
     public void addRecipe(String name,
                           IItemStack output,

--- a/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CuttingBoardRecipeHandler.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CuttingBoardRecipeHandler.java
@@ -1,0 +1,54 @@
+package vectorwing.farmersdelight.integration.crafttweaker;
+
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
+import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
+import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
+import com.blamejared.crafttweaker.api.util.StringUtils;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@IRecipeHandler.For(CuttingBoardRecipe.class)
+public class CuttingBoardRecipeHandler implements IRecipeHandler<CuttingBoardRecipe>
+{
+    @Override
+    public String dumpToCommandString(IRecipeManager manager, CuttingBoardRecipe recipe) {
+        return String.format(
+                "%s.addRecipe(%s, %s, %s, %s, %s);",
+                manager.getCommandString(),
+                StringUtils.quoteAndEscape(recipe.getId()),
+                IIngredient.fromIngredient(recipe.getIngredients().get(0)).getCommandString(),
+                recipe.getResults().stream()
+                        .map(MCItemStackMutable::new)
+                        .map(MCItemStackMutable::getCommandString)
+                        .collect(Collectors.joining(", ", "[", "]")),
+                IIngredient.fromIngredient(recipe.getTool()).getCommandString(),
+                recipe.getSoundEventID()
+        );
+    }
+
+    @Override
+    public Optional<Function<ResourceLocation, CuttingBoardRecipe>> replaceIngredients(IRecipeManager manager, CuttingBoardRecipe recipe, List<IReplacementRule> rules) {
+        return ReplacementHandlerHelper.replaceIngredientList(
+                recipe.getIngredientsAndTool(),
+                Ingredient.class,
+                recipe,
+                rules,
+                newIngredients -> id ->
+                        new CuttingBoardRecipe(id,
+                                recipe.getGroup(),
+                                newIngredients.get(0),
+                                newIngredients.get(1),
+                                recipe.getResults(),
+                                recipe.getSoundEventID())
+        );
+    }
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CuttingBoardRecipeManager.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/CuttingBoardRecipeManager.java
@@ -7,6 +7,7 @@ import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.NonNullList;
@@ -16,10 +17,31 @@ import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.integration.crafttweaker.actions.ActionRemoveCuttingBoardRecipe;
 import vectorwing.farmersdelight.utils.ListUtils;
 
+/**
+ * Farmer's Delight Cutting Board recipes.
+ *
+ * @docParam this <recipetype:farmersdelight:cutting>
+ */
+@Document("mods/farmersdelight/CuttingBoard")
 @ZenRegister
 @ZenCodeType.Name("mods.farmersdelight.CuttingBoard")
 public class CuttingBoardRecipeManager implements IRecipeManager
 {
+    /**
+     * Add a cutting board recipe.
+     *
+     * @param name    Name of the recipe to add
+     * @param input   Input ingredient
+     * @param results Output items
+     * @param tool    Tool ingredient
+     * @param sound   Sound event name
+     *
+     * @docParam name "cutting_board_test"
+     * @docParam input <item:minecraft:gravel>
+     * @docParam results [<item:minecraft:flint>]
+     * @docParam tool <item:minecraft:string>
+     * @docParam sound "minecraft:block.gravel.break"
+     */
     @ZenCodeType.Method
     public void addRecipe(String name,
                           IIngredient input,
@@ -43,6 +65,13 @@ public class CuttingBoardRecipeManager implements IRecipeManager
         removeRecipe(new IItemStack[]{output});
     }
 
+    /**
+     * Remove a cutting board recipe with multiple outputs.
+     *
+     * @param outputs Output items
+     *
+     * @docParam outputs [<item:farmersdelight:cooked_salmon_slice> * 2, <item:minecraft:bone_meal>]
+     */
     @ZenCodeType.Method
     public void removeRecipe(IItemStack[] outputs) {
         CraftTweakerAPI.apply(new ActionRemoveCuttingBoardRecipe(this, outputs));

--- a/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/MCToolIngredient.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/crafttweaker/MCToolIngredient.java
@@ -5,12 +5,17 @@ import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraftforge.common.ToolType;
 import org.openzen.zencode.java.ZenCodeType;
 import vectorwing.farmersdelight.crafting.ingredients.ToolIngredient;
 
+/**
+ * An ingredient that matches any item with the given tool type.
+ */
+@Document("mods/farmersdelight/ToolIngredient")
 @ZenRegister
 @ZenCodeType.Name("mods.farmersdelight.ToolIngredient")
 public class MCToolIngredient implements IIngredient
@@ -26,14 +31,30 @@ public class MCToolIngredient implements IIngredient
         this(new ToolIngredient(type));
     }
 
+    /**
+     * Get a tool ingredient from a tool type name.
+     *
+     * @param type The name of the type
+     * @return The ingredient
+     *
+     * @docParam type "axe"
+     */
     @ZenCodeType.Method
     @BracketResolver(PREFIX)
-    public static MCToolIngredient get(String type) {
-        return get(ToolType.get(type));
+    public static MCToolIngredient getToolIngredient(String type) {
+        return getToolIngredient(ToolType.get(type));
     }
 
+    /**
+     * Get a tool ingredient from a tool type.
+     *
+     * @param type The tool type
+     * @return The ingredient
+     *
+     * @docParam type <tooltype:axe>
+     */
     @ZenCodeType.Method
-    public static MCToolIngredient get(ToolType type) {
+    public static MCToolIngredient getToolIngredient(ToolType type) {
         return new MCToolIngredient(type);
     }
 


### PR DESCRIPTION
This PR updates Farmer's Delight's CraftTweaker integration.

- Automatic documentation generation.
  - JavaDocs have been added to existing Cooking Pot and Cutting Board recipe manager methods.
  - Existing PR updated [here](https://github.com/CraftTweaker/CraftTweaker-Documentation/pull/395).
- Recipe Handlers have been added for Cooking Pot and Cutting Board recipes, so ingredient replacements are supported.
  e.g.
```zs
for recipe in <recipetype:farmersdelight:cutting>.allRecipes {
    recipe.replace(<tag:items:forge:tools/knives>, <toolingredient:axe>);
}
```
- `MCToolIngredient#get` has been renamed to `getToolIngredient` because [`get` is a ZenCode keyword](https://github.com/ZenCodeLang/ZenCode/blob/374d290882219c30ca50ba811b46428d03575334/Parser/src/main/java/org/openzen/zenscript/lexer/ZSTokenType.java#L104).

Additionally, the build script has been updated with the following:

- ModMaven was removed from the `repositories` block, since the SSL certificate appears to have expired.
- CT documentation annotation processors and deps have been added, commented out, for documentation generation.