### PR TITLE
Make Rich Soil use a HashMap for Mushroom Colonies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out
 *.iml
 .idea
 
+# vscode
+.vscode/
+
 # gradle
 build
 .gradle

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ out
 *.iml
 .idea
 
-# vscode
-.vscode/
-
 # gradle
 build
 .gradle

--- a/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
@@ -47,7 +47,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 		.apply(builder, MushroomColonyBlock::new)
 	);
 
-	public static HashMap<ItemLike, MushroomColonyBlock> COLONIES = new HashMap<>();
+	private static HashMap<ItemLike, Block> COLONIES = new HashMap<>();
 	public static final int PLACING_LIGHT_LEVEL = 13;
 	public final ItemLike mushroomType;
 
@@ -125,6 +125,10 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 			level.setBlock(pos, state.setValue(COLONY_AGE, age + 1), 2);
 			CommonHooks.fireCropGrowPost(level, pos, state);
 		}
+	}
+
+	public static HashMap<ItemLike, Block> getMushroomColonies() {
+		return COLONIES;
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
@@ -6,7 +6,6 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
@@ -40,13 +39,13 @@ import vectorwing.farmersdelight.common.tag.ModTags;
 public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 {
 	public static final MapCodec<MushroomColonyBlock> CODEC = RecordCodecBuilder.mapCodec(
-			builder -> builder.group(BuiltInRegistries.ITEM.holderByNameCodec().fieldOf("mushroom").forGetter(block -> block.mushroomType), propertiesCodec())
+			builder -> builder.group(BuiltInRegistries.ITEM.byNameCodec().fieldOf("mushroom").forGetter(block -> block.mushroomType), propertiesCodec())
 					.apply(builder, MushroomColonyBlock::new)
 	);
 
-	public static HashMap<Holder<Item>, MushroomColonyBlock> COLONIES = new HashMap<>();
+	public static HashMap<Item, MushroomColonyBlock> COLONIES = new HashMap<>();
 	public static final int PLACING_LIGHT_LEVEL = 13;
-	public final Holder<Item> mushroomType;
+	public final Item mushroomType;
 
 	public static final IntegerProperty COLONY_AGE = BlockStateProperties.AGE_3;
 	protected static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
@@ -56,7 +55,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 			Block.box(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D),
 	};
 
-	public MushroomColonyBlock(Holder<Item> mushroomType, Properties properties) {
+	public MushroomColonyBlock(Item mushroomType, Properties properties) {
 		super(properties);
 		this.mushroomType = mushroomType;
 		this.registerDefaultState(this.stateDefinition.any().setValue(COLONY_AGE, 0));
@@ -126,7 +125,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 
 	@Override
 	public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
-		return new ItemStack(this.mushroomType.value());
+		return new ItemStack(this.mushroomType);
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
@@ -6,6 +6,7 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
@@ -17,9 +18,9 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -39,13 +40,16 @@ import vectorwing.farmersdelight.common.tag.ModTags;
 public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 {
 	public static final MapCodec<MushroomColonyBlock> CODEC = RecordCodecBuilder.mapCodec(
-			builder -> builder.group(BuiltInRegistries.ITEM.byNameCodec().fieldOf("mushroom").forGetter(block -> block.mushroomType), propertiesCodec())
-					.apply(builder, MushroomColonyBlock::new)
+		builder -> builder.group(
+			BuiltInRegistries.ITEM.byNameCodec().fieldOf("mushroom").forGetter(block -> block.mushroomType.asItem()), 
+			propertiesCodec()
+		)
+		.apply(builder, MushroomColonyBlock::new)
 	);
 
-	public static HashMap<Item, MushroomColonyBlock> COLONIES = new HashMap<>();
+	public static HashMap<ItemLike, MushroomColonyBlock> COLONIES = new HashMap<>();
 	public static final int PLACING_LIGHT_LEVEL = 13;
-	public final Item mushroomType;
+	public final ItemLike mushroomType;
 
 	public static final IntegerProperty COLONY_AGE = BlockStateProperties.AGE_3;
 	protected static final VoxelShape[] SHAPE_BY_AGE = new VoxelShape[]{
@@ -55,7 +59,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 			Block.box(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D),
 	};
 
-	public MushroomColonyBlock(Item mushroomType, Properties properties) {
+	public MushroomColonyBlock(ItemLike mushroomType, Properties properties) {
 		super(properties);
 		this.mushroomType = mushroomType;
 		this.registerDefaultState(this.stateDefinition.any().setValue(COLONY_AGE, 0));
@@ -88,7 +92,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 		if (floorState.is(BlockTags.MUSHROOM_GROW_BLOCK)) {
 			return true;
 		} else {
-			return level.getRawBrightness(pos, 0) < PLACING_LIGHT_LEVEL && floorState.canSustainPlant(level, floorPos, net.minecraft.core.Direction.UP, state).isDefault();
+			return level.getRawBrightness(pos, 0) < PLACING_LIGHT_LEVEL && floorState.canSustainPlant(level, floorPos, Direction.UP, state).isDefault();
 		}
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/MushroomColonyBlock.java
@@ -1,7 +1,10 @@
 package vectorwing.farmersdelight.common.block;
 
+import java.util.HashMap;
+
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -34,7 +37,6 @@ import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.Tags;
 import vectorwing.farmersdelight.common.tag.ModTags;
 
-@SuppressWarnings("deprecation")
 public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 {
 	public static final MapCodec<MushroomColonyBlock> CODEC = RecordCodecBuilder.mapCodec(
@@ -42,6 +44,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 					.apply(builder, MushroomColonyBlock::new)
 	);
 
+	public static HashMap<Holder<Item>, MushroomColonyBlock> COLONIES = new HashMap<>();
 	public static final int PLACING_LIGHT_LEVEL = 13;
 	public final Holder<Item> mushroomType;
 
@@ -57,6 +60,7 @@ public class MushroomColonyBlock extends BushBlock implements BonemealableBlock
 		super(properties);
 		this.mushroomType = mushroomType;
 		this.registerDefaultState(this.stateDefinition.any().setValue(COLONY_AGE, 0));
+		COLONIES.put(mushroomType, this);
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
@@ -41,7 +41,7 @@ public class RichSoilBlock extends Block
 		}
 
 		// Convert mushrooms to colonies if it's dark enough
-		var newBlock = MushroomColonyBlock.COLONIES.get(aboveBlock.asItem());
+		var newBlock = MushroomColonyBlock.getMushroomColonies().get(aboveBlock.asItem());
 
 		if (newBlock != null) {
 			level.setBlockAndUpdate(abovePos, newBlock.defaultBlockState());

--- a/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
@@ -1,5 +1,10 @@
 package vectorwing.farmersdelight.common.block;
 
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -19,8 +24,7 @@ import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.tag.ModTags;
 import vectorwing.farmersdelight.common.utility.MathUtils;
 
-import javax.annotation.Nullable;
-
+@SuppressWarnings("deprecation")
 public class RichSoilBlock extends Block
 {
 	public RichSoilBlock(Properties properties) {
@@ -40,12 +44,10 @@ public class RichSoilBlock extends Block
 			}
 
 			// Convert mushrooms to colonies if it's dark enough
-			if (aboveBlock == Blocks.BROWN_MUSHROOM) {
-				level.setBlockAndUpdate(pos.above(), ModBlocks.BROWN_MUSHROOM_COLONY.get().defaultBlockState());
-				return;
-			}
-			if (aboveBlock == Blocks.RED_MUSHROOM) {
-				level.setBlockAndUpdate(pos.above(), ModBlocks.RED_MUSHROOM_COLONY.get().defaultBlockState());
+			var newBlock = MushroomColonyBlock.COLONIES.get(aboveBlock.asItem().builtInRegistryHolder());
+
+			if (newBlock != null) {
+				level.setBlockAndUpdate(abovePos, newBlock.defaultBlockState());
 				return;
 			}
 

--- a/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RichSoilBlock.java
@@ -1,8 +1,5 @@
 package vectorwing.farmersdelight.common.block;
 
-import java.util.HashMap;
-import java.util.function.Supplier;
-
 import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
@@ -12,7 +9,6 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.CommonHooks;
@@ -24,7 +20,6 @@ import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.tag.ModTags;
 import vectorwing.farmersdelight.common.utility.MathUtils;
 
-@SuppressWarnings("deprecation")
 public class RichSoilBlock extends Block
 {
 	public RichSoilBlock(Properties properties) {
@@ -33,35 +28,36 @@ public class RichSoilBlock extends Block
 
 	@Override
 	public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource rand) {
-		if (!level.isClientSide) {
-			BlockPos abovePos = pos.above();
-			BlockState aboveState = level.getBlockState(abovePos);
-			Block aboveBlock = aboveState.getBlock();
+		if (level.isClientSide)
+			return;
 
-			// Do nothing if the plant is unaffected by rich soil
-			if (aboveState.is(ModTags.UNAFFECTED_BY_RICH_SOIL)) {
-				return;
-			}
+		BlockPos abovePos = pos.above();
+		BlockState aboveState = level.getBlockState(abovePos);
+		Block aboveBlock = aboveState.getBlock();
 
-			// Convert mushrooms to colonies if it's dark enough
-			var newBlock = MushroomColonyBlock.COLONIES.get(aboveBlock.asItem().builtInRegistryHolder());
+		// Do nothing if the plant is unaffected by rich soil
+		if (aboveState.is(ModTags.UNAFFECTED_BY_RICH_SOIL)) {
+			return;
+		}
 
-			if (newBlock != null) {
-				level.setBlockAndUpdate(abovePos, newBlock.defaultBlockState());
-				return;
-			}
+		// Convert mushrooms to colonies if it's dark enough
+		var newBlock = MushroomColonyBlock.COLONIES.get(aboveBlock.asItem());
 
-			if (Configuration.RICH_SOIL_BOOST_CHANCE.get() == 0.0) {
-				return;
-			}
+		if (newBlock != null) {
+			level.setBlockAndUpdate(abovePos, newBlock.defaultBlockState());
+			return;
+		}
 
-			// If all else fails, and it's a plant, give it a growth boost now and then!
-			if (aboveBlock instanceof BonemealableBlock growable && MathUtils.RAND.nextFloat() <= Configuration.RICH_SOIL_BOOST_CHANCE.get()) {
-				if (growable.isValidBonemealTarget(level, pos.above(), aboveState) && CommonHooks.canCropGrow(level, pos.above(), aboveState, true)) {
-					growable.performBonemeal(level, level.random, pos.above(), aboveState);
-					//level.levelEvent(1505, pos.above(), 0);
-					CommonHooks.fireCropGrowPost(level, pos.above(), aboveState);
-				}
+		if (Configuration.RICH_SOIL_BOOST_CHANCE.get() == 0.0) {
+			return;
+		}
+
+		// If all else fails, and it's a plant, give it a growth boost now and then!
+		if (aboveBlock instanceof BonemealableBlock growable && MathUtils.RAND.nextFloat() <= Configuration.RICH_SOIL_BOOST_CHANCE.get()) {
+			if (growable.isValidBonemealTarget(level, pos.above(), aboveState) && CommonHooks.canCropGrow(level, pos.above(), aboveState, true)) {
+				growable.performBonemeal(level, level.random, pos.above(), aboveState);
+				//level.levelEvent(1505, pos.above(), 0);
+				CommonHooks.fireCropGrowPost(level, pos.above(), aboveState);
 			}
 		}
 	}

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModBlocks.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModBlocks.java
@@ -237,9 +237,9 @@ public class ModBlocks
 
 	// Composting
 	public static final Supplier<Block> BROWN_MUSHROOM_COLONY = BLOCKS.register("brown_mushroom_colony",
-			() -> new MushroomColonyBlock(Items.BROWN_MUSHROOM.builtInRegistryHolder(), Block.Properties.ofFullCopy(Blocks.BROWN_MUSHROOM)));
+			() -> new MushroomColonyBlock(Items.BROWN_MUSHROOM, Block.Properties.ofFullCopy(Blocks.BROWN_MUSHROOM)));
 	public static final Supplier<Block> RED_MUSHROOM_COLONY = BLOCKS.register("red_mushroom_colony",
-			() -> new MushroomColonyBlock(Items.RED_MUSHROOM.builtInRegistryHolder(), Block.Properties.ofFullCopy(Blocks.RED_MUSHROOM)));
+			() -> new MushroomColonyBlock(Items.RED_MUSHROOM, Block.Properties.ofFullCopy(Blocks.RED_MUSHROOM)));
 	public static final Supplier<Block> ORGANIC_COMPOST = BLOCKS.register("organic_compost",
 			() -> new OrganicCompostBlock(Block.Properties.ofFullCopy(Blocks.DIRT).strength(1.2F).sound(SoundType.CROP)));
 	public static final Supplier<Block> RICH_SOIL = BLOCKS.register("rich_soil",


### PR DESCRIPTION
This allows addons to add their own Mushroom Colonies without needing to mixin `RichSoilBlock`. 

This also changes the `MushroomColonyBlock` to use an `Item` instead of a `Holder<Item>`, as the `builtInRegistryHolder` method is deprecated and using an `Item` works fine.
