### PR TITLE
Fix candle cakes not dropping slices

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/loot/modifier/PastrySlicingModifier.java
+++ b/src/main/java/vectorwing/farmersdelight/common/loot/modifier/PastrySlicingModifier.java
@@ -8,6 +8,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.CakeBlock;
+import net.minecraft.world.level.block.CandleCakeBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -51,6 +52,8 @@ public class PastrySlicingModifier extends LootModifier
 			if (targetBlock instanceof CakeBlock) {
 				int bites = state.getValue(CakeBlock.BITES);
 				generatedLoot.add(new ItemStack(pastrySlice, MAX_CAKE_BITES - bites));
+			} else if (targetBlock instanceof CandleCakeBlock) {
+				generatedLoot.add(new ItemStack(pastrySlice, MAX_CAKE_BITES));
 			} else if (targetBlock instanceof PieBlock) {
 				int bites = state.getValue(PieBlock.BITES);
 				generatedLoot.add(new ItemStack(pastrySlice, MAX_PIE_BITES - bites));

--- a/src/main/resources/data/farmersdelight/loot_modifiers/slicing_cake.json
+++ b/src/main/resources/data/farmersdelight/loot_modifiers/slicing_cake.json
@@ -8,8 +8,81 @@
       }
     },
     {
-      "condition": "minecraft:block_state_property",
-      "block": "minecraft:cake"
+      "condition": "minecraft:alternative",
+      "terms":[
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:white_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:orange_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:magenta_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:light_blue_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:yellow_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:lime_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:pink_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:gray_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:light_gray_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:cyan_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:purple_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:blue_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:brown_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:green_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:red_candle_cake"
+        },
+        {
+          "condition": "minecraft:block_state_property",
+          "block": "minecraft:black_candle_cake"
+        }
+      ]
     }
   ],
   "slice": "farmersdelight:cake_slice"


### PR DESCRIPTION
This PR adds cakes with candles to `loot_modifiers/slicing_cake.json`.

Fixes #631