### PR TITLE
Rearrange Basket's implementation and add proper Capability for Basket and Cabinet

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/Basket.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/Basket.java
@@ -1,8 +1,17 @@
 package vectorwing.farmersdelight.common.block.entity;
 
+import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.EntitySelector;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.shapes.VoxelShape;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 
 public interface Basket extends Container
 {
@@ -15,22 +24,154 @@ public interface Basket extends Container
 			Block.box(0.0D, 0.0D, 0.0D, 32.0D, 16.0D, 16.0D)        // east
 	};
 
+	/**
+	 * Get the {@link VoxelShape area} for collecting in world {@link ItemEntity} for a specific facing direction.
+	 * @param facingIndex the the {@link Direction#get3DDataValue() index} of the facing direction.
+	 * @return the collection area for collecting in world {@link ItemEntity}.
+	 */
 	default VoxelShape getFacingCollectionArea(int facingIndex) {
 		return COLLECTION_AREA_SHAPES[facingIndex];
 	}
 
 	/**
-	 * Gets the world X position for this hopper entity.
+	 * Gets the world X position for this basket entity.
 	 */
 	double getLevelX();
 
 	/**
-	 * Gets the world Y position for this hopper entity.
+	 * Gets the world Y position for this basket entity.
 	 */
 	double getLevelY();
 
 	/**
-	 * Gets the world Z position for this hopper entity.
+	 * Gets the world Z position for this basket entity.
 	 */
 	double getLevelZ();
