### PR TITLE
Fixed `Nourishment` & `Comfort` effects descriptions for each lang file

### DIFF
--- a/src/main/resources/assets/farmersdelight/lang/be_by.json
+++ b/src/main/resources/assets/farmersdelight/lang/be_by.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Сытасць",
   "effect.farmersdelight.comfort": "Камфорт",
 
-  "effect.farmersdelight.nourishment.0.desc": "Папярэджвае голад, за выключэннем выкарыстання насычанасці для лячэння.",
-  "effect.farmersdelight.comfort.0.desc": "Забяспечвае натуральнае аднаўленне, нягледзячы наколькі вы галодныя.",
+  "effect.farmersdelight.nourishment.description": "Папярэджвае голад, за выключэннем выкарыстання насычанасці для лячэння.",
+  "effect.farmersdelight.comfort.description": "Забяспечвае натуральнае аднаўленне, нягледзячы наколькі вы галодныя.",
 
   "enchantment.farmersdelight.backstabbing": "Здрадніцтва",
   "enchantment.farmersdelight.backstabbing.desc": "Павялічвае шкоду пры атацы са спіны.",

--- a/src/main/resources/assets/farmersdelight/lang/ca_es.json
+++ b/src/main/resources/assets/farmersdelight/lang/ca_es.json
@@ -182,8 +182,8 @@
   "effect.farmersdelight.nourishment": "Nodrit",
   "effect.farmersdelight.comfort": "Benesetar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita l'increment de la gana, excepte quan s'utilitza la saturació per curar el mal",
-  "effect.farmersdelight.comfort.0.desc": "Et dona immunitat a la gana, la lentitud i la debilitat.",
+  "effect.farmersdelight.nourishment.description": "Evita l'increment de la gana, excepte quan s'utilitza la saturació per curar el mal",
+  "effect.farmersdelight.comfort.description": "Et dona immunitat a la gana, la lentitud i la debilitat.",
 
   "enchantment.farmersdelight.backstabbing": "Punyalada per l'esquena",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el mal al apunyalar un objectiu per darrere.",

--- a/src/main/resources/assets/farmersdelight/lang/da_dk.json
+++ b/src/main/resources/assets/farmersdelight/lang/da_dk.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Næring",
   "effect.farmersdelight.comfort": "Komfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Forhindrer tab af sult, undtagen når du bruger saturation til at helbrede skader.",
-  "effect.farmersdelight.comfort.0.desc": "Giver naturlig regenerering, uanset hvor sulten du er.",
+  "effect.farmersdelight.nourishment.description": "Forhindrer tab af sult, undtagen når du bruger saturation til at helbrede skader.",
+  "effect.farmersdelight.comfort.description": "Giver naturlig regenerering, uanset hvor sulten du er.",
 
   "enchantment.farmersdelight.backstabbing": "Rygstik",
   "enchantment.farmersdelight.backstabbing.desc": "Forstærker skaden, når du rammer et mål bagfra.",

--- a/src/main/resources/assets/farmersdelight/lang/de_de.json
+++ b/src/main/resources/assets/farmersdelight/lang/de_de.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Gesättigt",
   "effect.farmersdelight.comfort": "Komfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Verhindert Hungerverlust, es sei denn es wird Leben regeneriert.",
-  "effect.farmersdelight.comfort.0.desc": "Verleiht Immunität gegenüber Hunger, Langsamkeit und Schwäche",
+  "effect.farmersdelight.nourishment.description": "Verhindert Hungerverlust, es sei denn es wird Leben regeneriert.",
+  "effect.farmersdelight.comfort.description": "Verleiht Immunität gegenüber Hunger, Langsamkeit und Schwäche",
 
   "enchantment.farmersdelight.backstabbing": "Hinterhalt",
   "enchantment.farmersdelight.backstabbing.desc": "Mehr Schaden durch Angriffe von hinten.",

--- a/src/main/resources/assets/farmersdelight/lang/en_pt.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_pt.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Belly's Full",
   "effect.farmersdelight.comfort": "Heart's Warm",
 
-  "effect.farmersdelight.nourishment.0.desc": "Ye can't get hungry, lest yer belly be digestin' food ta heal ye.",
-  "effect.farmersdelight.comfort.0.desc": "Yer body gon' heal up slowly, no matter if ye're starvin' or not.",
+  "effect.farmersdelight.nourishment.description": "Ye can't get hungry, lest yer belly be digestin' food ta heal ye.",
+  "effect.farmersdelight.comfort.description": "Yer body gon' heal up slowly, no matter if ye're starvin' or not.",
 
   "enchantment.farmersdelight.backstabbing": "Mutiny",
   "enchantment.farmersdelight.backstabbing.desc": "Strikes true at the heart o' yer victim, be their backs turned on ye.",

--- a/src/main/resources/assets/farmersdelight/lang/en_us.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_us.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nourishment",
   "effect.farmersdelight.comfort": "Comfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Prevents hunger loss, except when using saturation to heal damage.",
-  "effect.farmersdelight.comfort.0.desc": "Provides natural regeneration, regardless of how hungry you are.",
+  "effect.farmersdelight.nourishment.description": "Prevents hunger loss, except when using saturation to heal damage.",
+  "effect.farmersdelight.comfort.description": "Provides natural regeneration, regardless of how hungry you are.",
 
   "enchantment.farmersdelight.backstabbing": "Backstabbing",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifies damage when striking a target from behind.",

