### PR TITLE
Update support for Botany Pots.

### DIFF
--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/brown_mushroom_colony.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/brown_mushroom_colony.json
@@ -1,0 +1,36 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "botanypots"
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "farmersdelight:brown_mushroom_colony"
+  },
+  "categories": ["mushroom"],
+  "growthTicks": 1400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "farmersdelight:brown_mushroom_colony"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "minecraft:brown_mushroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 3
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:brown_mushroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/cabbages.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/cabbages.json
@@ -10,21 +10,19 @@
     "item": "farmersdelight:cabbage_seeds"
   },
   "categories": ["dirt"],
-  "growthTicks": 1000,
+  "growthTicks": 1200,
   "display": {
-    "block": "farmersdelight:cabbages",
-    "properties": {
-      "age": 7
-    }
+    "type": "botanypots:aging",
+    "block": "farmersdelight:cabbages"
   },
-  "results": [
+  "drops": [
     {
-      "chance": 0.75,
+      "chance": 1.00,
       "output": {
         "item": "farmersdelight:cabbage"
       },
       "minRolls": 1,
-      "maxRolls": 1
+      "maxRolls": 2
     },
     {
       "chance": 0.05,

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/onions.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/onions.json
@@ -10,16 +10,14 @@
     "item": "farmersdelight:onion"
   },
   "categories": ["dirt"],
-  "growthTicks": 1000,
+  "growthTicks": 1200,
   "display": {
-    "block": "farmersdelight:onions",
-    "properties": {
-      "age": 7
-    }
+    "type": "botanypots:aging",
+    "block": "farmersdelight:onions"
   },
-  "results": [
+  "drops": [
     {
-      "chance": 0.75,
+      "chance": 1.00,
       "output": {
         "item": "farmersdelight:onion"
       },

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/red_mushroom_colony.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/red_mushroom_colony.json
@@ -1,0 +1,36 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "botanypots"
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "farmersdelight:red_mushroom_colony"
+  },
+  "categories": ["mushroom"],
+  "growthTicks": 1400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "farmersdelight:red_mushroom_colony"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "minecraft:red_mushroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 3
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:red_mushroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/rice_crop.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/rice_crop.json
@@ -10,16 +10,14 @@
     "item": "farmersdelight:rice"
   },
   "categories": ["dirt"],
-  "growthTicks": 1000,
+  "growthTicks": 1200,
   "display": {
-    "block": "farmersdelight:rice_panicles",
-    "properties": {
-      "age": 3
-    }
+    "type": "botanypots:aging",
+    "block": "farmersdelight:rice_panicles"
   },
-  "results": [
+  "drops": [
     {
-      "chance": 0.75,
+      "chance": 1.00,
       "output": {
         "item": "farmersdelight:rice_panicle"
       },

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/tomatoes.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/crops/tomatoes.json
@@ -10,21 +10,19 @@
     "item": "farmersdelight:tomato_seeds"
   },
   "categories": ["dirt"],
-  "growthTicks": 1000,
+  "growthTicks": 1200,
   "display": {
-    "block": "farmersdelight:tomatoes",
-    "properties": {
-      "age": 7
-    }
+    "type": "botanypots:aging",
+    "block": "farmersdelight:tomatoes"
   },
-  "results": [
+  "drops": [
     {
-      "chance": 0.75,
+      "chance": 1.00,
       "output": {
         "item": "farmersdelight:tomato"
       },
       "minRolls": 1,
-      "maxRolls": 1
+      "maxRolls": 2
     },
     {
       "chance": 0.05,

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/soil/rich_soil.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/soil/rich_soil.json
@@ -13,5 +13,5 @@
     "block": "farmersdelight:rich_soil"
   },
   "categories": ["dirt", "grass", "podzol", "mushroom"],
-  "growthModifier": 0.10
+  "growthModifier": 1.10
 }

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypots/soil/rich_soil_farmland.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypots/soil/rich_soil_farmland.json
@@ -16,5 +16,5 @@
     }
   },
   "categories": ["dirt", "farmland"],
-  "growthModifier": 0.25
+  "growthModifier": 1.25
 }


### PR DESCRIPTION
There were a few changes to the BotanyPots schema so the existing crops would fail to load and the soils would have inverted growth rates. This PR fixes those issues and adds support for the mushroom colonies. 