### PR TITLE
Add non object ingredient support for cutting recipes

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/crafting/CuttingBoardRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/CuttingBoardRecipe.java
@@ -150,8 +150,7 @@ public class CuttingBoardRecipe implements Recipe<RecipeWrapper>
 		public CuttingBoardRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
 			final String groupIn = GsonHelper.getAsString(json, "group", "");
 			final NonNullList<Ingredient> inputItemsIn = readIngredients(GsonHelper.getAsJsonArray(json, "ingredients"));
-			final JsonObject toolObject = GsonHelper.getAsJsonObject(json, "tool");
-			final Ingredient toolIn = Ingredient.fromJson(toolObject);
+			final Ingredient toolIn = Ingredient.fromJson(json.get("tool"));
 			if (inputItemsIn.isEmpty()) {
 				throw new JsonParseException("No ingredients for cutting recipe");
 			} else if (toolIn.isEmpty()) {


### PR DESCRIPTION
This essentially is just Forge [CompoundIngredient](https://docs.minecraftforge.net/en/1.18.x/resources/server/recipes/ingredients/#compoundingredient) support, does not change functionality for anything else in the mod, and all current recipes are compatible.