--- a/src/main/resources/assets/farmersdelight/lang/es_ar.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_ar.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nutrición",
   "effect.farmersdelight.comfort": "Comodidad",
 
-  "effect.farmersdelight.nourishment.0.desc": "Previene la pérdida de hambre, excepto cuando se usa la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Proporciona regeneración natural, sin importar el hambre que tengas.",
+  "effect.farmersdelight.nourishment.description": "Previene la pérdida de hambre, excepto cuando se usa la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Proporciona regeneración natural, sin importar el hambre que tengas.",
 
   "enchantment.farmersdelight.backstabbing": "Puñalada por la espalda",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_cl.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_cl.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nutrido",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te hace inmune al hambre, la lentitud y la debilidad.",
+  "effect.farmersdelight.nourishment.description": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te hace inmune al hambre, la lentitud y la debilidad.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_ec.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_ec.json
@@ -148,8 +148,8 @@
   "effect.farmersdelight.nourishment": "Nutrido",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
+  "effect.farmersdelight.nourishment.description": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas por la espalda",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_es.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_es.json
@@ -182,8 +182,8 @@
   "effect.farmersdelight.nourishment": "Nutrido",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
+  "effect.farmersdelight.nourishment.description": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas por la espalda",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_mx.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_mx.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nutrición",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita el hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te da regeneración, sin importar cuanta hambre tengas.",
+  "effect.farmersdelight.nourishment.description": "Evita el hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te da regeneración, sin importar cuanta hambre tengas.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_uy.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_uy.json
@@ -148,8 +148,8 @@
   "effect.farmersdelight.nourishment": "Nutrido",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
+  "effect.farmersdelight.nourishment.description": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas por la espalda",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/es_ve.json
+++ b/src/main/resources/assets/farmersdelight/lang/es_ve.json
@@ -148,8 +148,8 @@
   "effect.farmersdelight.nourishment": "Nutrido",
   "effect.farmersdelight.comfort": "Bienestar",
 
-  "effect.farmersdelight.nourishment.0.desc": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
-  "effect.farmersdelight.comfort.0.desc": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
+  "effect.farmersdelight.nourishment.description": "Evita la pérdida de hambre, excepto cuando se utiliza la saturación para curar el daño.",
+  "effect.farmersdelight.comfort.description": "Te hace inmune al Hambre, la Lentitud y la Debilidad.",
 
   "enchantment.farmersdelight.backstabbing": "Puñaladas por la espalda",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica el daño al golpear a un objetivo por detrás.",

--- a/src/main/resources/assets/farmersdelight/lang/fi_fi.json
+++ b/src/main/resources/assets/farmersdelight/lang/fi_fi.json
@@ -171,8 +171,8 @@
   "effect.farmersdelight.nourishment": "Ravittu",
   "effect.farmersdelight.comfort": "Mukavuus",
 
-  "effect.farmersdelight.nourishment.0.desc": "Estää nälkiintymisen silloin kun kylläisyyttä ei käytetä elinvoiman palauttamiseen.",
-  "effect.farmersdelight.comfort.0.desc": "Estää nälän, hitauden ja heikkouden saamisen.",
+  "effect.farmersdelight.nourishment.description": "Estää nälkiintymisen silloin kun kylläisyyttä ei käytetä elinvoiman palauttamiseen.",
+  "effect.farmersdelight.comfort.description": "Estää nälän, hitauden ja heikkouden saamisen.",
 
   "enchantment.farmersdelight.backstabbing": "Selkäänpuukotus",
   "enchantment.farmersdelight.backstabbing.desc": "Vahvistaa vahinkoa takaa päin hyökätessä.",

--- a/src/main/resources/assets/farmersdelight/lang/fr_fr.json
+++ b/src/main/resources/assets/farmersdelight/lang/fr_fr.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Bien mangé",
   "effect.farmersdelight.comfort": "Confort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Empêche la perte de faim, sauf lors de l'utilisation de la saturation pour soigner les dégâts.",
-  "effect.farmersdelight.comfort.0.desc": "Vous rend immunisé contre la faim, la lenteur et la faiblesse.",
+  "effect.farmersdelight.nourishment.description": "Empêche la perte de faim, sauf lors de l'utilisation de la saturation pour soigner les dégâts.",
+  "effect.farmersdelight.comfort.description": "Vous rend immunisé contre la faim, la lenteur et la faiblesse.",
 
   "enchantment.farmersdelight.backstabbing": "Poignardage par derrière",
   "enchantment.farmersdelight.backstabbing.desc": "Augmente les dégâts quand une cible est frappée par derrière.",

--- a/src/main/resources/assets/farmersdelight/lang/id_id.json
+++ b/src/main/resources/assets/farmersdelight/lang/id_id.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Bergizi",
   "effect.farmersdelight.comfort": "Kenyamanan",
 
