### PR TITLE
[Mod Integration][Botania] Make Pies edible for Kekimurus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ mixin {
     add sourceSets.main, "farmersdelight.refmap.json"
 }
 
+jarJar.enable()
+
 version = "${mc_version}-${mod_version}"
 group = 'vectorwing.farmersdelight' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'FarmersDelight'
@@ -97,6 +99,7 @@ minecraft {
 }
 
 repositories {
+    mavenCentral()
     maven {
         // JEI
         name = "Progwml6 maven"
@@ -116,6 +119,11 @@ sourceSets.main.resources {
 
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
+
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.5"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:${mixinextras_version}")) {
+        jarJar.ranged(it, "[${mixinextras_version},)")
+    }
 
     // compile against the JEI API but do not include it at runtime
     compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")
@@ -139,27 +147,42 @@ dependencies {
 
 }
 
-jar {
-    manifest {
-        attributes([
-                "Specification-Title"     : "farmersdelight",
-                "Specification-Vendor"    : "vectorwing",
-                "Specification-Version"   : "1", // We are version 1 of ourselves
-                "Implementation-Title"    : project.name,
-                "Implementation-Version"  : "${version}",
-                "Implementation-Vendor"   : "vectorwing",
-                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-                "MixinConfigs"            : "farmersdelight.mixins.json"
-        ])
+void processJar(Jar jarTask) {
+    jarTask.configure {
+        from "LICENSE"
+        exclude ".cache"
+
+        manifest {
+            attributes([
+                    "Specification-Title"     : "farmersdelight",
+                    "Specification-Vendor"    : "vectorwing",
+                    "Specification-Version"   : "1", // We are version 1 of ourselves
+                    "Implementation-Title"    : project.name,
+                    "Implementation-Version"  : "${version}",
+                    "Implementation-Vendor"   : "vectorwing",
+                    "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+                    "MixinConfigs"            : "farmersdelight.mixins.json"
+            ])
+        }
     }
 }
 
 jar.finalizedBy('reobfJar')
+jar.setArchiveClassifier('slim')
+tasks.jarJar.setArchiveClassifier('')
+tasks.jarJar.finalizedBy('reobfJarJar')
+
+processJar(jar)
+processJar(tasks.jarJar)
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifact jar
+            artifactId = archivesBaseName
+
+            from components.java
+            fg.component(it)
+            jarJar.component(it)
         }
     }
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ mc_version=1.20.1
 forge_version=47.1.0
 
 # Dependency Info
+mixinextras_version=0.3.5
 jei_version=15.0.0.12
 appleskin_version=mc1.20.1-2.5.0
 crafttweaker_version=14.0.6

--- a/src/main/java/vectorwing/farmersdelight/common/mixin/integration/KekimurusBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/mixin/integration/KekimurusBlockEntity.java
@@ -1,0 +1,38 @@
+package vectorwing.farmersdelight.common.mixin.integration;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import vectorwing.farmersdelight.common.block.PieBlock;
+
+@SuppressWarnings("UnresolvedMixinReference")
+@Pseudo
+@Mixin(targets = "vazkii.botania.common.block.flower.generating.KekimurusBlockEntity", remap = false)
+public class KekimurusBlockEntity {
+
+    @WrapOperation(method = "tickFlower", at = @At(value = "CONSTANT", args = "classValue=net.minecraft.world.level.block.CakeBlock", remap = true))
+    private boolean checkForPieBlock(Object block, Operation<Boolean> original, @Share("isPie") LocalBooleanRef isPie) {
+        isPie.set(block instanceof PieBlock);
+        return isPie.get() || original.call(block);
+    }
+
+    @ModifyExpressionValue(method = "tickFlower", at = @At(value = "CONSTANT", args = "intValue=6"))
+    private int usePieMaxBites(int original, @Share("isPie") LocalBooleanRef isPie) {
+        return isPie.get() ? 3 : original;
+    }
+
+    @ModifyExpressionValue(method = "tickFlower", at = @At(value = "FIELD", target = "Lnet/minecraft/world/level/block/CakeBlock;BITES:Lnet/minecraft/world/level/block/state/properties/IntegerProperty;", remap = true))
+    private IntegerProperty usePieProperty(IntegerProperty original, @Share("isPie") LocalBooleanRef isPie) {
+        if (isPie.get()) {
+            return PieBlock.BITES;
+        }
+        return original;
+    }
+
+}

--- a/src/main/resources/farmersdelight.mixins.json
+++ b/src/main/resources/farmersdelight.mixins.json
@@ -10,7 +10,8 @@
     "KeepRichSoilTreeMixin",
     "RabbitsEatCabbageMixin",
     "SoupItemMixin",
-    "accessor.RecipeManagerAccessor"
+    "accessor.RecipeManagerAccessor",
+    "integration.KekimurusBlockEntity"
   ],
   "client": [
     "CanvasSignEditScreenMixin",


### PR DESCRIPTION
### Intro
The Kekimurus in Botania is known for generating mana from eating cakes. Botania's code only checks for `CakeBlock` and thus only vanilla cake and some modded cakes.

Since FD's pies(including the sweet berry cheesecake) behaves like vanilla cake, it's reasonable for pies to have integration with Kekimurus.

It's possible to make this integration on Botania's side, but that would be requiring Botania to compile against FD. Since I found a way to implement it on FD's side without needing to compile against Botania, I believe making a PR to FD would be better.

[Related Discord discussion](https://discordapp.com/channels/734511833947439156/734514412873973830/1227887864633753620)

### Implementation
This PR used a `@Pseudo` mixin on the `KekimurusBlockEntity` to avoid adding Botania as a hard dependency on compile time.

Not having Botania on the compile classpath results in not being able to call Botania specific methods in the mixin, however with MixinExtras, a safe and possibly more coremod-compatible implementation could be made. The mixin result will basically be equivalent to the code below:
<details>

<summary>Click to uncollapse</summary>

```java
/*
 * This class is distributed as part of the Botania Mod.
 * Get the Source Code in github:
 * https://github.com/Vazkii/Botania
 *
 * Botania is Open Source and distributed under the
 * Botania License: http://botaniamod.net/license.php
 */

@Override
public void tickFlower() {
	boolean isPie = false;
	super.tickFlower();

	if (getLevel().isClientSide) {
		return;
	}

	int mana = 1800;

	if (getMaxMana() - this.getMana() >= mana && !getLevel().isClientSide && ticksExisted % 80 == 0) {
		for (int i = 0; i < RANGE * 2 + 1; i++) {
			for (int j = 0; j < RANGE * 2 + 1; j++) {
				for (int k = 0; k < RANGE * 2 + 1; k++) {
					BlockPos pos = getEffectivePos().offset(i - RANGE, j - RANGE, k - RANGE);
					BlockState state = getLevel().getBlockState(pos);
					Block block = state.getBlock();
					if ((isPie = block instanceof PieBlock) && (block instanceof CakeBlock)) {
						int nextSlicesEaten = state.getValue(isPie ? PieBlock.BITES : CakeBlock.BITES) + 1;
						if (nextSlicesEaten > (isPie ? 3 : 6)) {
							getLevel().removeBlock(pos, false);
						} else {
							getLevel().setBlockAndUpdate(pos, state.setValue(isPie ? PieBlock.BITES : CakeBlock.BITES, nextSlicesEaten));
						}

						getLevel().levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, pos, Block.getId(state));
						//Usage of vanilla sound event: Subtitle is "Eating", generic sounds are meant to be reused.
						getLevel().playSound(null, getEffectivePos(), SoundEvents.GENERIC_EAT, SoundSource.BLOCKS, 1F, 0.5F + (float) Math.random() * 0.5F);
						addMana(mana);
						sync();
						return;
					}
				}
			}
		}
	}
}
```

</details>

### Changes
MixinExtras is now embedded in the mod's jar using Forge's jar in jar, so no extra dependency for players is introduced. Since NeoForge 20.2.84+ includes MixinExtras already, removing the embedded dependency when FD updates to NeoForge is possible.

The only change for the building workflow is that now the `jarJar` task should be used to create the jar used for production instead of the original `jar` task.

### Discussion
The Kekimurus generates 1800 mana per bite for all cakes, currently I let the pie use the same value. However, since pie slices are generally better than cake slices, and pies only have 4 bites comparing to cake's 7 bites, we might should consider a proper value for the mana generated per bite for pies.

My current preferred value is 3200 mana, which is 12800 mana in total, while for cake it's 12600 mana in total.

Of course, this value should be made tweakable through config, but we still need some discussion to determine a default value.

If the discussion results in rejecting this integration PR, I shall port it to Create: Central Kitchen for those who're interested in it :)