### PR TITLE
(1.21.1) Fix crash when placing Canvas Signs (and hanging signs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,15 +106,15 @@ configurations {
 
 dependencies {
     // compile against the JEI API but do not include it at runtime
-    compileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
-    compileOnly "mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${jei_minecraft}-common-api:${jei_version}"
+    compileOnly "mezz.jei:jei-${jei_minecraft}-neoforge-api:${jei_version}"
     // at runtime, use the full JEI jar for Forge
-    localRuntime "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"
+    localRuntime "mezz.jei:jei-${jei_minecraft}-neoforge:${jei_version}"
 
     compileOnly "squeek.appleskin:appleskin-neoforge:${appleskin_version}:api"
     runtimeOnly "squeek.appleskin:appleskin-neoforge:${appleskin_version}"
 
-    def ctDep = "com.blamejared.crafttweaker:CraftTweaker-neoforge-${minecraft_version}:${crafttweaker_version}"
+    def ctDep = "com.blamejared.crafttweaker:CraftTweaker-neoforge-${crafttweaker_minecraft}:${crafttweaker_version}"
     compileOnly ctDep
     runtimeOnly ctDep
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ parchment_mappings_version=2024.07.28
 
 # Minecraft
 minecraft_version=1.21.1
-minecraft_version_range=[1.21,1.21.1)
+minecraft_version_range=[1.21.1,1.22)
 neo_version=21.1.4
 neo_version_range=[21.0.102-beta,)
 loader_version_range=[4,)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ org.gradle.configuration-cache=true
 
 # Parchment
 parchment_minecraft_version=1.21
-parchment_mappings_version=2024.07.07
+parchment_mappings_version=2024.07.28
 
 # Minecraft
-minecraft_version=1.21
+minecraft_version=1.21.1
 minecraft_version_range=[1.21,1.21.1)
-neo_version=21.0.145
+neo_version=21.1.4
 neo_version_range=[21.0.102-beta,)
 loader_version_range=[4,)
 
@@ -25,7 +25,9 @@ mod_authors=vectorwing
 mod_description=A cozy farming and cooking expansion for Minecraft!
 
 # Dependency Info
-jei_version=19.5.0.31
-appleskin_version=mc1.21-3.0.4
-crafttweaker_version=20.0.17
+jei_minecraft=1.21
+jei_version=19.8.2.99
+appleskin_version=mc1.21-3.0.5
+crafttweaker_minecraft=1.21
+crafttweaker_version=20.0.21
 crafttweaker_ap_version=3.0.0.15

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CanvasSignBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CanvasSignBlockEntity.java
@@ -16,4 +16,9 @@ public class CanvasSignBlockEntity extends SignBlockEntity
 	public BlockEntityType<?> getType() {
 		return ModBlockEntityTypes.CANVAS_SIGN.get();
 	}
+
+	@Override
+	public boolean isValidBlockState(BlockState state) {
+		return this.getType().isValid(state);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/HangingCanvasSignBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/HangingCanvasSignBlockEntity.java
@@ -18,6 +18,11 @@ public class HangingCanvasSignBlockEntity extends HangingSignBlockEntity
 		return ModBlockEntityTypes.HANGING_CANVAS_SIGN.get();
 	}
 
+	@Override
+	public boolean isValidBlockState(BlockState state) {
+		return this.getType().isValid(state);
+	}
+
 	public int getTextLineHeight() {
 		return 9;
 	}


### PR DESCRIPTION
* Update Neoforge to 1.21 and update some dependencies
* Fix crash with the Canvas sign block entity and hanging block entity