-  "effect.farmersdelight.nourishment.0.desc": "Mencegah kehilangan rasa lapar, kecuali saat menggunakan saturasi untuk menyembuhkan luka.",
-  "effect.farmersdelight.comfort.0.desc": "Membuat Anda kebal terhadap Kelaparan, Kelambatan dan Kelemahan.",
+  "effect.farmersdelight.nourishment.description": "Mencegah kehilangan rasa lapar, kecuali saat menggunakan saturasi untuk menyembuhkan luka.",
+  "effect.farmersdelight.comfort.description": "Membuat Anda kebal terhadap Kelaparan, Kelambatan dan Kelemahan.",
 
   "enchantment.farmersdelight.backstabbing": "Menusuk dari Belakang",
   "enchantment.farmersdelight.backstabbing.desc": "Memperkuat kerusakan saat menyerang target dari belakang.",

--- a/src/main/resources/assets/farmersdelight/lang/it_it.json
+++ b/src/main/resources/assets/farmersdelight/lang/it_it.json
@@ -184,8 +184,8 @@
   "effect.farmersdelight.nourishment": "Nutrimento",
   "effect.farmersdelight.comfort": "Benessere",
 
-  "effect.farmersdelight.nourishment.0.desc": "Impedisce la perdita della fame, tranne quando si utilizza saturazione per guarire i danni.",
-  "effect.farmersdelight.comfort.0.desc": "Ti rende immuno alla fame, lentezza e debolezza.",
+  "effect.farmersdelight.nourishment.description": "Impedisce la perdita della fame, tranne quando si utilizza saturazione per guarire i danni.",
+  "effect.farmersdelight.comfort.description": "Ti rende immuno alla fame, lentezza e debolezza.",
 
   "enchantment.farmersdelight.backstabbing": "Pugnalata alla schiena",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica i danni quando colpisci il bersaglio da dietro.",

--- a/src/main/resources/assets/farmersdelight/lang/ja_jp.json
+++ b/src/main/resources/assets/farmersdelight/lang/ja_jp.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "栄養",
   "effect.farmersdelight.comfort": "健康",
 
-  "effect.farmersdelight.nourishment.0.desc": "体力を回復する場合を除き、空腹ゲージの減少を防ぐ",
-  "effect.farmersdelight.comfort.0.desc": "空腹、移動速度低下、弱体化に対しての耐性を与える",
+  "effect.farmersdelight.nourishment.description": "体力を回復する場合を除き、空腹ゲージの減少を防ぐ",
+  "effect.farmersdelight.comfort.description": "空腹、移動速度低下、弱体化に対しての耐性を与える",
   "effect.farmersdelight.nourishment.description": "体力を回復する場合を除き、空腹ゲージの減少を防ぐ",
   "effect.farmersdelight.comfort.description": "空腹、移動速度低下、弱体化に対しての耐性を与える",
 

--- a/src/main/resources/assets/farmersdelight/lang/ko_kr.json
+++ b/src/main/resources/assets/farmersdelight/lang/ko_kr.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "배부름",
   "effect.farmersdelight.comfort": "편안함",
 
-  "effect.farmersdelight.nourishment.0.desc": "생명력을 회복할 때를 제외하고 배고픔 수치가 줄어들지 않습니다.",
-  "effect.farmersdelight.comfort.0.desc": "배고픔 수치와 상관없이, 생명력을 회복합니다.",
+  "effect.farmersdelight.nourishment.description": "생명력을 회복할 때를 제외하고 배고픔 수치가 줄어들지 않습니다.",
+  "effect.farmersdelight.comfort.description": "배고픔 수치와 상관없이, 생명력을 회복합니다.",
 
   "enchantment.farmersdelight.backstabbing": "암습",
   "enchantment.farmersdelight.backstabbing.desc": "대상을 뒤에서 공격할 때 피해가 증가합니다.",

--- a/src/main/resources/assets/farmersdelight/lang/nl_be.json
+++ b/src/main/resources/assets/farmersdelight/lang/nl_be.json
@@ -174,8 +174,8 @@
   "effect.farmersdelight.nourishment": "Voeding",
   "effect.farmersdelight.comfort": "Comfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Voorkomt hongerverlies, behalve bij gebruik van verzadiging om schade te genezen.",
-  "effect.farmersdelight.comfort.0.desc": "Zorgt voor natuurlijke regeneratie, ongeacht hoe hongerig je bent.",
+  "effect.farmersdelight.nourishment.description": "Voorkomt hongerverlies, behalve bij gebruik van verzadiging om schade te genezen.",
+  "effect.farmersdelight.comfort.description": "Zorgt voor natuurlijke regeneratie, ongeacht hoe hongerig je bent.",
 
   "enchantment.farmersdelight.backstabbing": "Achtersteken",
   "enchantment.farmersdelight.backstabbing.desc": "Vergroot de schade bij het van achteren raken van een doelwit.",

--- a/src/main/resources/assets/farmersdelight/lang/nl_nl.json
+++ b/src/main/resources/assets/farmersdelight/lang/nl_nl.json
@@ -174,8 +174,8 @@
   "effect.farmersdelight.nourishment": "Voeding",
   "effect.farmersdelight.comfort": "Comfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Voorkomt hongerverlies, behalve bij gebruik van verzadiging om schade te genezen.",
