### PR TITLE
Make wild rice loot table use `forge:shears`

### DIFF
--- a/src/main/resources/data/farmersdelight/loot_tables/blocks/wild_rice.json
+++ b/src/main/resources/data/farmersdelight/loot_tables/blocks/wild_rice.json
@@ -65,7 +65,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],


### PR DESCRIPTION
Right now only the lower half uses the `forge:shears` tag, while the upper block uses `minecraft:shears`. This leads to some unexpected weirdness when using modded shears, so I changed it to use `forge:shears` for both.