### PR TITLE
Added configuration option for hitboxes for some crops 

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/Configuration.java
+++ b/src/main/java/vectorwing/farmersdelight/common/Configuration.java
@@ -25,6 +25,7 @@ public class Configuration
 	public static final String CATEGORY_FARMING = "farming";
 	public static ForgeConfigSpec.ConfigValue<String> DEFAULT_TOMATO_VINE_ROPE;
 	public static ForgeConfigSpec.BooleanValue ENABLE_TOMATO_VINE_CLIMBING_TAGGED_ROPES;
+	public static ForgeConfigSpec.BooleanValue ENABLE_NARROW_CROP_HITBOXES;
 
 	public static final String CATEGORY_RECIPE_BOOK = "recipe_book";
 	public static ForgeConfigSpec.BooleanValue ENABLE_RECIPE_BOOK_COOKING_POT;
@@ -95,6 +96,8 @@ public class Configuration
 		ENABLE_TOMATO_VINE_CLIMBING_TAGGED_ROPES = COMMON_BUILDER.comment("Should tomato vines be able to climb any rope tagged as farmersdelight:ropes?",
 						"Beware: this will convert these blocks into the block specified in defaultTomatoVineRope.")
 				.define("enableTomatoVineClimbingTaggedRopes", true);
+		ENABLE_NARROW_CROP_HITBOXES = COMMON_BUILDER.comment("Should crops blocks use narrower hitboxes that follow their rendered size closer?")
+				.define("enableNarrowCropHitboxes", false);
 		COMMON_BUILDER.pop();
 
 		COMMON_BUILDER.comment("Recipe book").push(CATEGORY_RECIPE_BOOK);

--- a/src/main/java/vectorwing/farmersdelight/common/block/BuddingTomatoBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/BuddingTomatoBlock.java
@@ -8,15 +8,37 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import vectorwing.farmersdelight.common.Configuration;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 
 public class BuddingTomatoBlock extends BuddingBushBlock implements BonemealableBlock
 {
+	private static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
+			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 2.0D, 16.0D),
+			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 6.0D, 16.0D),
+			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 10.0D, 16.0D),
+			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 14.0D, 16.0D),
+			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 14.0D, 16.0D)};
+	private static final VoxelShape[] NARROW_SHAPE_BY_AGE = new VoxelShape[]{
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 2.0D, 12.0D),
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 6.0D, 12.0D),
+			Block.box(3.0D, 0.0D, 3.0D, 13.0D, 10.0D, 13.0D),
+			Block.box(2.0D, 0.0D, 3.0D, 13.0D, 14.0D, 13.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 14.0D, 14.0D)};
+
 	public BuddingTomatoBlock(Properties properties) {
 		super(properties);
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+		return Configuration.ENABLE_NARROW_CROP_HITBOXES.get() ? NARROW_SHAPE_BY_AGE[state.getValue(this.getAgeProperty())] : SHAPE_BY_AGE[state.getValue(this.getAgeProperty())];
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/CabbageBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/CabbageBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import vectorwing.farmersdelight.common.Configuration;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.registry.ModItems;
 
@@ -26,6 +27,17 @@ public class CabbageBlock extends CropBlock
 			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 10.0D, 16.0D)
 	};
 
+	private static final VoxelShape[] NARROW_SHAPE_BY_AGE = new VoxelShape[]{
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 2.0D, 12.0D),
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 3.0D, 12.0D),
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 5.0D, 12.0D),
+			Block.box(4.0D, 0.0D, 4.0D, 12.0D, 7.0D, 12.0D),
+			Block.box(3.0D, 0.0D, 3.0D, 13.0D, 8.0D, 13.0D),
+			Block.box(3.0D, 0.0D, 3.0D, 13.0D, 9.0D, 13.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 9.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 10.0D, 14.0D)
+	};
+
 	public CabbageBlock(Properties properties) {
 		super(properties);
 	}
@@ -42,6 +54,6 @@ public class CabbageBlock extends CropBlock
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return SHAPE_BY_AGE[state.getValue(this.getAgeProperty())];
+		return Configuration.ENABLE_NARROW_CROP_HITBOXES.get() ? NARROW_SHAPE_BY_AGE[state.getValue(this.getAgeProperty())] : SHAPE_BY_AGE[state.getValue(this.getAgeProperty())];
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/OnionBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/OnionBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import vectorwing.farmersdelight.common.Configuration;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.registry.ModItems;
 
@@ -26,6 +27,17 @@ public class OnionBlock extends CropBlock
 			Block.box(0.0D, 0.0D, 0.0D, 16.0D, 9.0D, 16.0D)
 	};
 
+	private static final VoxelShape[] NARROW_SHAPE_BY_AGE = new VoxelShape[]{
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 2.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 3.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 5.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 6.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 7.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 8.0D, 14.0D),
+			Block.box(2.0D, 0.0D, 2.0D, 14.0D, 9.0D, 14.0D)
+	};
+
 	public OnionBlock(Properties properties) {
 		super(properties);
 	}
@@ -42,6 +54,6 @@ public class OnionBlock extends CropBlock
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return SHAPE_BY_AGE[state.getValue(this.getAgeProperty())];
+		return Configuration.ENABLE_NARROW_CROP_HITBOXES.get() ? NARROW_SHAPE_BY_AGE[state.getValue(this.getAgeProperty())] : SHAPE_BY_AGE[state.getValue(this.getAgeProperty())];
 	}
 }


### PR DESCRIPTION
Hitboxes for the crops (tomato, cabbage, and onion) closer follow the rendering of the crops. Config option defaults to false.