-  "effect.farmersdelight.comfort.0.desc": "Zorgt voor natuurlijke regeneratie, ongeacht hoe hongerig je bent.",
+  "effect.farmersdelight.nourishment.description": "Voorkomt hongerverlies, behalve bij gebruik van verzadiging om schade te genezen.",
+  "effect.farmersdelight.comfort.description": "Zorgt voor natuurlijke regeneratie, ongeacht hoe hongerig je bent.",
 
   "enchantment.farmersdelight.backstabbing": "Achtersteken",
   "enchantment.farmersdelight.backstabbing.desc": "Vergroot de schade bij het van achteren raken van een doelwit.",

--- a/src/main/resources/assets/farmersdelight/lang/no_no.json
+++ b/src/main/resources/assets/farmersdelight/lang/no_no.json
@@ -171,8 +171,8 @@
   "effect.farmersdelight.nourishment": "Næring",
   "effect.farmersdelight.comfort": "Komfort",
 
-  "effect.farmersdelight.nourishment.0.desc": "Forhindrer sult, med unntak når metthet benyttes for å helberede skade.",
-  "effect.farmersdelight.comfort.0.desc": "Gjør deg immun mot Sult, Treghet og Svakhet.",
+  "effect.farmersdelight.nourishment.description": "Forhindrer sult, med unntak når metthet benyttes for å helberede skade.",
+  "effect.farmersdelight.comfort.description": "Gjør deg immun mot Sult, Treghet og Svakhet.",
 
   "enchantment.farmersdelight.backstabbing": "Bakholdsangrep",
   "enchantment.farmersdelight.backstabbing.desc": "Øker utført skade når du slår et mål bakfra.",

--- a/src/main/resources/assets/farmersdelight/lang/pl_pl.json
+++ b/src/main/resources/assets/farmersdelight/lang/pl_pl.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Najedzenie",
   "effect.farmersdelight.comfort": "Komfort",
   
-  "effect.farmersdelight.nourishment.0.desc": "Zapobiega spadaniu poziomu głodu kiedy nasycenie nie jest używane do leczenia obrażeń",
-  "effect.farmersdelight.comfort.0.desc": "Nadaje graczowi odporność na głód, spowolnienie i słabość",
+  "effect.farmersdelight.nourishment.description": "Zapobiega spadaniu poziomu głodu kiedy nasycenie nie jest używane do leczenia obrażeń",
+  "effect.farmersdelight.comfort.description": "Nadaje graczowi odporność na głód, spowolnienie i słabość",
 
   "enchantment.farmersdelight.backstabbing": "Dźganie w plecy",
   "enchantment.farmersdelight.backstabbing.desc": "Zwiększa obrażenia przy uderzeniu w cel od tyłu.",

--- a/src/main/resources/assets/farmersdelight/lang/pt_br.json
+++ b/src/main/resources/assets/farmersdelight/lang/pt_br.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nutrição",
   "effect.farmersdelight.comfort": "Conforto",
 
-  "effect.farmersdelight.nourishment.0.desc": "Previne perda de fome, exceto quando puder curar-se com saturação.",
-  "effect.farmersdelight.comfort.0.desc": "Concede regeneração natural, não importa o quão faminto você estiver.",
+  "effect.farmersdelight.nourishment.description": "Previne perda de fome, exceto quando puder curar-se com saturação.",
+  "effect.farmersdelight.comfort.description": "Concede regeneração natural, não importa o quão faminto você estiver.",
 
   "enchantment.farmersdelight.backstabbing": "Punhalada nas costas",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica o dano ao atingir um alvo pelas costas.",

--- a/src/main/resources/assets/farmersdelight/lang/pt_pt.json
+++ b/src/main/resources/assets/farmersdelight/lang/pt_pt.json
@@ -148,8 +148,8 @@
   "effect.farmersdelight.nourishment": "Nutrição",
   "effect.farmersdelight.comfort": "Conforto",
 
-  "effect.farmersdelight.nourishment.0.desc": "Previne o apetite, exceto ao usar saturação para curar dano.",
-  "effect.farmersdelight.comfort.0.desc": "Torna-te imune à Fome, Lentidão e Fraqueza.",
+  "effect.farmersdelight.nourishment.description": "Previne o apetite, exceto ao usar saturação para curar dano.",
+  "effect.farmersdelight.comfort.description": "Torna-te imune à Fome, Lentidão e Fraqueza.",
 
   "enchantment.farmersdelight.backstabbing": "Facada nas costas",
   "enchantment.farmersdelight.backstabbing.desc": "Amplifica dano ao atacar o alvo por trás.",

--- a/src/main/resources/assets/farmersdelight/lang/ru_ru.json
+++ b/src/main/resources/assets/farmersdelight/lang/ru_ru.json
@@ -33,7 +33,7 @@
   "block.farmersdelight.rice_bale": "Рисовый тюк",
   "block.farmersdelight.rice_bag": "Мешок риса",
   "block.farmersdelight.straw_bale": "Тюк соломы",
-  
+
   "block.farmersdelight.canvas_sign": "Холщовая табличка",
   "block.farmersdelight.white_canvas_sign": "Белая холщовая табличка",
   "block.farmersdelight.orange_canvas_sign": "Оранжевая холщовая табличка",
@@ -124,7 +124,7 @@
   "item.farmersdelight.cod_slice": "Ломтик сырой трески",
   "item.farmersdelight.cooked_cod_slice": "Ломтик жареной трески",
   "item.farmersdelight.salmon_slice": "Ломтик сырого лосося",
