### PR TITLE
An option that lets Deployers not place items on Cutting Boards

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/Configuration.java
+++ b/src/main/java/vectorwing/farmersdelight/common/Configuration.java
@@ -21,6 +21,7 @@ public class Configuration
 	public static ForgeConfigSpec.DoubleValue CUTTING_BOARD_FORTUNE_BONUS;
 	public static ForgeConfigSpec.BooleanValue ENABLE_ROPE_REELING;
 	public static ForgeConfigSpec.ConfigValue<List<? extends String>> CANVAS_SIGN_DARK_BACKGROUND_LIST;
+	public static ForgeConfigSpec.BooleanValue DEPLOYER_PLACES_ITEM_ON_CUTTING_BOARD;
 
 	public static final String CATEGORY_FARMING = "farming";
 	public static ForgeConfigSpec.ConfigValue<String> DEFAULT_TOMATO_VINE_ROPE;
@@ -87,6 +88,8 @@ public class Configuration
 		CANVAS_SIGN_DARK_BACKGROUND_LIST = COMMON_BUILDER.comment("A list of dye colors that, when used as the background of a Canvas Sign, should default to white text when placed.",
 						"Dyes: [\"white\", \"orange\", \"magenta\", \"light_blue\", \"yellow\", \"lime\", \"pink\", \"gray\", \"light_gray\", \"cyan\", \"purple\", \"blue\", \"brown\", \"green\", \"red\", \"black\"]")
 				.defineList("canvasSignDarkBackgroundList", ImmutableList.of("gray", "purple", "blue", "brown", "green", "red", "black"), obj -> true);
+		DEPLOYER_PLACES_ITEM_ON_CUTTING_BOARD = COMMON_BUILDER.comment("Should the Deployer from Create mod be able to place held item on Cutting Boards? (if set to false, it will be able to process Cutting Board recipes)")
+				.define("deployerPlacesItemOnCuttingBoard", false);
 		COMMON_BUILDER.pop();
 
 		COMMON_BUILDER.comment("Farming").push(CATEGORY_FARMING);

--- a/src/main/java/vectorwing/farmersdelight/common/block/CuttingBoardBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/CuttingBoardBlock.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -27,7 +28,6 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -36,17 +36,20 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.Configuration;
 import vectorwing.farmersdelight.common.block.entity.CuttingBoardBlockEntity;
 import vectorwing.farmersdelight.common.registry.ModBlockEntityTypes;
 import vectorwing.farmersdelight.common.tag.ModTags;
 
 import javax.annotation.Nullable;
+import java.util.UUID;
 
 @SuppressWarnings("deprecation")
 public class CuttingBoardBlock extends BaseEntityBlock implements SimpleWaterloggedBlock
 {
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
+	// public static final UUID DEPLOYER_UUID = UUID.fromString("9e2faded-cafe-4ec2-c314-dad129ae971d");
 
 	protected static final VoxelShape SHAPE = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 1.0D, 15.0D);
 
@@ -98,6 +101,11 @@ public class CuttingBoardBlock extends BaseEntityBlock implements SimpleWaterlog
 					}
 				}
 				if (heldStack.isEmpty()) {
+					return InteractionResult.PASS;
+				} else if (player.getDisplayName().equals(new TranslatableComponent("create.block.deployer.damage_source_name"))
+						&& !(Configuration.DEPLOYER_PLACES_ITEM_ON_CUTTING_BOARD.get())) {
+					// Due to how Create's code was written to let Deployers work in protected areas, we can only check the name of entity to see if we should let it do anything
+					FarmersDelight.LOGGER.info("DEPLOYER DETECTED");
 					return InteractionResult.PASS;
 				} else if (cuttingBoardEntity.addItem(player.getAbilities().instabuild ? heldStack.copy() : heldStack)) {
 					level.playSound(null, pos.getX(), pos.getY(), pos.getZ(), SoundEvents.WOOD_PLACE, SoundSource.BLOCKS, 1.0F, 0.8F);


### PR DESCRIPTION
A new option that determines if Create Deployers should be able to place items on Cutting Boards or not (false by default). This makes automating Cutting Board recipes easier (or actually just makes it able to really automate them?).

As tested:
- Using the same ingrediants for cutting is about 13.3% faster than deploying
- Axes on the boards are basically the same speed as Mechanical Saw cutting, while they require tools and cost durability

Due to how Create's new code was written to prevent Deployers from not working in protected chunks, so far it's using the display name to detect if the player entity using the board is a Deployer or not. Thanks!