### PR TITLE
Fix hand-held skillet ingredient rendering

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/client/model/SkilletModel.java
+++ b/src/main/java/vectorwing/farmersdelight/client/model/SkilletModel.java
@@ -17,11 +17,14 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.model.SimpleModelState;
+import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.FarmersDelight;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import vectorwing.farmersdelight.common.registry.ModItems;
+
 import java.util.*;
 
 /**
@@ -140,18 +143,22 @@ public class SkilletModel implements BakedModel
 			}
 
 			RandomSource rand = RandomSource.create(0);
-			genQuads.addAll(ingredientBaked.getQuads(null, null, rand));
+			for (BakedModel pass : ingredientBaked.getRenderPasses(ingredientStack, false)) {
+				genQuads.addAll(pass.getQuads(null, null, rand, ModelData.EMPTY, null));
 
-			for (Direction e : Direction.values()) {
-				rand.setSeed(0);
-				faceQuads.get(e).addAll(ingredientBaked.getQuads(null, e, rand));
+				for (Direction e : Direction.values()) {
+					rand.setSeed(0);
+					faceQuads.get(e).addAll(pass.getQuads(null, e, rand, ModelData.EMPTY, null));
+				}
 			}
 
-			rand.setSeed(0);
-			genQuads.addAll(skillet.getQuads(null, null, rand));
-			for (Direction e : Direction.values()) {
+			for (BakedModel pass : skillet.getRenderPasses(ModItems.SKILLET.get().getDefaultInstance(), false)) {
 				rand.setSeed(0);
-				faceQuads.get(e).addAll(skillet.getQuads(null, e, rand));
+				genQuads.addAll(pass.getQuads(null, null, rand, ModelData.EMPTY, null));
+				for (Direction e : Direction.values()) {
+					rand.setSeed(0);
+					faceQuads.get(e).addAll(pass.getQuads(null, e, rand, ModelData.EMPTY, null));
+				}
 			}
 		}
 

--- a/src/main/java/vectorwing/farmersdelight/client/model/WrappedItemModel.java
+++ b/src/main/java/vectorwing/farmersdelight/client/model/WrappedItemModel.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public class WrappedItemModel<T extends BakedModel> extends BakedModelWrapper<T>
 {
+	private final List<BakedModel> renderPasses = List.of(this);
+
 	public WrappedItemModel(T originalModel) {
 		super(originalModel);
 	}
@@ -27,6 +29,6 @@ public class WrappedItemModel<T extends BakedModel> extends BakedModelWrapper<T>
 
 	@Override
 	public List<BakedModel> getRenderPasses(ItemStack itemStack, boolean fabulous) {
-		return List.of(this);
+		return renderPasses;
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/client/model/WrappedItemModel.java
+++ b/src/main/java/vectorwing/farmersdelight/client/model/WrappedItemModel.java
@@ -3,7 +3,10 @@ package vectorwing.farmersdelight.client.model;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.model.BakedModelWrapper;
+
+import java.util.List;
 
 public class WrappedItemModel<T extends BakedModel> extends BakedModelWrapper<T>
 {
@@ -20,5 +23,10 @@ public class WrappedItemModel<T extends BakedModel> extends BakedModelWrapper<T>
 	public BakedModel applyTransform(ItemTransforms.TransformType cameraTransformType, PoseStack poseStack, boolean applyLeftHandTransform) {
 		BakedModel model = super.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform);
 		return model.equals(this) || model instanceof WrappedItemModel ? this : new WrappedItemModel<>(model);
+	}
+
+	@Override
+	public List<BakedModel> getRenderPasses(ItemStack itemStack, boolean fabulous) {
+		return List.of(this);
 	}
 }


### PR DESCRIPTION
_The diff is a joke, really._

fixes #515

---

Story time:

So basically I don't really know if what I did is clean or not. I simply did a good 30min Java debugger session to understand the different steps involved in rendering items (especially the skillet), and found out that `CompositeBakedModel::getQuads` was never called. That's an issue because there's no other way the Minecraft Item renderer could possibly know how to draw this dynamic skillet model. It needs to call `CompositeBakedModel::getQuads` at some point.

What the debugger taught me is that when rendering items, a double for loop iterates over `BakedModel::getRenderPasses` instead of directly calling `getQuads`[^note1]. And `BakedModel::getRenderPasses` returns an array of BakedModel. And its these secondary baked models whose quads are actually rendered (that makes no sense to me).

My fix, as you can see, is to just return `List.of(this)` inside `getRenderPasses`. I don't know if that's safe or if that will infinitely recurse one day. Again, I don't fully understand the logic behind nesting models.

At least the fix works, and I can't immediately think of any edge case where it would break, so I don't feel _too_ shameful about submitting code I don't fully understand. Maybe someone here who knows more about model baking will be able to sort this out?

[^note1]: In `ItemRenderer::render`, L131