-  "item.farmersdelight.cooked_salmon_slice": "Ломтик жареного лосося",  
+  "item.farmersdelight.cooked_salmon_slice": "Ломтик жареного лосося",
   "item.farmersdelight.mutton_chops": "Сырые бараньи отбивные",
   "item.farmersdelight.cooked_mutton_chops": "Жареные бараньи отбивные",
   "item.farmersdelight.ham": "Ветчина",
@@ -140,7 +140,7 @@
   "item.farmersdelight.honey_cookie": "Медовое печенье",
   "item.farmersdelight.melon_popsicle": "Арбузное мороженое",
   "item.farmersdelight.glow_berry_custard": "Крем из светящихся ягод",
-  
+
   "item.farmersdelight.earthworm": "Дождевой червь",
 
   "item.farmersdelight.flint_knife": "Кремневый нож",
@@ -154,7 +154,7 @@
   "item.farmersdelight.chicken_sandwich": "Сэндвич с курицей",
   "item.farmersdelight.hamburger": "Гамбургер",
   "item.farmersdelight.bacon_sandwich": "Сэндвич с беконом",
-  "item.farmersdelight.mutton_wrap": "Завёрнутая баранина",
+  "item.farmersdelight.mutton_wrap": "Рулет с бараниной",
   "item.farmersdelight.dumplings": "Хинкали",
   "item.farmersdelight.stuffed_potato": "Фаршированный картофель",
   "item.farmersdelight.cabbage_rolls": "Голубцы",
@@ -184,7 +184,7 @@
   "item.farmersdelight.vegetable_noodles": "Овощная лапша",
   "item.farmersdelight.ratatouille": "Рататуй",
   "item.farmersdelight.squid_ink_pasta": "Паста с чернилами спрута",
-  "item.farmersdelight.grilled_salmon": "Жареный лосось",
+  "item.farmersdelight.grilled_salmon": "Лосось на гриле",
   "item.farmersdelight.mushroom_rice": "Рис с грибами",
 
   "block.farmersdelight.roast_chicken_block": "Жареная курица",
@@ -196,7 +196,7 @@
   "block.farmersdelight.shepherds_pie_block": "Пастуший пирог",
   "item.farmersdelight.shepherds_pie": "Тарелка пастушьего пирога",
   "block.farmersdelight.rice_roll_medley_block": "Ассорти из роллов",
-  
+
   "item.farmersdelight.dog_food": "Собачий корм",
   "item.farmersdelight.horse_feed": "Лошадиный корм",
 
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Сытость",
   "effect.farmersdelight.comfort": "Комфорт",
 
-  "effect.farmersdelight.nourishment.0.desc": "Предотвращает потерю голода, за исключением случаев использования насыщения для лечения.",
-  "effect.farmersdelight.comfort.0.desc": "Обеспечивает естественную регенерацию, независимо от того, насколько вы голодны.",
+  "effect.farmersdelight.nourishment.description": "Предотвращает потерю голода, за исключением случаев использования насыщения для лечения.",
+  "effect.farmersdelight.comfort.description": "Обеспечивает естественную регенерацию, независимо от того, насколько вы голодны.",
 
   "enchantment.farmersdelight.backstabbing": "Предательство",
   "enchantment.farmersdelight.backstabbing.desc": "Увеличивает урон при атаке цели со спины.",
@@ -214,7 +214,7 @@
   "itemGroup.farmersdelight": "Фермерский Восторг",
 
   "farmersdelight.container.recipe_book.cookable": "Доступно к готовке",
-  "farmersdelight.container.cooking_pot": "Кухонный котел",
+  "farmersdelight.container.cooking_pot": "Кухонный котёл",
   "farmersdelight.container.cooking_pot.served_on": "Подаётся: %s",
   "farmersdelight.container.cooking_pot.not_heated": "Нужен нагрев снизу",
   "farmersdelight.container.cooking_pot.heated": "Нагрето",
@@ -222,15 +222,15 @@
   "farmersdelight.container.cabinet": "Кладовая",
 
   "farmersdelight.tooltip.cooking_pot.empty": "Пусто",
-  "farmersdelight.tooltip.cooking_pot.single_serving": "Содержит одну порцию",
-  "farmersdelight.tooltip.cooking_pot.many_servings": "Содержит порций: %s ",
+  "farmersdelight.tooltip.cooking_pot.single_serving": "Содержит одну порцию:",
+  "farmersdelight.tooltip.cooking_pot.many_servings": "Содержит %s порций:",
   "farmersdelight.tooltip.dog_food.when_feeding": "Если скормить прирученному волку:",
   "farmersdelight.tooltip.horse_feed.when_feeding": "Если скормить прирученной лошади:",
   "farmersdelight.tooltip.milk_bottle": "Очищает от 1 эффекта",
   "farmersdelight.tooltip.hot_cocoa": "Очищает от 1 вредного эффекта",
   "farmersdelight.tooltip.melon_juice": "Восстанавливает немного здоровья",
 
-  "farmersdelight.advancement.root": "Фермерский Восторг",
+  "farmersdelight.advancement.root": "Фермерский восторг",
   "farmersdelight.advancement.root.desc": "Вас ожидает целый мир разнообразных вкусов!",
 
   "farmersdelight.advancement.craft_knife": "Охота и собирательство",
