### PR TITLE
Wheat to Straw Cutting Recipe

### DIFF
--- a/wheat.json
+++ b/wheat.json
@@ -1,0 +1,17 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "minecraft:wheat"
+    }
+  ],
+  "result": [
+    {
+      "item": "farmersdelight:straw"
+    }
+  ],
+
+  "tool": {
+    "tag": "forge:tools/knives",
+  }
+}


### PR DESCRIPTION
Since straw can also be made from wheat in the real world, it feels only fitting that it's doable inside Minecraft, too :)