### PR TITLE
Subclassable Recipe Builders

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
@@ -103,9 +103,14 @@ public class CookingPotRecipeBuilder
 		return this;
 	}
 
+	protected String getDefaultRecipeName(ResourceLocation resultItemKey) {
+		return FarmersDelight.MODID + ":cooking/" + resultItemKey.getPath();
+	}
+
 	public void build(Consumer<FinishedRecipe> consumerIn) {
 		ResourceLocation location = ForgeRegistries.ITEMS.getKey(result);
-		build(consumerIn, FarmersDelight.MODID + ":cooking/" + location.getPath());
+		assert location != null;
+		build(consumerIn, getDefaultRecipeName(location));
 	}
 
 	public void build(Consumer<FinishedRecipe> consumerIn, String save) {

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
@@ -41,7 +41,7 @@ public class CookingPotRecipeBuilder
 	private final Item container;
 	private final Advancement.Builder advancement = Advancement.Builder.advancement();
 
-	private CookingPotRecipeBuilder(ItemLike resultIn, int count, int cookingTime, float experience, @Nullable ItemLike container) {
+	protected CookingPotRecipeBuilder(ItemLike resultIn, int count, int cookingTime, float experience, @Nullable ItemLike container) {
 		this.result = resultIn.asItem();
 		this.count = count;
 		this.cookingTime = cookingTime;

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CookingPotRecipeBuilder.java
@@ -115,7 +115,8 @@ public class CookingPotRecipeBuilder
 
 	public void build(Consumer<FinishedRecipe> consumerIn, String save) {
 		ResourceLocation resourcelocation = ForgeRegistries.ITEMS.getKey(result);
-		if ((new ResourceLocation(save)).equals(resourcelocation)) {
+		assert resourcelocation != null;
+		if (save.equals(getDefaultRecipeName(resourcelocation))) {
 			throw new IllegalStateException("Cooking Recipe " + save + " should remove its 'save' argument");
 		} else {
 			build(consumerIn, new ResourceLocation(save));

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -90,7 +90,8 @@ public class CuttingBoardRecipeBuilder
 
 	public void build(Consumer<FinishedRecipe> consumerIn, String save) {
 		ResourceLocation resourcelocation = ForgeRegistries.ITEMS.getKey(this.ingredient.getItems()[0].getItem());
-		if ((new ResourceLocation(save)).equals(resourcelocation)) {
+		assert resourcelocation != null;
+		if (save.equals(getDefaultRecipeName(resourcelocation))) {
 			throw new IllegalStateException("Cutting Recipe " + save + " should remove its 'save' argument");
 		} else {
 			this.build(consumerIn, new ResourceLocation(save));

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -29,7 +29,7 @@ public class CuttingBoardRecipeBuilder
 	private final Ingredient tool;
 	private String soundEventID;
 
-	private CuttingBoardRecipeBuilder(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
+	protected CuttingBoardRecipeBuilder(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
 		this.results.add(new ChanceResult(new ItemStack(mainResult.asItem(), count), chance));
 		this.ingredient = ingredient;
 		this.tool = tool;

--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -79,9 +79,13 @@ public class CuttingBoardRecipeBuilder
 		return this;
 	}
 
+	protected String getDefaultRecipeName(ResourceLocation ingredientItemKey) {
+		return FarmersDelight.MODID + ":cutting/" + ingredientItemKey.getPath();
+	}
+
 	public void build(Consumer<FinishedRecipe> consumerIn) {
 		ResourceLocation location = ForgeRegistries.ITEMS.getKey(this.ingredient.getItems()[0].getItem());
-		this.build(consumerIn, FarmersDelight.MODID + ":cutting/" + location.getPath());
+		this.build(consumerIn, getDefaultRecipeName(location));
 	}
 
 	public void build(Consumer<FinishedRecipe> consumerIn, String save) {


### PR DESCRIPTION
When an addon mod for Farmer's Delight (Farmer's Respite, Nether's Delight, etc) want to register a `CuttingBoardRecipe` or `CookingPotRecipe`, they cannot subclass the existing recipe builders as their constructors are private. That means developers are limited to 
- ~~making an access transformer that modifies the recipe builders' constructor~~ (access transformers do not work on other mods)
- copy + pasting the implementation of the recipe builder (present solution 😭)

This PR enables subclassing the recipe builders, for example
```java
package umpaz.nethersdelight.data.builder;

import net.minecraft.MethodsReturnNonnullByDefault;
import net.minecraft.resources.ResourceLocation;
import net.minecraft.world.level.ItemLike;

import javax.annotation.Nullable;
import javax.annotation.ParametersAreNonnullByDefault;

@ParametersAreNonnullByDefault
@MethodsReturnNonnullByDefault
class NethersDelightCookingPotRecipeBuilder extends CookingPotRecipeBuilder {
    protected NethersDelightCookingPotRecipeBuilder(ItemLike resultIn, int count, int cookingTime, float experience, @Nullable ItemLike container) {
        super(resultIn, count, cookingTime, experience, container);
    }

    public static NethersDelightCookingPotRecipeBuilder cookingPotRecipe(ItemLike mainResult, int count, int cookingTime, float experience) {
        return new NethersDelightCookingPotRecipeBuilder(mainResult, count, cookingTime, experience, null);
    }

    public static NethersDelightCookingPotRecipeBuilder cookingPotRecipe(ItemLike mainResult, int count, int cookingTime, float experience, ItemLike container) {
        return new NethersDelightCookingPotRecipeBuilder(mainResult, count, cookingTime, experience, container);
    }

    @Override
    protected String getDefaultRecipeName(ResourceLocation resultItemKey) {
        return "nethersdelight" + ":cooking/" + resultItemKey.getPath();
    }
}
```

This is achieved by making the constructors `protected` and providing an overridable method `getDefaultRecipeName` on each RecipeBuilder.