@@ -242,14 +242,14 @@
   "farmersdelight.advancement.get_rich_soil": "Выращивание пищи",
   "farmersdelight.advancement.get_rich_soil.desc": "Оставьте немного органического компоста разлагаться, пока он не превратится в плодородную почву. Грибы могут помочь!",
   "farmersdelight.advancement.get_ham": "Дикий мясник",
-  "farmersdelight.advancement.get_ham.desc": "Используйте нож для извлечения больших кусков мяса из Свиней",  
+  "farmersdelight.advancement.get_ham.desc": "Используйте нож для извлечения больших кусков мяса из Свиней",
   "farmersdelight.advancement.use_cutting_board": "Следи за пальцами",
   "farmersdelight.advancement.use_cutting_board.desc": "Держа инструмент в руках, используйте его на разделочной доске, чтобы разделать некоторые предметы",
-  "farmersdelight.advancement.obtain_netherite_knife": "Если ты не выдержишь жару…",
+  "farmersdelight.advancement.obtain_netherite_knife": "Если ты не выдержишь жару...",
   "farmersdelight.advancement.obtain_netherite_knife.desc": "Потратьте целый незеритовый слиток, чтобы улучшить свой нож! Или свалите с кухни.",
 
   "farmersdelight.advancement.get_fd_seed": "Урожаи дикой природы",
-  "farmersdelight.advancement.get_fd_seed.desc": "Четыре новых культуры можно найти в природе, в разных климатах… или где-нибудь в сундуках.",
+  "farmersdelight.advancement.get_fd_seed.desc": "Четыре новых культуры можно найти в дикой природе, в разных климатах... или где-нибудь в сундуках.",
   "farmersdelight.advancement.plant_rice": "Погружая свои корни",
   "farmersdelight.advancement.plant_rice.desc": "Посадите рис в неглубокий водоём",
   "farmersdelight.advancement.harvest_ropelogged_tomato": "Шпалера",
@@ -291,10 +291,12 @@
 
   "farmersdelight.block.feast.use_container": "Вам нужно %s чтобы съесть это.",
   "farmersdelight.block.rice.invalid_placement": "Этот посев не выживет за пределами мелководья.",
-  "farmersdelight.block.cutting_board.invalid_item": "Кажется это нельзя разрезать…",
-  "farmersdelight.block.cutting_board.invalid_tool": "Возможно другим инструментом…",
-  "farmersdelight.block.skillet.invalid_item": "Это нельзя приготовить…",
+  "farmersdelight.block.cutting_board.invalid_item": "Кажется это нельзя разрезать...",
+  "farmersdelight.block.cutting_board.invalid_tool": "Возможно другим инструментом...",
+  "farmersdelight.block.skillet.invalid_item": "Это нельзя приготовить...",
+  "farmersdelight.block.skillet.underwater": "Нельзя готовить при затоплении...",
   "farmersdelight.item.skillet.how_to_cook": "Используйте другую руку, чтобы держать ингредиенты!",
+  "farmersdelight.item.skillet.underwater": "Нельзя готовить под водой...",
 
   "death.attack.farmersdelight.stove": "%1$s был зажарен на гриле",
   "death.attack.farmersdelight.stove.player": "%1$s был брошен на гриль шефом %2$s",
@@ -306,10 +308,10 @@
   "farmersdelight.jei.decomposition.light": "Процесс ускоряется под воздействием солнечного света",
   "farmersdelight.jei.decomposition.fluid": "Процесс ускоряется посредством добавления воды",
   "farmersdelight.jei.decomposition.accelerators": "Процесс ускоряется посредством добавления активаторов (см. выше)",
-  
+
   "farmersdelight.jei.info.straw": "Сухое растительное волокно, используемое для создания предметов. Получают путем срезания ножом травянистых культур и растений.",
-  "farmersdelight.jei.info.knife": "Ножи — это лёгкое оружие ближнего боя. Они могут собирать солому с травы и гарантируют получение вторичного дропа с животных.",
-  "farmersdelight.jei.info.ham": "Большой кусок мяса со cвиней или хоглинов. Для разделки понадобится что-то полегче меча…",
+  "farmersdelight.jei.info.knife": "Лёгкое оружие ближнего боя, с быстрыми взмахами и небольшим уроном.\n\nОни могут собирать солому с травы и гарантируют получение вторичного дропа с животных.",
+  "farmersdelight.jei.info.ham": "Большой кусок мяса со cвиней или хоглинов.\n\nДля разделки понадобится что-то полегче меча...",
   "farmersdelight.jei.info.wild_cabbages": "Капусту обычно можно встретить в качестве дикорастущего растения на пляжных побережьях.",
   "farmersdelight.jei.info.wild_beetroots": "Свеклу обычно можно встретить в виде дикорастущего растения на пляжных побережьях.",
   "farmersdelight.jei.info.wild_carrots": "Морковь обычно можно встретить в виде дикорастущего растения в умеренных местах, таких как равнины и леса.",

--- a/src/main/resources/assets/farmersdelight/lang/sk_sk.json
+++ b/src/main/resources/assets/farmersdelight/lang/sk_sk.json
@@ -184,8 +184,8 @@
   "effect.farmersdelight.nourishment": "Výživa",
   "effect.farmersdelight.comfort": "Saturácia",
 
