### PR TITLE
Add data-driven pantry registration

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
+++ b/src/main/java/vectorwing/farmersdelight/FarmersDelight.java
@@ -2,6 +2,10 @@ package vectorwing.farmersdelight;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
@@ -14,13 +18,17 @@ import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import vectorwing.farmersdelight.blocks.PantryBlock;
 import vectorwing.farmersdelight.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.crafting.ingredients.ToolIngredient;
+import vectorwing.farmersdelight.items.FuelBlockItem;
 import vectorwing.farmersdelight.registry.*;
 import vectorwing.farmersdelight.setup.ClientEventHandler;
 import vectorwing.farmersdelight.setup.CommonEventHandler;
 import vectorwing.farmersdelight.setup.Configuration;
+import vectorwing.farmersdelight.utils.DataDrivenRegistrar;
 
 @Mod(FarmersDelight.MODID)
 @Mod.EventBusSubscriber(modid = FarmersDelight.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -54,6 +62,9 @@ public class FarmersDelight
 		ModTileEntityTypes.TILES.register(modEventBus);
 		ModContainerTypes.CONTAINER_TYPES.register(modEventBus);
 		ModRecipeSerializers.RECIPE_SERIALIZERS.register(modEventBus);
+		new DataDrivenRegistrar<String>(modEventBus, "farmersdelightPantryCompat")
+				.blockFactory(id -> new PantryBlock(Block.Properties.copy(Blocks.BARREL)).setRegistryName(id))
+				.itemFactory(block -> new FuelBlockItem(block, new Item.Properties().tab(FarmersDelight.ITEM_GROUP), 300).setRegistryName(block.getRegistryName()));
 
 		MinecraftForge.EVENT_BUS.register(this);
 	}

--- a/src/main/java/vectorwing/farmersdelight/blocks/PantryBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/blocks/PantryBlock.java
@@ -22,12 +22,11 @@ import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import vectorwing.farmersdelight.registry.ModBlocks;
 import vectorwing.farmersdelight.tile.PantryTileEntity;
 
 import javax.annotation.Nullable;
 import java.util.Random;
-
-import net.minecraft.block.AbstractBlock.Properties;
 
 @SuppressWarnings("deprecation")
 public class PantryBlock extends ContainerBlock
@@ -38,6 +37,7 @@ public class PantryBlock extends ContainerBlock
 	public PantryBlock(Properties properties) {
 		super(properties);
 		this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(OPEN, false));
+		ModBlocks.PANTRIES.add(this);
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModBlocks.java
@@ -14,7 +14,10 @@ import vectorwing.farmersdelight.blocks.*;
 import vectorwing.farmersdelight.blocks.signs.StandingCanvasSignBlock;
 import vectorwing.farmersdelight.blocks.signs.WallCanvasSignBlock;
 
+import java.util.Set;
 import java.util.function.ToIntFunction;
+
+import com.google.common.collect.Sets;
 
 public class ModBlocks
 {
@@ -52,6 +55,7 @@ public class ModBlocks
 			() -> new StrawBaleBlock(Block.Properties.copy(Blocks.HAY_BLOCK).harvestTool(ToolType.HOE)));
 
 	// Building
+	public static final Set<Block> PANTRIES = Sets.newHashSet();
 	public static final RegistryObject<Block> ROPE = BLOCKS.register("rope", RopeBlock::new);
 	public static final RegistryObject<Block> SAFETY_NET = BLOCKS.register("safety_net", SafetyNetBlock::new);
 	public static final RegistryObject<Block> OAK_PANTRY = BLOCKS.register("oak_pantry",

--- a/src/main/java/vectorwing/farmersdelight/registry/ModTileEntityTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/registry/ModTileEntityTypes.java
@@ -22,9 +22,7 @@ public class ModTileEntityTypes
 	public static final RegistryObject<TileEntityType<SkilletTileEntity>> SKILLET_TILE = TILES.register("skillet",
 			() -> TileEntityType.Builder.of(SkilletTileEntity::new, ModBlocks.SKILLET.get()).build(null));
 	public static final RegistryObject<TileEntityType<PantryTileEntity>> PANTRY_TILE = TILES.register("pantry",
-			() -> TileEntityType.Builder.of(PantryTileEntity::new,
-					ModBlocks.OAK_PANTRY.get(), ModBlocks.BIRCH_PANTRY.get(), ModBlocks.SPRUCE_PANTRY.get(), ModBlocks.JUNGLE_PANTRY.get(), ModBlocks.ACACIA_PANTRY.get(), ModBlocks.DARK_OAK_PANTRY.get())
-					.build(null));
+			() -> new TileEntityType<>(PantryTileEntity::new, ModBlocks.PANTRIES, null));
 	public static final RegistryObject<TileEntityType<CanvasSignTileEntity>> CANVAS_SIGN_TILE = TILES.register("canvas_sign",
 			() -> TileEntityType.Builder.of(CanvasSignTileEntity::new,
 					ModBlocks.CANVAS_SIGN.get(),

--- a/src/main/java/vectorwing/farmersdelight/utils/DataDrivenRegistrar.java
+++ b/src/main/java/vectorwing/farmersdelight/utils/DataDrivenRegistrar.java
@@ -1,0 +1,66 @@
+package vectorwing.farmersdelight.utils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.forgespi.language.IModInfo;
+
+public class DataDrivenRegistrar<IN> {
+
+	public final String key;
+	protected Function<IN, Block> blockFactory;
+	protected Function<Block, Item> itemFactory;
+	private List<Item> itemsToAdd;
+
+	public DataDrivenRegistrar(IEventBus bus, String key) {
+		this.key = key;
+		bus.addGenericListener(Block.class, this::registerBlocks);
+		bus.addGenericListener(Item.class, this::registerItems);
+	}
+
+	public DataDrivenRegistrar<IN> blockFactory(Function<IN, Block> blockFactory) {
+		this.blockFactory = blockFactory;
+		return this;
+	}
+
+	public DataDrivenRegistrar<IN> itemFactory(Function<Block, Item> itemFactory) {
+		this.itemFactory = itemFactory;
+		return this;
+	}
+
+	private void registerBlocks(RegistryEvent.Register<Block> event) {
+	    itemsToAdd = stream()
+				.map(blockFactory::apply)
+				.filter(Objects::nonNull)
+				.peek(event.getRegistry()::register)
+				.map(itemFactory::apply)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
+	}
+
+	private void registerItems(RegistryEvent.Register<Item> event) {
+		itemsToAdd.forEach(event.getRegistry()::register);
+		itemsToAdd = null;
+	}
+
+	protected Stream<IN> stream() {
+		return ImmutableList.copyOf(ModList.get().getMods())
+				.stream()
+				.map(IModInfo::getModProperties)
+				.filter($ -> $.containsKey(key))
+				.map($ -> (List<IN>) $.get(key))
+				.flatMap($ -> $.stream());
+	}
+
+}


### PR DESCRIPTION
This PR adds a feature letting modders add their own pantries without the need of adding FarmersDelight as their dependency.

Modders just need to provide resources, recipes and loot tables, and simply add two lines in their `mods.toml`:

```toml
[modproperties.modid]
    farmersdelightPantryCompat=[ "modid:custom_pantry" ]
```
