### PR TITLE
Fixed #433: Introducing biome specific wild crops generation configs

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/Configuration.java
+++ b/src/main/java/vectorwing/farmersdelight/common/Configuration.java
@@ -1,9 +1,11 @@
 package vectorwing.farmersdelight.common;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Mod.EventBusSubscriber
@@ -34,6 +36,8 @@ public class Configuration
 	public static ForgeConfigSpec.BooleanValue CROPS_ON_SHIPWRECKS;
 	public static ForgeConfigSpec.BooleanValue CROPS_ON_VILLAGE_HOUSES;
 	public static ForgeConfigSpec.BooleanValue GENERATE_VILLAGE_COMPOST_HEAPS;
+	public static ForgeConfigSpec.BooleanValue GENERATE_WILD_CROPS_IN_VANILLA_BIOMES_ONLY;
+	public static ForgeConfigSpec.ConfigValue<List<? extends String>> WILD_CROPS_BIOME_BLACKLIST;
 	public static ForgeConfigSpec.BooleanValue GENERATE_WILD_CABBAGES;
 	public static ForgeConfigSpec.IntValue CHANCE_WILD_CABBAGES;
 	public static ForgeConfigSpec.BooleanValue GENERATE_WILD_BEETROOTS;
@@ -98,6 +102,10 @@ public class Configuration
 				.define("cropsOnVillageHouseLoot", true);
 		GENERATE_VILLAGE_COMPOST_HEAPS = COMMON_BUILDER.comment("Generate Compost Heaps across all village biomes")
 				.define("genVillageCompostHeaps", true);
+		GENERATE_WILD_CROPS_IN_VANILLA_BIOMES_ONLY = COMMON_BUILDER.comment("Generate wild crops in vanilla biomes only")
+			.define("genWildCropsInVanillaBiomesOnly", false);
+		WILD_CROPS_BIOME_BLACKLIST = COMMON_BUILDER.comment("Prevent wild crops' generation in certain biomes")
+				.defineList("wildCropsBiomeBlocklist", new ArrayList<>(), obj -> true);
 
 		COMMON_BUILDER.comment("Wild Cabbage generation").push("wild_cabbages");
 		GENERATE_WILD_CABBAGES = COMMON_BUILDER.comment("Generate wild cabbages on beaches")

--- a/src/main/java/vectorwing/farmersdelight/common/event/CommonEvents.java
+++ b/src/main/java/vectorwing/farmersdelight/common/event/CommonEvents.java
@@ -67,41 +67,53 @@ public class CommonEvents
 		Biome.ClimateSettings climate = event.getClimate();
 
 		ResourceLocation biomeName = event.getName();
-		if (biomeName != null && biomeName.getPath().equals("beach")) {
-			if (Configuration.GENERATE_WILD_BEETROOTS.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_BEETROOTS);
+		boolean shouldGenWildCrops = true;
+		if(Configuration.GENERATE_WILD_CROPS_IN_VANILLA_BIOMES_ONLY.get()) {
+			shouldGenWildCrops = biomeName != null && biomeName.getNamespace().equals("minecraft");
+		}
+
+		if(biomeName != null) {
+			shouldGenWildCrops &= !Configuration.WILD_CROPS_BIOME_BLACKLIST.get().contains(biomeName.toString());
+		}
+
+		if (shouldGenWildCrops) {
+			if (biomeName != null && biomeName.getPath().equals("beach")) {
+				if (Configuration.GENERATE_WILD_BEETROOTS.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_BEETROOTS);
+				}
+				if (Configuration.GENERATE_WILD_CABBAGES.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_CABBAGES);
+				}
 			}
-			if (Configuration.GENERATE_WILD_CABBAGES.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_CABBAGES);
+
+			if (event.getCategory().equals(Biome.BiomeCategory.SWAMP) || event.getCategory().equals(Biome.BiomeCategory.JUNGLE)) {
+				if (Configuration.GENERATE_WILD_RICE.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_RICE);
+				}
+			}
+
+			if (climate.temperature >= 1.0F) {
+				if (Configuration.GENERATE_WILD_TOMATOES.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_TOMATOES);
+				}
+			}
+
+			if (climate.temperature > 0.3F && climate.temperature < 1.0F) {
+				if (Configuration.GENERATE_WILD_CARROTS.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_CARROTS);
+				}
+				if (Configuration.GENERATE_WILD_ONIONS.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_ONIONS);
+				}
+			}
+
+			if (climate.temperature > 0.0F && climate.temperature <= 0.3F) {
+				if (Configuration.GENERATE_WILD_POTATOES.get()) {
+					builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_POTATOES);
+				}
 			}
 		}
 
-		if (event.getCategory().equals(Biome.BiomeCategory.SWAMP) || event.getCategory().equals(Biome.BiomeCategory.JUNGLE)) {
-			if (Configuration.GENERATE_WILD_RICE.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_RICE);
-			}
-		}
-
-		if (climate.temperature >= 1.0F) {
-			if (Configuration.GENERATE_WILD_TOMATOES.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_TOMATOES);
-			}
-		}
-
-		if (climate.temperature > 0.3F && climate.temperature < 1.0F) {
-			if (Configuration.GENERATE_WILD_CARROTS.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_CARROTS);
-			}
-			if (Configuration.GENERATE_WILD_ONIONS.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_ONIONS);
-			}
-		}
-
-		if (climate.temperature > 0.0F && climate.temperature <= 0.3F) {
-			if (Configuration.GENERATE_WILD_POTATOES.get()) {
-				builder.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, WildCropGeneration.PATCH_WILD_POTATOES);
-			}
-		}
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
This PR fixed #433 by introducing 2 more configs:
1. (Boolean) Generate wild crops in vanilla biome only
2. (List<String>) Wild crops biome blacklist

Dimension specific generation config is kind of unrealizable, so I made the first one instead. It's kind of duplicated with the second one, but may be useful in certain conditions (e.g. the player added too many biome related mods and is exhausted to test and blacklisting every possible biomes).