-  "effect.farmersdelight.nourishment.0.desc": "Zabraňuje strate hladu, okrem prípadov, keď sa na liečenie poškodenia používa saturácia.",
-  "effect.farmersdelight.comfort.0.desc": "Poskytuje prirodzenú regeneráciu bez ohľadu na to, aký máte hlad.",
+  "effect.farmersdelight.nourishment.description": "Zabraňuje strate hladu, okrem prípadov, keď sa na liečenie poškodenia používa saturácia.",
+  "effect.farmersdelight.comfort.description": "Poskytuje prirodzenú regeneráciu bez ohľadu na to, aký máte hlad.",
   
   "enchantment.farmersdelight.backstabbing": "Útok zozadu",
   "enchantment.farmersdelight.backstabbing.desc": "Zosilňuje poškodenie pri zasiahnutí cieľa zozadu.",

--- a/src/main/resources/assets/farmersdelight/lang/sr_sp.json
+++ b/src/main/resources/assets/farmersdelight/lang/sr_sp.json
@@ -174,8 +174,8 @@
   "effect.farmersdelight.nourishment": "Ухрањеност",
   "effect.farmersdelight.comfort": "Удобност",
 
-  "effect.farmersdelight.nourishment.0.desc": "Спречава губитак глади, осим током коришћења засичћености за исцеливање повреда.",
-  "effect.farmersdelight.comfort.0.desc": "Обезбеђује природну регенерацију, без обзира колико си гладан.",
+  "effect.farmersdelight.nourishment.description": "Спречава губитак глади, осим током коришћења засичћености за исцеливање повреда.",
+  "effect.farmersdelight.comfort.description": "Обезбеђује природну регенерацију, без обзира колико си гладан.",
 
   "enchantment.farmersdelight.backstabbing": "Убод у леђа",
   "enchantment.farmersdelight.backstabbing.desc": "Појачава напад приликом удара мете отпозади.",

--- a/src/main/resources/assets/farmersdelight/lang/sv_se.json
+++ b/src/main/resources/assets/farmersdelight/lang/sv_se.json
@@ -185,8 +185,8 @@
 
   "entity.farmersdelight.rotten_tomato": "Rutten tomat",
 
-  "effect.farmersdelight.nourishment.0.desc": "Förhindrar hungerförlust, förutom när man använder mättnad för att återfå hjärtan.",
-  "effect.farmersdelight.comfort.0.desc": "Ger naturlig återhämtning, oavsett hur hungrig du är.",
+  "effect.farmersdelight.nourishment.description": "Förhindrar hungerförlust, förutom när man använder mättnad för att återfå hjärtan.",
+  "effect.farmersdelight.comfort.description": "Ger naturlig återhämtning, oavsett hur hungrig du är.",
 
   "enchantment.farmersdelight.backstabbing": "Hugga i ryggen",
   "enchantment.farmersdelight.backstabbing.desc": "Förstärker skadan när du träffar ett mål bakifrån.",

--- a/src/main/resources/assets/farmersdelight/lang/tok.json
+++ b/src/main/resources/assets/farmersdelight/lang/tok.json
@@ -204,8 +204,8 @@
   "effect.farmersdelight.nourishment": "moku suli",
   "effect.farmersdelight.comfort": "pilin pona",
 
-  "effect.farmersdelight.nourishment.0.desc": "ni la, sijelo sina li pakala ala la sina wile ala e moku.",
-  "effect.farmersdelight.comfort.0.desc": "ni la, mute moku ale la sijelo sina li kama pona.",
+  "effect.farmersdelight.nourishment.description": "ni la, sijelo sina li pakala ala la sina wile ala e moku.",
+  "effect.farmersdelight.comfort.description": "ni la, mute moku ale la sijelo sina li kama pona.",
 
   "enchantment.farmersdelight.backstabbing": "pakala monsi",
   "enchantment.farmersdelight.backstabbing.desc": "ni la, pakala lon monsi li pakala suli.",

--- a/src/main/resources/assets/farmersdelight/lang/tr_tr.json
+++ b/src/main/resources/assets/farmersdelight/lang/tr_tr.json
@@ -184,8 +184,8 @@
   "effect.farmersdelight.nourishment": "Beslenme",
   "effect.farmersdelight.comfort": "Konfor",
 
-  "effect.farmersdelight.nourishment.0.desc": "İyileşmek için doygunluğun kullanıldığı durumlar dışında açlık kaybetmeni önler.",
-  "effect.farmersdelight.comfort.0.desc": "Ne kadar aç olursanız olun doğal yenilenme sağlar.",
+  "effect.farmersdelight.nourishment.description": "İyileşmek için doygunluğun kullanıldığı durumlar dışında açlık kaybetmeni önler.",
+  "effect.farmersdelight.comfort.description": "Ne kadar aç olursanız olun doğal yenilenme sağlar.",
 
   "enchantment.farmersdelight.backstabbing": "Sırtından Bıçaklama",
   "enchantment.farmersdelight.backstabbing.desc": "Bir hedefe arkadan vururkenki hasarı artırır.",

