### PR TITLE
Add more Create-integration recipes

### DIFF
--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/bacon_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/bacon_from_cutting.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:porkchop" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:bacon", "count": 2 },
+	{ "item": "farmersdelight:bacon", "count": 1, "chance": 0.2 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/cabbage_slice_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/cabbage_slice_from_cutting.json
@@ -5,7 +5,7 @@
       "modid": "create"
     }
   ],
-  "type": "create:mixing",
+  "type": "create:cutting",
   "ingredients": [
     {
       "item": "farmersdelight:cabbage"

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/chicken_cuts_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/chicken_cuts_from_cutting.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:chicken" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:chicken_cuts", "count": 2 },
+	{ "item": "farmersdelight:chicken_cuts", "count": 1, "chance": 0.2 },
+	{ "item": "minecraft:bone_meal", "count": 1 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/cod_slice_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/cod_slice_from_cutting.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:cod" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:cod_slice", "count": 2 },
+	{ "item": "farmersdelight:cod_slice", "count": 1, "chance": 0.2 },
+	{ "item": "minecraft:bone_meal", "count": 1 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/mutton_chops_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/mutton_chops_from_cutting.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:mutton" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:mutton_chops", "count": 2 },
+	{ "item": "farmersdelight:mutton_chops", "count": 1, "chance": 0.2 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/pumpkin_slices_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/pumpkin_slices_from_cutting.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:pumpkin" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:pumpkin_slice", "count": 4 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/raw_pasta_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/raw_pasta_from_cutting.json
@@ -1,0 +1,15 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "create:dough" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:raw_pasta", "count": 1 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/salmon_slice_from_cutting.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/cutting/salmon_slice_from_cutting.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+  	{ "item": "minecraft:salmon" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:salmon_slice", "count": 2 },
+	{ "item": "farmersdelight:salmon_slice", "count": 1, "chance": 0.2 },
+	{ "item": "minecraft:bone_meal", "count": 1 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/filling/milk_bottle.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/filling/milk_bottle.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "minecraft:glass_bottle"
+    },
+    {
+      "fluidTag": "forge:milk",
+      "amount": 250
+    }
+  ],
+  "results": [
+    {
+      "item": "farmersdelight:milk_bottle"
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/milling/minced_beef_from_milling.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/milling/minced_beef_from_milling.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+  	{ "item": "minecraft:beef" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:minced_beef", "count": 2 },
+	{ "item": "farmersdelight:minced_beef", "count": 1, "chance": 0.2 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/mixing/raw_pasta_from_dough.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/mixing/raw_pasta_from_dough.json
@@ -1,0 +1,16 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:mixing",
+  "ingredients": [
+  	{ "item": "create:dough" },
+    { "item": "minecraft:egg" }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:raw_pasta", "count": 1 }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/create/mixing/raw_pasta_from_mixing.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/create/mixing/raw_pasta_from_mixing.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:mixing",
+  "ingredients": [
+  	{ "item": "minecraft:wheat" },
+  	{ "item": "minecraft:wheat" },
+  	{ "item": "minecraft:wheat" },
+  	{ "item": "minecraft:wheat" },
+    { "fluid": "minecraft:water", "nbt": {}, "amount": 1000 }
+  ],
+  "results": [
+  	{ "item": "farmersdelight:raw_pasta", "count": 2 }
+  ]
+}


### PR DESCRIPTION
Add more recipes using Create machines:

- Cabbage leaves are now made by running a cabbage through a mechanical saw instead of the mixer
  - I'm not sure which is funnier, but the idea of running a cabbage across a wood saw is tickling me.
- Add sawing recipes for all the meat-doubling recipes
  - Each recipe follows the normal cutting board recipe, but with a 20% chance to produce an additional meat cut.
  - Minced beef is made in the mill instead, obviously
- Add filling recipe for milk bottles (250mB of milk, as implied by other recipes)
- Add sawing recipe for pumpkin slices
- Add several different recipes for making raw pasta:
  - Mixing 4 wheat with liquid water = 2 pasta
  - Mixing 1 dough and 1 egg = 1 pasta
  - Cutting 1 dough on the saw = 1 pasta (you know, like a... pasta roller? kind of?)

Happy to take feedback and adjust any of these!