### PR TITLE
added translation for british english

### DIFF
--- a/src/main/resources/assets/farmersdelight/lang/en_gb.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_gb.json
@@ -1,0 +1,4 @@
+{
+  "block.farmersdelight.gray_canvas_sign": "Grey Canvas Sign",
+  "block.farmersdelight.light_gray_canvas_sign": "Light Grey Canvas Sign"
+}


### PR DESCRIPTION
gray canvas signs are now called grey canvas signs when using the british translation 
since that was missing (light grey canvas signs are also included in this)