--- a/src/main/resources/assets/farmersdelight/lang/uk_ua.json
+++ b/src/main/resources/assets/farmersdelight/lang/uk_ua.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Ситість",
   "effect.farmersdelight.comfort": "Затишок",
 
-  "effect.farmersdelight.nourishment.0.desc": "Запобігає втраті голоду, за винятком використання насичення для лікування ушкоджень.",
-  "effect.farmersdelight.comfort.0.desc": "Забезпечує природне зцілення, незалежно від того, наскільки ви голодні.",
+  "effect.farmersdelight.nourishment.description": "Запобігає втраті голоду, за винятком використання насичення для лікування ушкоджень.",
+  "effect.farmersdelight.comfort.description": "Забезпечує природне зцілення, незалежно від того, наскільки ви голодні.",
 
   "enchantment.farmersdelight.backstabbing": "Підступність",
   "enchantment.farmersdelight.backstabbing.desc": "Збільшує шкоду при ударі цілі зі спини.",

--- a/src/main/resources/assets/farmersdelight/lang/vi_vn.json
+++ b/src/main/resources/assets/farmersdelight/lang/vi_vn.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Nuôi dưỡng",
   "effect.farmersdelight.comfort": "An nhàn",
 
-  "effect.farmersdelight.nourishment.0.desc": "Ngăn chặn đói, ngoại trừ khi sử dụng bão hòa để chữa lành sát thương.",
-  "effect.farmersdelight.comfort.0.desc": "Cung cấp khả năng hồi phục tự nhiên, bất kể bạn đói như thế nào.",
+  "effect.farmersdelight.nourishment.description": "Ngăn chặn đói, ngoại trừ khi sử dụng bão hòa để chữa lành sát thương.",
+  "effect.farmersdelight.comfort.description": "Cung cấp khả năng hồi phục tự nhiên, bất kể bạn đói như thế nào.",
 
   "enchantment.farmersdelight.backstabbing": "Đâm lén",
   "enchantment.farmersdelight.backstabbing.desc": "Tăng sát thương khi tấn công mục tiêu từ phía sau.",

--- a/src/main/resources/assets/farmersdelight/lang/vp_vl.json
+++ b/src/main/resources/assets/farmersdelight/lang/vp_vl.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "Vonanamting",
   "effect.farmersdelight.comfort": "Poheiwa",
 
-  "effect.farmersdelight.nourishment.0.desc": "Lakinaj mahaminus oharemauge, linaj bruk oharemauge per reforma.",
-  "effect.farmersdelight.comfort.0.desc": "Nasi shiknu razbengvona, awen li du ohare.",
+  "effect.farmersdelight.nourishment.description": "Lakinaj mahaminus oharemauge, linaj bruk oharemauge per reforma.",
+  "effect.farmersdelight.comfort.description": "Nasi shiknu razbengvona, awen li du ohare.",
 
   "enchantment.farmersdelight.backstabbing": "Hinavras",
   "enchantment.farmersdelight.backstabbing.desc": "Mahaplus arkatai li arka hina fu jenadjin.",

--- a/src/main/resources/assets/farmersdelight/lang/zh_cn.json
+++ b/src/main/resources/assets/farmersdelight/lang/zh_cn.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "滋养",
   "effect.farmersdelight.comfort": "舒适",
 
-  "effect.farmersdelight.nourishment.0.desc": "你不会再消耗饥饿值，除非需要借以恢复生命值。",
-  "effect.farmersdelight.comfort.0.desc": "使你对饥饿、缓慢和虚弱效果免疫。",
+  "effect.farmersdelight.nourishment.description": "你不会再消耗饥饿值，除非需要借以恢复生命值。",
+  "effect.farmersdelight.comfort.description": "使你对饥饿、缓慢和虚弱效果免疫。",
 
   "enchantment.farmersdelight.backstabbing": "背刺",
   "enchantment.farmersdelight.backstabbing.desc": "增加从后攻击目标时的伤害。",

--- a/src/main/resources/assets/farmersdelight/lang/zh_tw.json
+++ b/src/main/resources/assets/farmersdelight/lang/zh_tw.json
@@ -205,8 +205,8 @@
   "effect.farmersdelight.nourishment": "滋補",
   "effect.farmersdelight.comfort": "療癒",
 
-  "effect.farmersdelight.nourishment.0.desc": "除非需要回復血量，否則不再減少飽食度。",
-  "effect.farmersdelight.comfort.0.desc": "無視飢餓值，提供玩家自然回復效果。",
+  "effect.farmersdelight.nourishment.description": "除非需要回復血量，否則不再減少飽食度。",
+  "effect.farmersdelight.comfort.description": "無視飢餓值，提供玩家自然回復效果。",
 
   "enchantment.farmersdelight.backstabbing": "背刺",
   "enchantment.farmersdelight.backstabbing.desc": "從背後攻擊時的傷害增加。",


### PR DESCRIPTION
Fixed the format of the key string to the correct `effect.<mod_id>.<effect_id>.description` for each available language, as the current one doesn't work by default:
![image](https://github.com/user-attachments/assets/9fbc123b-0e14-4e08-b7e7-c3eb0b4f2dfd).
The same goes for the `Comfort` effect.
Test setup:
![image](https://github.com/user-attachments/assets/280c575f-8185-4b26-901b-bb6504fd9adc)

Updated `ru_ru.json`.