### PR TITLE
fixed a null error in CookingPotRecipeSerializer codec

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/common/crafting/CookingPotRecipe.java
@@ -163,7 +163,7 @@ public class CookingPotRecipe implements Recipe<RecipeWrapper>
 	{
 		private static final MapCodec<CookingPotRecipe> CODEC = RecordCodecBuilder.mapCodec(inst -> inst.group(
 				Codec.STRING.optionalFieldOf("group", "").forGetter(CookingPotRecipe::getGroup),
-				CookingPotRecipeBookTab.CODEC.optionalFieldOf("recipe_book_tab").xmap(optional -> optional.orElse(null), Optional::of).forGetter(CookingPotRecipe::getRecipeBookTab),
+				CookingPotRecipeBookTab.CODEC.optionalFieldOf("recipe_book_tab").xmap(optional -> optional.orElse(CookingPotRecipeBookTab.MISC), Optional::of).forGetter(CookingPotRecipe::getRecipeBookTab),
 				Ingredient.LIST_CODEC_NONEMPTY.fieldOf("ingredients").xmap(ingredients -> {
 					NonNullList<Ingredient> nonNullList = NonNullList.create();
 					nonNullList.addAll(ingredients);


### PR DESCRIPTION
replacing that null with one of the existing recipe book tabs fixed an error that was being caused by trying to create a kubejs plugin for FD