+
+	/**
+	 * Sets the transfer cooldown for the basket entity.
+	 * @param ticks cooldown ticks
+	 */
+	void setCooldown(int ticks);
+
+	/**
+	 * @return if the basket is currently on cooldown,
+	 * cooldown should only be set when the basket is not on cooldown.
+	 */
+	boolean isOnCooldown();
+
+	/**
+	 * @return if the basket's current cooldown exceeds default cooldown,
+	 * and should be respected when updating cooldown with default.
+	 */
+	boolean isOnCustomCooldown();
+
+	/**
+	 * Updates the transfer cooldown upon a transfer attempt.
+	 * @param transfer the transfer attempt, returning
+	 */
+	void tryTransfer(BooleanSupplier transfer);
+
+	/**
+	 * Collect items from the {@link #getFacingCollectionArea(int) collection area}.
+	 * @param level the {@link Level} of the basket
+	 * @param facingIndex the {@link Direction#get3DDataValue() index} of the facing direction.
+	 * @return if any items are succesfully captured and placed in the basket.
+	 */
+	default boolean collectItems(Level level, int facingIndex) {
+		for (ItemEntity itementity : getItemsToCollect(level, facingIndex)) {
+			if (collectItem(itementity)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @param level the {@link Level} of the basket
+	 * @param facingIndex the {@link Direction#get3DDataValue() index} of the facing direction.
+	 * @return all {@link ItemEntity item entities} within the {@link #getFacingCollectionArea(int) collection area}.
+	 */
+	default List<ItemEntity> getItemsToCollect(Level level, int facingIndex) {
+		return this.getFacingCollectionArea(facingIndex).toAabbs()
+				.stream()
+				.flatMap((aabb) -> level.getEntitiesOfClass(
+						ItemEntity.class,
+						aabb.move(this.getLevelX() - 0.5D, this.getLevelY() - 0.5D, this.getLevelZ() - 0.5D),
+						EntitySelector.ENTITY_STILL_ALIVE
+				).stream())
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Collect a single {@link ItemEntity item entity}.
+	 * @param itemEntity the {@link ItemEntity item entity} to be collected.
+	 * @return if the {@link ItemEntity item entity} is successfully collected.
+	 */
+	default boolean collectItem(ItemEntity itemEntity) {
+		boolean flag = false;
+		ItemStack entityItemStack = itemEntity.getItem().copy();
+		ItemStack remainderStack = insert(entityItemStack);
+		if (remainderStack.isEmpty()) {
+			flag = true;
+			itemEntity.discard();
+		} else {
+			itemEntity.setItem(remainderStack);
+		}
+		return flag;
+	}
+
+	/**
+	 * Attempt to insert an {@link ItemStack} to all available slots of the basket.
+	 * @param stack the {@link ItemStack} to insert.
+	 * @return the remainder after the insertion.
+	 */
+	default ItemStack insert(ItemStack stack) {
+		int size = this.getContainerSize();
+		for (int slot = 0; slot < size && !stack.isEmpty(); ++slot) {
+			stack = this.insert(slot, stack);
+		}
+		return stack;
+	}
+
+	/**
+	 * Attempt to insert an {@link ItemStack} to one of the basket slots.
+	 * @param slot the slot to insert into.
+	 * @param stack the {@link ItemStack} to insert.
+	 * @return the remainder after the insertion.
+	 */
+	default ItemStack insert(int slot, ItemStack stack) {
+		ItemStack slotStack = this.getItem(slot);
+		if (this.canPlaceItem(slot, stack)) {
+			boolean inserted = false;
+			if (slotStack.isEmpty()) {
+				this.setItem(slot, stack);
+				stack = ItemStack.EMPTY;
+				inserted = true;
+			} else if (canMergeItems(slotStack, stack)) {
+				int insertCount = stack.getMaxStackSize() - slotStack.getCount();
+				insertCount = Math.min(stack.getCount(), insertCount);
+				stack.shrink(insertCount);
+				slotStack.grow(insertCount);
+				inserted = insertCount > 0;
+			}
+			if (inserted) {
+				if (this.isEmpty() && !this.isOnCustomCooldown()) {
+					this.setCooldown(8);
+				}
+				this.setChanged();
+			}
+		}
+		return stack;
+	}
+
+	/**
+	 * Helper method for checking if two {@link ItemStack} can be merged (with remainders).
+	 * @param stack1 the first {@link ItemStack}.
+	 * @param stack2 the second {@link ItemStack}.
+	 * @return if the two {@link ItemStack} can be merged (with remainders).
+	 */
+	static boolean canMergeItems(ItemStack stack1, ItemStack stack2) {
+		return stack1.getCount() <= stack1.getMaxStackSize() && ItemStack.isSameItemSameComponents(stack1, stack2);
+	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/BasketBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/BasketBlockEntity.java
@@ -1,17 +1,11 @@
 package vectorwing.farmersdelight.common.block.entity;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.Container;
 import net.minecraft.world.ContainerHelper;
-import net.minecraft.world.WorldlyContainer;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntitySelector;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ChestMenu;
@@ -20,17 +14,19 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.phys.shapes.BooleanOp;
-import net.minecraft.world.phys.shapes.Shapes;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.block.BasketBlock;
+import vectorwing.farmersdelight.common.block.entity.inventory.BasketInvWrapper;
 import vectorwing.farmersdelight.common.registry.ModBlockEntityTypes;
 import vectorwing.farmersdelight.common.utility.TextUtils;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import java.util.function.BooleanSupplier;
 
+@EventBusSubscriber(modid = FarmersDelight.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class BasketBlockEntity extends RandomizableContainerBlockEntity implements Basket
 {
 	private NonNullList<ItemStack> items = NonNullList.withSize(27, ItemStack.EMPTY);
@@ -38,6 +34,15 @@ public class BasketBlockEntity extends RandomizableContainerBlockEntity implemen
 
 	public BasketBlockEntity(BlockPos pos, BlockState state) {
 		super(ModBlockEntityTypes.BASKET.get(), pos, state);
+	}
+
+	@SubscribeEvent
+	public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+		event.registerBlockEntity(
+				Capabilities.ItemHandler.BLOCK,
+				ModBlockEntityTypes.BASKET.get(),
+				(be, context) -> new BasketInvWrapper(be)
+		);
 	}
 
 	@Override
@@ -85,84 +90,6 @@ public class BasketBlockEntity extends RandomizableContainerBlockEntity implemen
 		return TextUtils.getTranslation("container.basket");
 	}
 
-	public static boolean pullItems(Level level, Basket basket, int facingIndex) {
-		for (ItemEntity itementity : getCaptureItems(level, basket, facingIndex)) {
-			if (captureItem(basket, itementity)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public static ItemStack putStackInInventoryAllSlots(Container destination, ItemStack stack) {
-		int i = destination.getContainerSize();
-
-		for (int j = 0; j < i && !stack.isEmpty(); ++j) {
-			stack = insertStack(destination, stack, j);
-		}
-
-		return stack;
-	}
-
-	private static boolean canInsertItemInSlot(Container inventoryIn, ItemStack stack, int index, @Nullable Direction side) {
-		if (!inventoryIn.canPlaceItem(index, stack)) return false;
-		return !(inventoryIn instanceof WorldlyContainer) || ((WorldlyContainer) inventoryIn).canPlaceItemThroughFace(index, stack, side);
-	}
-
-	private static boolean canCombine(ItemStack stack1, ItemStack stack2) {
-		return stack1.getCount() <= stack1.getMaxStackSize() && ItemStack.isSameItemSameComponents(stack1, stack2);
-	}
-
-	private static ItemStack insertStack(Container destination, ItemStack stack, int index) {
-		ItemStack itemstack = destination.getItem(index);
-		if (canInsertItemInSlot(destination, stack, index, null)) {
-			boolean flag = false;
-			boolean isDestinationEmpty = destination.isEmpty();
-			if (itemstack.isEmpty()) {
-				destination.setItem(index, stack);
-				stack = ItemStack.EMPTY;
-				flag = true;
-			} else if (canCombine(itemstack, stack)) {
-				int i = stack.getMaxStackSize() - itemstack.getCount();
-				int j = Math.min(stack.getCount(), i);
-				stack.shrink(j);
-				itemstack.grow(j);
-				flag = j > 0;
-			}
-
-			if (flag) {
-				if (isDestinationEmpty && destination instanceof BasketBlockEntity firstBasket) {
-					if (!firstBasket.mayTransfer()) {
-						int k = 0;
-						firstBasket.setTransferCooldown(8 - k);
-					}
-				}
-
-				destination.setChanged();
-			}
-		}
-
-		return stack;
-	}
-
-	public static boolean captureItem(Container inventory, ItemEntity itemEntity) {
-		boolean flag = false;
-		ItemStack entityItemStack = itemEntity.getItem().copy();
-		ItemStack remainderStack = putStackInInventoryAllSlots(inventory, entityItemStack);
-		if (remainderStack.isEmpty()) {
-			flag = true;
-			itemEntity.discard();
-		} else {
-			itemEntity.setItem(remainderStack);
-		}
-
-		return flag;
-	}
-
-	public static List<ItemEntity> getCaptureItems(Level level, Basket basket, int facingIndex) {
-		return basket.getFacingCollectionArea(facingIndex).toAabbs().stream().flatMap((aabb) -> level.getEntitiesOfClass(ItemEntity.class, aabb.move(basket.getLevelX() - 0.5D, basket.getLevelY() - 0.5D, basket.getLevelZ() - 0.5D), EntitySelector.ENTITY_STILL_ALIVE).stream()).collect(Collectors.toList());
-	}
-
 	// -- STANDARD INVENTORY STUFF --
 	@Override
 	protected NonNullList<ItemStack> getItems() {
@@ -179,52 +106,44 @@ public class BasketBlockEntity extends RandomizableContainerBlockEntity implemen
 		return ChestMenu.threeRows(id, player, this);
 	}
 
-	public void setTransferCooldown(int ticks) {
+	@Override
+	public void setCooldown(int ticks) {
 		this.transferCooldown = ticks;
 	}
 
-	private boolean isOnTransferCooldown() {
+	public boolean isOnCooldown() {
 		return this.transferCooldown > 0;
 	}
 
-	public boolean mayTransfer() {
+	@Override
+	public boolean isOnCustomCooldown() {
 		return this.transferCooldown > 8;
 	}
 
-	private void updateHopper(Supplier<Boolean> supplier) {
+	@Override
+	public void tryTransfer(BooleanSupplier transfer) {
 		if (this.level != null && !this.level.isClientSide) {
-			if (!this.isOnTransferCooldown() && this.getBlockState().getValue(BlockStateProperties.ENABLED)) {
+			if (!this.isOnCooldown() && this.getBlockState().getValue(BlockStateProperties.ENABLED)) {
 				boolean flag = false;
 				if (!this.isFull()) {
-					flag = supplier.get();
+					flag = transfer.getAsBoolean();
 				}
 
 				if (flag) {
-					this.setTransferCooldown(8);
+					this.setCooldown(8);
 					this.setChanged();
 				}
 			}
 		}
 	}
 
-	private boolean isFull() {
+	protected boolean isFull() {
 		for (ItemStack itemstack : this.items) {
 			if (itemstack.isEmpty() || itemstack.getCount() != itemstack.getMaxStackSize()) {
 				return false;
 			}
 		}
-
 		return true;
-	}
-
-	public void onEntityCollision(Entity entity) {
-		if (entity instanceof ItemEntity) {
-			BlockPos blockpos = this.getBlockPos();
-			int facing = this.getBlockState().getValue(BasketBlock.FACING).get3DDataValue();
-			if (Shapes.joinIsNotEmpty(Shapes.create(entity.getBoundingBox().move(-blockpos.getX(), -blockpos.getY(), -blockpos.getZ())), this.getFacingCollectionArea(facing), BooleanOp.AND)) {
-				this.updateHopper(() -> captureItem(this, (ItemEntity) entity));
-			}
-		}
 	}
 
 	@Override
@@ -244,10 +163,10 @@ public class BasketBlockEntity extends RandomizableContainerBlockEntity implemen
 
 	public static void pushItemsTick(Level level, BlockPos pos, BlockState state, BasketBlockEntity blockEntity) {
 		--blockEntity.transferCooldown;
-		if (!blockEntity.isOnTransferCooldown()) {
-			blockEntity.setTransferCooldown(0);
+		if (!blockEntity.isOnCooldown()) {
+			blockEntity.setCooldown(0);
 			int facing = state.getValue(BasketBlock.FACING).get3DDataValue();
-			blockEntity.updateHopper(() -> pullItems(level, blockEntity, facing));
+			blockEntity.tryTransfer(() -> blockEntity.collectItems(level, facing));
 		}
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CabinetBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CabinetBlockEntity.java
@@ -19,11 +19,18 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.ContainerOpenersCounter;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.items.wrapper.InvWrapper;
+import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.block.CabinetBlock;
 import vectorwing.farmersdelight.common.registry.ModBlockEntityTypes;
 import vectorwing.farmersdelight.common.registry.ModSounds;
 import vectorwing.farmersdelight.common.utility.TextUtils;
 
+@EventBusSubscriber(modid = FarmersDelight.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class CabinetBlockEntity extends RandomizableContainerBlockEntity
 {
 	private NonNullList<ItemStack> contents = NonNullList.withSize(27, ItemStack.EMPTY);
@@ -54,6 +61,15 @@ public class CabinetBlockEntity extends RandomizableContainerBlockEntity
 
 	public CabinetBlockEntity(BlockPos pos, BlockState state) {
 		super(ModBlockEntityTypes.CABINET.get(), pos, state);
+	}
+
+	@SubscribeEvent
+	public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+		event.registerBlockEntity(
+				Capabilities.ItemHandler.BLOCK,
+				ModBlockEntityTypes.CABINET.get(),
+				(be, context) -> new InvWrapper(be)
+		);
 	}
 
 	@Override

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/inventory/BasketInvWrapper.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/inventory/BasketInvWrapper.java
@@ -1,0 +1,31 @@
+package vectorwing.farmersdelight.common.block.entity.inventory;
+
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.items.wrapper.InvWrapper;
+import vectorwing.farmersdelight.common.block.entity.Basket;
+
+public class BasketInvWrapper extends InvWrapper {
+    protected final Basket basket;
+
+    public BasketInvWrapper(Basket basket) {
+        super(basket);
+        this.basket = basket;
+    }
+
+    @Override
+    public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+        if (simulate) {
+            return super.insertItem(slot, stack, true);
+        } else {
+            boolean wasEmpty = basket.isEmpty();
+            int originalCount = stack.getCount();
+            stack = super.insertItem(slot, stack, false);
+            if (wasEmpty && originalCount > stack.getCount()) {
+                if (!basket.isOnCustomCooldown()) {
+                    basket.setCooldown(8);
+                }
+            }
+            return stack;
+        }
+    }
+}

--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/inventory/package-info.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/inventory/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package vectorwing.farmersdelight.common.block.entity.inventory;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR rearranged Basket's implementation, moving shared implementation to the `Basket` interface for extensibility (afaik Miner's Delight has their own Basket variant and the mod is not ported to 1.21.1 yet).

Also added back proper Capability for Basket and Cabinet, as NeoForge reworked the Capability system so containers no longer automatically provide Capability. Fixes #1096.