### PR TITLE
Allow serving meals from a Cooking Pot on a crafting grid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
   - Wild Potatoes now scatter individual Alliums around them, making a more natural bush;
   - Tomato Vines and Wild Potatoes now grow amidst a bush of local foliage;
   - Wild Cabbage and Sea Beet now grow amidst a patch of Sandy Shrub, a new beach plant;
+- You can now take servings from a Cooking Pot directly in a crafting grid, by placing the pot and a valid container on it;
 - Updated a few recipes:
   - Knives are now crafted in a **vertical** arrangement instead of diagonal. This was done to reduce recipe conflicts with other mods;
   - Barbecue on a Stick is now made from any cooked meat! Have your barbecue your way;

--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -824,6 +824,7 @@ be34126249ed7317b23ed824a011cda28cea13f5 data/forge/tags/items/vegetables/beetro
 40627c72fae961ee773ede39523ed65f68568e4c data/forge/tags/items/vegetables/onion.json
 1c951c2bae0947388025fc943118e4bf04fe0393 data/forge/tags/items/vegetables/potato.json
 96372565b5bba2039f97768cc9a924c4197e0947 data/forge/tags/items/vegetables/tomato.json
+7773d4b35e33a943fde5791011ee80a80e5c0e2a data/minecraft/recipes/food_serving.json
 721feacb3244b5607c0a12563963ca72b0be0ca9 data/minecraft/tags/blocks/bamboo_plantable_on.json
 3d08a1b63877a3cd2a803269fca075c549c3efa1 data/minecraft/tags/blocks/carpets.json
 d642d516a8ea6ba5652ec270b8f23d17d469c742 data/minecraft/tags/blocks/climbable.json

--- a/src/generated/resources/data/minecraft/recipes/food_serving.json
+++ b/src/generated/resources/data/minecraft/recipes/food_serving.json
@@ -1,0 +1,3 @@
+{
+  "type": "farmersdelight:food_serving"
+}

