### PR TITLE
Basically satisfied #432: Made ropes collectable from top

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/RopeBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RopeBlock.java
@@ -49,42 +49,22 @@ public class RopeBlock extends IronBarsBlock
 		return state != null ? state.setValue(TIED_TO_BELL, world.getBlockState(posAbove).getBlock() == Blocks.BELL) : null;
 	}
 
-	public int findSlotForRope(Inventory inventory) {
-		int firstEmpty = -1;
-		ItemStack rope = new ItemStack(this.asItem());
-		for(int i = 0; i < inventory.items.size(); i++) {
-			ItemStack stack = inventory.items.get(i);
-			if(ItemStack.isSameItemSameTags(stack, rope) && stack.getCount() < stack.getMaxStackSize()) {
-				return i;
-			} else if(firstEmpty == -1 && stack.isEmpty() && i != inventory.selected) {
-				firstEmpty = i;
-			}
-		}
-		return firstEmpty;
-	}
-
 	@Override
 	public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player player, InteractionHand handIn, BlockHitResult hit) {
 		if (player.getItemInHand(handIn).isEmpty()) {
 			if(player.isSecondaryUseActive()) {
-				if(player.getAbilities().mayBuild) {
-					Inventory inventory = player.getInventory();
-					int ropeSlot = this.findSlotForRope(inventory);
-					if(ropeSlot > -1) {
-						BlockPos.MutableBlockPos blockpos$mutable = pos.mutable().move(Direction.DOWN);
-						int minBuildHeight = worldIn.getMinBuildHeight();
+				if(player.getAbilities().mayBuild && player.getInventory().add(new ItemStack(this.asItem()))) {
+					BlockPos.MutableBlockPos blockpos$mutable = pos.mutable().move(Direction.DOWN);
+					int minBuildHeight = worldIn.getMinBuildHeight();
 
-						while(blockpos$mutable.getY() >= minBuildHeight) {
-							BlockState blockStateBelow = worldIn.getBlockState(blockpos$mutable);
-							if(blockStateBelow.is(this)) {
-								blockpos$mutable.move(Direction.DOWN);
-							} else {
-								blockpos$mutable.move(Direction.UP);
-								worldIn.destroyBlock(blockpos$mutable, false, player);
-								inventory.add(ropeSlot, new ItemStack(this.asItem()));
-
-								return InteractionResult.sidedSuccess(worldIn.isClientSide);
-							}
+					while(blockpos$mutable.getY() >= minBuildHeight) {
+						BlockState blockStateBelow = worldIn.getBlockState(blockpos$mutable);
+						if(blockStateBelow.is(this)) {
+							blockpos$mutable.move(Direction.DOWN);
+						} else {
+							blockpos$mutable.move(Direction.UP);
+							worldIn.destroyBlock(blockpos$mutable, false, player);
+							return InteractionResult.sidedSuccess(worldIn.isClientSide);
 						}
 					}
 				}


### PR DESCRIPTION
This PR solved #432 : Ropes now can be collected from top using Shift + Right Click.

Additional information:
1. Player must have its mainhand empty to do this.
2. Collected ropes will be merged into existing rope item stack in inventory (if present) or added into the first empty slot in inventory (except for both hands, because having rope item in offhand leads to the action of placing it, which is unexpected).
3. I didn't check whether the clicked rope block is the upper end. From my POV, one can pull ropes from its middle for sure, and this function would be too useless if we add such restriction.
4. The idea of collecting ropes from bottom is unrequired by the issue, and I haven't got any reason to do so.