### PR TITLE
Make shapes of pies and feasts rotate depending on their direction

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/FeastBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/FeastBlock.java
@@ -23,8 +23,11 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import vectorwing.farmersdelight.common.utility.ShapeUtils;
 import vectorwing.farmersdelight.common.utility.TextUtils;
 
 import java.util.function.Supplier;
@@ -76,6 +79,17 @@ public class FeastBlock extends Block
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
 		return SHAPES[state.getValue(SERVINGS)];
+	}
+
+	/**
+	 * This method can be used to get a rotated shape of the block with plate and serving included.
+	 *
+	 * @param plateShape      Plate's shape.
+	 * @param shapesPerStages The array of VoxelShapes per each stage of the block except for the leftover, starting from the full one without any bites.
+	 * @return Full and rotated shape of the block.
+	 */
+	public VoxelShape getPlatedServingShape(BlockState state, VoxelShape plateShape, VoxelShape[] shapesPerStages) {
+		return state.getValue(SERVINGS) == 0 ? plateShape : ShapeUtils.rotateShape(Shapes.join(plateShape, shapesPerStages[getMaxServings() - state.getValue(SERVINGS)], BooleanOp.OR), state.getValue(FACING));
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/HoneyGlazedHamBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/HoneyGlazedHamBlock.java
@@ -5,19 +5,20 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.function.Supplier;
 
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
-
 public class HoneyGlazedHamBlock extends FeastBlock
 {
 	protected static final VoxelShape PLATE_SHAPE = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 2.0D, 15.0D);
-	protected static final VoxelShape ROAST_SHAPE = Shapes.joinUnoptimized(PLATE_SHAPE, Block.box(4.0D, 2.0D, 4.0D, 12.0D, 10.0D, 12.0D), BooleanOp.OR);
+	protected static final VoxelShape[] ROAST_SHAPES = new VoxelShape[] {
+			Block.box(4.0D, 2.0D, 4.0D, 12.0D, 10.0D, 12.0D),
+			Block.box(4, 2, 6, 12, 10, 12),
+			Block.box(4, 2, 8, 12, 10, 12),
+			Block.box(4, 2, 4, 12, 4, 12)
+	};
 
 	public HoneyGlazedHamBlock(Properties properties, Supplier<Item> servingItem, boolean hasLeftovers) {
 		super(properties, servingItem, hasLeftovers);
@@ -25,6 +26,6 @@ public class HoneyGlazedHamBlock extends FeastBlock
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return state.getValue(SERVINGS) == 0 ? PLATE_SHAPE : ROAST_SHAPE;
+		return getPlatedServingShape(state, PLATE_SHAPE, ROAST_SHAPES);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/PieBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/PieBlock.java
@@ -25,10 +25,13 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import vectorwing.farmersdelight.common.tag.ModTags;
 import vectorwing.farmersdelight.common.utility.ItemUtils;
+import vectorwing.farmersdelight.common.utility.ShapeUtils;
 
 import java.util.function.Supplier;
 
@@ -38,7 +41,12 @@ public class PieBlock extends Block
 	public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 	public static final IntegerProperty BITES = IntegerProperty.create("bites", 0, 3);
 
-	protected static final VoxelShape SHAPE = Block.box(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D);
+	protected static final VoxelShape[] SHAPES = new VoxelShape[] {
+			Block.box(2, 0, 2, 14, 4, 14),
+			Shapes.join(Block.box(2, 0, 8, 8, 4, 14), Block.box(2, 0, 2, 14, 4, 8), BooleanOp.OR),
+			Block.box(2, 0, 2, 14, 4, 8),
+			Block.box(8, 0, 2, 14, 4, 8)
+	};
 
 	public final Supplier<Item> pieSlice;
 
@@ -58,7 +66,7 @@ public class PieBlock extends Block
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return SHAPE;
+		return ShapeUtils.rotateShape(SHAPES[state.getValue(BITES)], state.getValue(FACING));
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/RoastChickenBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RoastChickenBlock.java
@@ -5,19 +5,20 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.function.Supplier;
 
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
-
 public class RoastChickenBlock extends FeastBlock
 {
 	protected static final VoxelShape PLATE_SHAPE = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 2.0D, 15.0D);
-	protected static final VoxelShape ROAST_SHAPE = Shapes.joinUnoptimized(PLATE_SHAPE, Block.box(4.0D, 2.0D, 4.0D, 12.0D, 9.0D, 12.0D), BooleanOp.OR);
+	protected static final VoxelShape[] ROAST_SHAPES = new VoxelShape[] {
+			Block.box(4.0D, 2.0D, 4.0D, 12.0D, 9.0D, 12.0D),
+			Block.box(4, 2, 6, 12, 9, 12),
+			Block.box(4, 2, 8, 12, 9, 12),
+			Block.box(4, 2, 10, 12, 9, 12)
+	};
 
 	public RoastChickenBlock(Properties properties, Supplier<Item> servingItem, boolean hasLeftovers) {
 		super(properties, servingItem, hasLeftovers);
@@ -25,6 +26,6 @@ public class RoastChickenBlock extends FeastBlock
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return state.getValue(SERVINGS) == 0 ? PLATE_SHAPE : ROAST_SHAPE;
+		return getPlatedServingShape(state, PLATE_SHAPE, ROAST_SHAPES);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/ShepherdsPieBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/ShepherdsPieBlock.java
@@ -12,12 +12,15 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.function.Supplier;
 
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
-
 public class ShepherdsPieBlock extends FeastBlock
 {
 	protected static final VoxelShape PLATE_SHAPE = Block.box(1.0D, 0.0D, 1.0D, 15.0D, 2.0D, 15.0D);
-	protected static final VoxelShape PIE_SHAPE = Shapes.joinUnoptimized(PLATE_SHAPE, Block.box(2.0D, 2.0D, 2.0D, 14.0D, 8.0D, 14.0D), BooleanOp.OR);
+	protected static final VoxelShape[] PIE_SHAPES = new VoxelShape[] {
+			Block.box(2, 2, 2, 14, 8, 14),
+			Shapes.join(Block.box(8, 2, 2, 14, 8, 8), Block.box(2, 2, 8, 14, 8, 14), BooleanOp.OR),
+			Block.box(2, 2, 8, 14, 8, 14),
+			Block.box(2, 2, 8, 8, 8, 14)
+	};
 
 	public ShepherdsPieBlock(Properties properties, Supplier<Item> servingItem, boolean hasLeftovers) {
 		super(properties, servingItem, hasLeftovers);
@@ -25,6 +28,6 @@ public class ShepherdsPieBlock extends FeastBlock
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-		return state.getValue(SERVINGS) == 0 ? PLATE_SHAPE : PIE_SHAPE;
+		return getPlatedServingShape(state, PLATE_SHAPE, PIE_SHAPES);
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/loot/modifier/AddItemModifier.java
+++ b/src/main/java/vectorwing/farmersdelight/common/loot/modifier/AddItemModifier.java
@@ -33,7 +33,7 @@ public class AddItemModifier extends LootModifier
 	/**
 	 * This loot modifier adds an item to the loot table, given the conditions specified.
 	 */
-	protected AddItemModifier(LootItemCondition[] conditionsIn, Item addedItemIn, int count) {
+	public AddItemModifier(LootItemCondition[] conditionsIn, Item addedItemIn, int count) {
 		super(conditionsIn);
 		this.addedItem = addedItemIn;
 		this.count = count;

--- a/src/main/java/vectorwing/farmersdelight/common/loot/modifier/FDAddTableLootModifier.java
+++ b/src/main/java/vectorwing/farmersdelight/common/loot/modifier/FDAddTableLootModifier.java
@@ -30,7 +30,7 @@ public class FDAddTableLootModifier extends AddTableLootModifier
 
 	private final ResourceKey<LootTable> lootTable;
 
-	protected FDAddTableLootModifier(LootItemCondition[] conditionsIn, ResourceKey<LootTable> lootTable) {
+	public FDAddTableLootModifier(LootItemCondition[] conditionsIn, ResourceKey<LootTable> lootTable) {
 		super(conditionsIn, lootTable);
 		this.lootTable = lootTable;
 	}

--- a/src/main/java/vectorwing/farmersdelight/common/loot/modifier/PastrySlicingModifier.java
+++ b/src/main/java/vectorwing/farmersdelight/common/loot/modifier/PastrySlicingModifier.java
@@ -38,7 +38,7 @@ public class PastrySlicingModifier extends LootModifier
 	 * If the block is a PieBlock, it drops up to 4 slices.
 	 * Otherwise, this does nothing.
 	 */
-	protected PastrySlicingModifier(LootItemCondition[] conditionsIn, Item pastrySliceIn) {
+	public PastrySlicingModifier(LootItemCondition[] conditionsIn, Item pastrySliceIn) {
 		super(conditionsIn);
 		this.pastrySlice = pastrySliceIn;
 	}

--- a/src/main/java/vectorwing/farmersdelight/common/utility/ShapeUtils.java
+++ b/src/main/java/vectorwing/farmersdelight/common/utility/ShapeUtils.java
@@ -1,0 +1,45 @@
+package vectorwing.farmersdelight.common.utility;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ShapeUtils {
+    /**
+     * Rotate voxel. Credits to JTK222|Lukas
+     * Cache the result
+     */
+    public static VoxelShape rotateShape(VoxelShape shape, Direction direction) {
+        if (direction == Direction.NORTH) {
+            return shape;
+        }
+
+        Set<VoxelShape> rotatedShapes = new HashSet<>();
+
+        shape.forAllBoxes((x1, y1, z1, x2, y2, z2) -> {
+            x1 = (x1 * 16) - 8;
+            x2 = (x2 * 16) - 8;
+            z1 = (z1 * 16) - 8;
+            z2 = (z2 * 16) - 8;
+
+            if (direction == Direction.EAST) {
+                rotatedShapes.add(blockBox(8 - z1, y1 * 16, 8 + x1, 8 - z2, y2 * 16, 8 + x2));
+            } else if (direction == Direction.SOUTH) {
+                rotatedShapes.add(blockBox(8 - x1, y1 * 16, 8 - z1, 8 - x2, y2 * 16, 8 - z2));
+            } else if (direction == Direction.WEST) {
+                rotatedShapes.add(blockBox(8 + z1, y1 * 16, 8 - x1, 8 + z2, y2 * 16, 8 - x2));
+            }
+        });
+
+        return rotatedShapes.stream().reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).orElseGet(() -> Block.box(0, 0, 0, 16, 16, 16));
+    }
+
+    public static VoxelShape blockBox(double pX1, double pY1, double pZ1, double pX2, double pY2, double pZ2) {
+        return Block.box(Math.min(pX1, pX2), Math.min(pY1, pY2), Math.min(pZ1, pZ2), Math.max(pX1, pX2), Math.max(pY1, pY2), Math.max(pZ1, pZ2));
+    }
+}


### PR DESCRIPTION
Added shapes for each stage of the pies and made them rotate depending on the direction. Same with the feasts, but only for Shepherd's Pie, Honey Glazed Ham and Roast Chicken. I decided not to do this for the Rice Roll Medley because the model would be far too complicated.

https://github.com/user-attachments/assets/4b55e654-7ff1-429a-af03-ce78a31c9601

(Also, AddItemModifier, FDAddTableLootModifier and PastrySlicingModifier were made public in order to allow data generation with them in addon mods)