### PR TITLE
Update Fabric port on Bug Report form.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -26,7 +26,7 @@ body:
     id: forge_version
     attributes:
       label: Forge version
-      description: "For issues regarding the Fabric port, go to: https://github.com/newhoryzon/farmers-delight-fabric/issues"
+      description: "For issues regarding the Fabric port, go to: https://github.com/MehVahdJukaar/FarmersDelightRefabricated/issues"
       placeholder: | 
         Example: 47.0.1
     validations:


### PR DESCRIPTION
This PR changes the Fabric port to Farmer's Delight Refabricated's repository instead of the now deprecated Farmer's Delight Fabric.
https://github.com/MehVahdJukaar/FarmersDelightRefabricated