### PR TITLE
Fix Create's Harvester not consuming Tomato Seeds when replanting

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModItems.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModItems.java
@@ -186,7 +186,19 @@ public class ModItems
 	public static final RegistryObject<Item> RICE = ITEMS.register("rice",
 			() -> new RiceItem(ModBlocks.RICE_CROP.get(), basicItem()));
 	public static final RegistryObject<Item> CABBAGE_SEEDS = ITEMS.register("cabbage_seeds", () -> new ItemNameBlockItem(ModBlocks.CABBAGE_CROP.get(), basicItem()));
-	public static final RegistryObject<Item> TOMATO_SEEDS = ITEMS.register("tomato_seeds", () -> new ItemNameBlockItem(ModBlocks.BUDDING_TOMATO_CROP.get(), basicItem()));
+	public static final RegistryObject<Item> TOMATO_SEEDS = ITEMS.register("tomato_seeds", () -> new ItemNameBlockItem(ModBlocks.BUDDING_TOMATO_CROP.get(), basicItem()) {
+            @Override
+            public void registerBlocks(Map<Block, Item> blockToItemMap, Item item) {
+                super.registerBlocks(blockToItemMap, item);
+                blockToItemMap.put(ModBlocks.TOMATO_CROP.get(), item);
+            }
+
+            @Override
+            public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
+                super.removeFromBlockToItemMap(blockToItemMap, itemIn);
+                blockToItemMap.remove(ModBlocks.TOMATO_CROP.get());
+            }
+        });
 	public static final RegistryObject<Item> ROTTEN_TOMATO = ITEMS.register("rotten_tomato",
 			() -> new RottenTomatoItem(new Item.Properties().stacksTo(16).tab(FarmersDelight.CREATIVE_TAB)));
 


### PR DESCRIPTION
This should fix the problem of Create's Harvester not consuming Tomato Seeds when replanting.
[Create](https://github.com/Creators-of-Create/Create/blob/40f96b0038a91de7c50eb1ead0c4d4477000dab4/src/main/java/com/simibubi/create/content/contraptions/components/actors/HarvesterMovementBehaviour.java#L96-L105) uses the following logic to check if the dropped items from a crop is its seed, and thus consuming 1 of it from the drops for replanting:
```java
MutableBoolean seedSubtracted = new MutableBoolean(notCropButCuttable);
BlockState state = stateVisited;
BlockHelper.destroyBlockAs(world, pos, null, item, effectChance, stack -> {
	if (AllConfigs.SERVER.kinetics.harvesterReplants.get() && !seedSubtracted.getValue()
		&& stack.sameItem(new ItemStack(state.getBlock()))) {
		stack.shrink(1);
		seedSubtracted.setTrue();
	}
	dropItem(context, stack);
});
```
Actually, `stack.sameItem(new ItemStack(state.getBlock()))` checks if the dropped item is same as the crop block's item, which in normal cases should be the seeds.
However, the Grown Tomato Vine(`farmersdelight:tomatoes`) has no corresponding item, so the check always fails and the Tomato Seeds will never be consumed in replanting.
This PR registered `farmersdelight:tomato_seeds` as `farmersdelight:tomatoes`'s item, which should fix the problem.

P.S. I don't know if any other player has noticed this tiny problem yet, but I discovered this by accident when testing my code about providing Harvester support for Farmer's Respite's crops :P
P.P.S As I (LimonBlaze) was a past contributor listed in FD's `mods.toml`, it would be nice to see the id being updated to my currently used one :P