--- a/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotRecipeBookComponent.java
+++ b/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotRecipeBookComponent.java
@@ -37,7 +37,9 @@ public class CookingPotRecipeBookComponent extends RecipeBookComponent
 	public void setupGhostRecipe(Recipe<?> recipe, List<Slot> slots) {
 		ItemStack resultStack = recipe.getResultItem();
 		this.ghostRecipe.setRecipe(recipe);
-		this.ghostRecipe.addIngredient(Ingredient.of(resultStack), (slots.get(6)).x, (slots.get(6)).y);
+		if (slots.get(6).getItem().isEmpty()) {
+			this.ghostRecipe.addIngredient(Ingredient.of(resultStack), (slots.get(6)).x, (slots.get(6)).y);
+		}
 
 		if (recipe instanceof CookingPotRecipe cookingRecipe) {
 			ItemStack containerStack = cookingRecipe.getOutputContainer();

--- a/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotScreen.java
+++ b/src/main/java/vectorwing/farmersdelight/client/gui/CookingPotScreen.java
@@ -78,7 +78,7 @@ public class CookingPotScreen extends AbstractContainerScreen<CookingPotMenu> im
 		} else {
 			this.recipeBookComponent.render(ms, mouseX, mouseY, partialTicks);
 			super.render(ms, mouseX, mouseY, partialTicks);
-			this.recipeBookComponent.renderGhostRecipe(ms, this.leftPos, this.topPos, true, partialTicks);
+			this.recipeBookComponent.renderGhostRecipe(ms, this.leftPos, this.topPos, false, partialTicks);
 		}
 
 		this.renderMealDisplayTooltip(ms, mouseX, mouseY);

--- a/src/main/java/vectorwing/farmersdelight/common/block/CookingPotBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/CookingPotBlock.java
@@ -182,21 +182,15 @@ public class CookingPotBlock extends BaseEntityBlock implements SimpleWaterlogge
 	public void appendHoverText(ItemStack stack, @Nullable BlockGetter level, List<Component> tooltip, TooltipFlag flagIn) {
 		super.appendHoverText(stack, level, tooltip, flagIn);
 		CompoundTag nbt = stack.getTagElement("BlockEntityTag");
-		if (nbt != null) {
-			CompoundTag inventoryTag = nbt.getCompound("Inventory");
-			if (inventoryTag.contains("Items", 9)) {
-				ItemStackHandler handler = new ItemStackHandler();
-				handler.deserializeNBT(inventoryTag);
-				ItemStack mealStack = handler.getStackInSlot(6);
-				if (!mealStack.isEmpty()) {
-					MutableComponent textServingsOf = mealStack.getCount() == 1
-							? TextUtils.getTranslation("tooltip.cooking_pot.single_serving")
-							: TextUtils.getTranslation("tooltip.cooking_pot.many_servings", mealStack.getCount());
-					tooltip.add(textServingsOf.withStyle(ChatFormatting.GRAY));
-					MutableComponent textMealName = mealStack.getHoverName().copy();
-					tooltip.add(textMealName.withStyle(mealStack.getRarity().color));
-				}
-			}
+		ItemStack mealStack = CookingPotBlockEntity.getMealFromItem(stack);
+
+		if (!mealStack.isEmpty()) {
+			MutableComponent textServingsOf = mealStack.getCount() == 1
+					? TextUtils.getTranslation("tooltip.cooking_pot.single_serving")
+					: TextUtils.getTranslation("tooltip.cooking_pot.many_servings", mealStack.getCount());
+			tooltip.add(textServingsOf.withStyle(ChatFormatting.GRAY));
+			MutableComponent textMealName = mealStack.getHoverName().copy();
+			tooltip.add(textMealName.withStyle(mealStack.getRarity().color));
 		} else {
 			MutableComponent textEmpty = TextUtils.getTranslation("tooltip.cooking_pot.empty");
 			tooltip.add(textEmpty.withStyle(ChatFormatting.GRAY));

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
@@ -37,6 +37,7 @@ import vectorwing.farmersdelight.common.block.entity.inventory.CookingPotItemHan
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.mixin.accessor.RecipeManagerAccessor;
 import vectorwing.farmersdelight.common.registry.ModBlockEntityTypes;
+import vectorwing.farmersdelight.common.registry.ModItems;
 import vectorwing.farmersdelight.common.registry.ModParticleTypes;
 import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
 import vectorwing.farmersdelight.common.utility.ItemUtils;
@@ -79,6 +80,56 @@ public class CookingPotBlockEntity extends SyncedBlockEntity implements MenuProv
 		this.cookingPotData = createIntArray();
 		this.usedRecipeTracker = new Object2IntOpenHashMap<>();
 		this.checkNewRecipe = true;
+	}
+
+	public static ItemStack getMealFromItem(ItemStack cookingPotStack) {
+		if (!cookingPotStack.is(ModItems.COOKING_POT.get())) {
+			return ItemStack.EMPTY;
+		}
+
+		CompoundTag compound = cookingPotStack.getTagElement("BlockEntityTag");
+		if (compound != null) {
+			CompoundTag inventoryTag = compound.getCompound("Inventory");
+			if (inventoryTag.contains("Items", 9)) {
+				ItemStackHandler handler = new ItemStackHandler();
+				handler.deserializeNBT(inventoryTag);
+				return handler.getStackInSlot(6);
+			}
+		}
+
+		return ItemStack.EMPTY;
+	}
+
+	public static void takeServingFromItem(ItemStack cookingPotStack) {
+		if (!cookingPotStack.is(ModItems.COOKING_POT.get())) {
+			return;
+		}
+
+		CompoundTag compound = cookingPotStack.getTagElement("BlockEntityTag");
+		if (compound != null) {
+			CompoundTag inventoryTag = compound.getCompound("Inventory");
+			if (inventoryTag.contains("Items", 9)) {
+				ItemStackHandler handler = new ItemStackHandler();
+				handler.deserializeNBT(inventoryTag);
+				ItemStack newMealStack = handler.getStackInSlot(6);
+				newMealStack.shrink(1);
+				compound.remove("Inventory");
+				compound.put("Inventory", handler.serializeNBT());
+			}
+		}
+	}
+
+	public static ItemStack getContainerFromItem(ItemStack cookingPotStack) {
+		if (!cookingPotStack.is(ModItems.COOKING_POT.get())) {
+			return ItemStack.EMPTY;
+		}
+
+		CompoundTag compound = cookingPotStack.getTagElement("BlockEntityTag");
+		if (compound != null) {
+			return ItemStack.of(compound.getCompound("Container"));
+		}
+
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/crafting/FoodServingRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/FoodServingRecipe.java
@@ -1,0 +1,101 @@
+package vectorwing.farmersdelight.common.crafting;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CustomRecipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.Level;
+import vectorwing.farmersdelight.common.block.entity.CookingPotBlockEntity;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
+
+public class FoodServingRecipe extends CustomRecipe
+{
+	public FoodServingRecipe(ResourceLocation id) {
+		super(id);
+	}
+
+	@Override
+	public boolean matches(CraftingContainer container, Level level) {
+		ItemStack cookingPotStack = ItemStack.EMPTY;
+		ItemStack containerStack = ItemStack.EMPTY;
+
+		boolean hasFilledCookingPot = false;
+		boolean hasContainer = false;
+
+		for (int i = 0; i < container.getContainerSize(); ++i) {
+			ItemStack selectedStack = container.getItem(i);
+			if (!selectedStack.isEmpty() && selectedStack.is(ModItems.COOKING_POT.get())) {
+				if (hasFilledCookingPot) {
+					return false;
+				}
+				ItemStack mealStack = CookingPotBlockEntity.getMealFromItem(selectedStack);
+				if (mealStack.isEmpty()) {
+					return false;
+				}
+				cookingPotStack = selectedStack;
+				containerStack = CookingPotBlockEntity.getContainerFromItem(selectedStack);
+				hasFilledCookingPot = true;
+			}
+		}
+
+		for (int j = 0; j < container.getContainerSize(); ++j) {
+			ItemStack selectedStack = container.getItem(j);
+			if (!selectedStack.isEmpty()) {
+				if (selectedStack.is(containerStack.getItem()) && !hasContainer) {
+					hasContainer = true;
+				} else if (!selectedStack.equals(cookingPotStack)) {
+					return false;
+				}
+			}
+		}
+
+		return hasFilledCookingPot && hasContainer;
+	}
+
+	@Override
+	public ItemStack assemble(CraftingContainer container) {
+		for (int i = 0; i < container.getContainerSize(); ++i) {
+			ItemStack selectedStack = container.getItem(i);
+			if (!selectedStack.isEmpty() && selectedStack.is(ModItems.COOKING_POT.get())) {
+				ItemStack resultStack = CookingPotBlockEntity.getMealFromItem(selectedStack).copy();
+				resultStack.setCount(1);
+				return resultStack;
+			}
+		}
+
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public NonNullList<ItemStack> getRemainingItems(CraftingContainer container) {
+		NonNullList<ItemStack> remainders = NonNullList.withSize(container.getContainerSize(), ItemStack.EMPTY);
+
+		for (int i = 0; i < remainders.size(); ++i) {
+			ItemStack selectedStack = container.getItem(i);
+			if (selectedStack.hasContainerItem()) {
+				remainders.set(i, selectedStack.getContainerItem());
+			} else if (selectedStack.is(ModItems.COOKING_POT.get())) {
+				CookingPotBlockEntity.takeServingFromItem(selectedStack);
+				ItemStack newCookingPotStack = selectedStack.copy();
+				newCookingPotStack.setCount(1);
+				remainders.set(i, newCookingPotStack);
+				break;
+			}
+		}
+
+		return remainders;
+	}
+
+	@Override
+	public boolean canCraftInDimensions(int width, int height) {
+		return width >= 2 && height >= 2;
+	}
+
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return ModRecipeSerializers.FOOD_SERVING.get();
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/common/crafting/FoodServingRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/FoodServingRecipe.java
@@ -21,38 +21,28 @@ public class FoodServingRecipe extends CustomRecipe
 	public boolean matches(CraftingContainer container, Level level) {
 		ItemStack cookingPotStack = ItemStack.EMPTY;
 		ItemStack containerStack = ItemStack.EMPTY;
+		ItemStack secondStack = ItemStack.EMPTY;
 
-		boolean hasFilledCookingPot = false;
-		boolean hasContainer = false;
-
-		for (int i = 0; i < container.getContainerSize(); ++i) {
-			ItemStack selectedStack = container.getItem(i);
-			if (!selectedStack.isEmpty() && selectedStack.is(ModItems.COOKING_POT.get())) {
-				if (hasFilledCookingPot) {
-					return false;
-				}
-				ItemStack mealStack = CookingPotBlockEntity.getMealFromItem(selectedStack);
-				if (mealStack.isEmpty()) {
-					return false;
-				}
-				cookingPotStack = selectedStack;
-				containerStack = CookingPotBlockEntity.getContainerFromItem(selectedStack);
-				hasFilledCookingPot = true;
-			}
-		}
-
-		for (int j = 0; j < container.getContainerSize(); ++j) {
-			ItemStack selectedStack = container.getItem(j);
+		for (int index = 0; index < container.getContainerSize(); ++index) {
+			ItemStack selectedStack = container.getItem(index);
 			if (!selectedStack.isEmpty()) {
-				if (selectedStack.is(containerStack.getItem()) && !hasContainer) {
-					hasContainer = true;
-				} else if (!selectedStack.equals(cookingPotStack)) {
+				if (cookingPotStack.isEmpty()) {
+					ItemStack mealStack = CookingPotBlockEntity.getMealFromItem(selectedStack);
+					if (!mealStack.isEmpty()) {
+						cookingPotStack = selectedStack;
+						containerStack = CookingPotBlockEntity.getContainerFromItem(selectedStack);
+						continue;
+					}
+				}
+				if (secondStack.isEmpty()) {
+					secondStack = selectedStack;
+				} else {
 					return false;
 				}
 			}
 		}
 
-		return hasFilledCookingPot && hasContainer;
+		return !cookingPotStack.isEmpty() && !secondStack.isEmpty() && secondStack.is(containerStack.getItem());
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeSerializers.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeSerializers.java
@@ -1,12 +1,14 @@
 package vectorwing.farmersdelight.common.registry;
 
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.SimpleRecipeSerializer;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
+import vectorwing.farmersdelight.common.crafting.FoodServingRecipe;
 
 public class ModRecipeSerializers
 {
@@ -14,4 +16,7 @@ public class ModRecipeSerializers
 
 	public static final RegistryObject<RecipeSerializer<?>> COOKING = RECIPE_SERIALIZERS.register("cooking", CookingPotRecipe.Serializer::new);
 	public static final RegistryObject<RecipeSerializer<?>> CUTTING = RECIPE_SERIALIZERS.register("cutting", CuttingBoardRecipe.Serializer::new);
+
+	public static final RegistryObject<SimpleRecipeSerializer<?>> FOOD_SERVING =
+			RECIPE_SERIALIZERS.register("food_serving", () -> new SimpleRecipeSerializer<>(FoodServingRecipe::new));
 }

--- a/src/main/java/vectorwing/farmersdelight/data/recipe/CraftingRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/data/recipe/CraftingRecipes.java
@@ -1,10 +1,7 @@
 package vectorwing.farmersdelight.data.recipe;
 
 import net.minecraft.advancements.critereon.InventoryChangeTrigger;
-import net.minecraft.data.recipes.FinishedRecipe;
-import net.minecraft.data.recipes.ShapedRecipeBuilder;
-import net.minecraft.data.recipes.ShapelessRecipeBuilder;
-import net.minecraft.data.recipes.UpgradeRecipeBuilder;
+import net.minecraft.data.recipes.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
@@ -15,6 +12,7 @@ import net.minecraftforge.common.Tags;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
 import vectorwing.farmersdelight.common.tag.ForgeTags;
 import vectorwing.farmersdelight.common.tag.ModTags;
 
@@ -32,6 +30,7 @@ public class CraftingRecipes
 		recipesFoodstuffs(consumer);
 		recipesFoodBlocks(consumer);
 		recipesCraftedMeals(consumer);
+		SpecialRecipeBuilder.special(ModRecipeSerializers.FOOD_SERVING.get()).save(consumer, "food_serving");
 	}
 
 


### PR DESCRIPTION
You can now take servings from a Cooking Pot directly in a crafting grid, by placing the pot and a valid container on it.