### PR TITLE
Add Botany Pots Tiers Support

### DIFF
--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/brown_mushroom_colony.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/brown_mushroom_colony.json
@@ -1,0 +1,37 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:crop",
+    "seed": {
+      "item": "farmersdelight:brown_mushroom_colony"
+    },
+    "categories": ["mushroom"],
+    "growthTicks": 1400,
+    "display": {
+      "type": "botanypotstiers:aging",
+      "block": "farmersdelight:brown_mushroom_colony"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:brown_mushroom"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "minecraft:brown_mushroom"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      }
+    ]
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/cabbages.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/cabbages.json
@@ -1,0 +1,45 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:crop",
+    "seed": {
+      "item": "farmersdelight:cabbage_seeds"
+    },
+    "categories": ["dirt"],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypotstiers:aging",
+      "block": "farmersdelight:cabbages"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersdelight:cabbage"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersdelight:cabbage"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersdelight:cabbage_seeds"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      }
+    ]
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/onions.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/onions.json
@@ -1,0 +1,37 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:crop",
+    "seed": {
+      "item": "farmersdelight:onion"
+    },
+    "categories": ["dirt"],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypotstiers:aging",
+      "block": "farmersdelight:onions"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersdelight:onion"
+        },
+        "minRolls": 1,
+        "maxRolls": 1
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersdelight:onion"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      }
+    ]
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/red_mushroom_colony.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/red_mushroom_colony.json
@@ -1,0 +1,37 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:crop",
+    "seed": {
+      "item": "farmersdelight:red_mushroom_colony"
+    },
+    "categories": ["mushroom"],
+    "growthTicks": 1400,
+    "display": {
+      "type": "botanypotstiers:aging",
+      "block": "farmersdelight:red_mushroom_colony"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:red_mushroom"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "minecraft:red_mushroom"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      }
+    ]
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/rice_crop.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/rice_crop.json
@@ -1,0 +1,36 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "botanypotstiers"
+    }
+  ],
+  "type": "botanypotstiers:crop",
+  "seed": {
+    "item": "farmersdelight:rice"
+  },
+  "categories": ["dirt"],
+  "growthTicks": 1200,
+  "display": {
+    "type": "botanypotstiers:aging",
+    "block": "farmersdelight:rice_panicles"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "farmersdelight:rice_panicle"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "farmersdelight:rice_panicle"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/tomatoes.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/crops/tomatoes.json
@@ -1,0 +1,45 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:crop",
+    "seed": {
+      "item": "farmersdelight:tomato_seeds"
+    },
+    "categories": ["dirt"],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypotstiers:aging",
+      "block": "farmersdelight:tomatoes"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersdelight:tomato"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersdelight:tomato"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersdelight:tomato_seeds"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      }
+    ]
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/soil/rich_soil.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/soil/rich_soil.json
@@ -1,0 +1,18 @@
+{
+    "conditions": [
+      {
+        "type": "forge:mod_loaded",
+        "modid": "botanypotstiers"
+      }
+    ],
+    "type": "botanypotstiers:soil",
+    "input": {
+      "item": "farmersdelight:rich_soil"
+    },
+    "display": {
+      "block": "farmersdelight:rich_soil"
+    },
+    "categories": ["dirt", "grass", "podzol", "mushroom"],
+    "growthModifier": 1.10
+  }
+  

--- a/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/soil/rich_soil_farmland.json
+++ b/src/main/resources/data/farmersdelight/recipes/integration/botanypotstiers/soil/rich_soil_farmland.json
@@ -1,0 +1,20 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "botanypotstiers"
+    }
+  ],
+  "type": "botanypotstiers:soil",
+  "input": {
+    "item": "farmersdelight:rich_soil_farmland"
+  },
+  "display": {
+    "block": "farmersdelight:rich_soil_farmland",
+    "properties": {
+      "moisture": 7
+    }
+  },
+  "categories": ["dirt", "farmland"],
+  "growthModifier": 1.25
+}


### PR DESCRIPTION
Greetings. This pull request will be a simple one ahead of the 1.18 update. All this does is add support to the mod Botany Pots Tiers. It has been tested and works properly. 