### PR TITLE
Add support for `forge:dough` and `forge:dough/wheat`

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/tag/ForgeTags.java
+++ b/src/main/java/vectorwing/farmersdelight/common/tag/ForgeTags.java
@@ -37,6 +37,9 @@ public class ForgeTags
 	public static final TagKey<Item> CROPS_RICE = forgeItemTag("crops/rice");
 	public static final TagKey<Item> CROPS_TOMATO = forgeItemTag("crops/tomato");
 
+	public static final TagKey<Item> DOUGH = forgeItemTag("dough");
+	public static final TagKey<Item> DOUGH_WHEAT = forgeItemTag("dough/wheat");
+
 	public static final TagKey<Item> EGGS = forgeItemTag("eggs");
 
 	public static final TagKey<Item> GRAIN = forgeItemTag("grain");

--- a/src/main/java/vectorwing/farmersdelight/data/ItemTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/ItemTags.java
@@ -83,6 +83,9 @@ public class ItemTags extends ItemTagsProvider
 		tag(ForgeTags.CROPS_RICE).add(ModItems.RICE.get());
 		tag(ForgeTags.CROPS_TOMATO).add(ModItems.TOMATO.get());
 
+		tag(ForgeTags.DOUGH).add(ModItems.WHEAT_DOUGH.get());
+		tag(ForgeTags.DOUGH_WHEAT).add(ModItems.WHEAT_DOUGH.get());
+
 		tag(ForgeTags.EGGS).add(Items.EGG);
 
 		tag(ForgeTags.GRAIN).addTags(ForgeTags.GRAIN_WHEAT, ForgeTags.GRAIN_RICE);

--- a/src/main/java/vectorwing/farmersdelight/data/recipe/CookingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipe/CookingRecipes.java
@@ -92,7 +92,7 @@ public class CookingRecipes
 				.addIngredient(ForgeTags.CROPS_RICE)
 				.build(consumer);
 		CookingPotRecipeBuilder.cookingPotRecipe(ModItems.DUMPLINGS.get(), 2, NORMAL_COOKING, 0.35F)
-				.addIngredient(ModItems.WHEAT_DOUGH.get())
+				.addIngredient(ForgeTags.DOUGH)
 				.addIngredient(ForgeTags.CROPS_CABBAGE)
 				.addIngredient(ForgeTags.CROPS_ONION)
 				.addIngredient(Ingredient.fromValues(Stream.of(

--- a/src/main/java/vectorwing/farmersdelight/data/recipe/CuttingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipe/CuttingRecipes.java
@@ -91,7 +91,7 @@ public class CuttingRecipes
 	}
 
 	private static void cuttingPastries(Consumer<FinishedRecipe> consumer) {
-		CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(ModItems.WHEAT_DOUGH.get()), Ingredient.of(ForgeTags.TOOLS_KNIVES), ModItems.RAW_PASTA.get(), 1)
+		CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(ForgeTags.DOUGH), Ingredient.of(ForgeTags.TOOLS_KNIVES), ModItems.RAW_PASTA.get(), 1)
 				.build(consumer);
 		CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(Items.CAKE), Ingredient.of(ForgeTags.TOOLS_KNIVES), ModItems.CAKE_SLICE.get(), 7)
 				.build(consumer);


### PR DESCRIPTION
This allows Farmer's Delight dough to be used in Create recipes, and Create dough to be used in Farmer's Delight recipes.
The ingredient for the recipes has been set to the wider scope of `forge:dough` as this is also what Create uses.