### PR TITLE
Fix rich soil farmland turning into dirt and negating fall damage

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/RichSoilFarmlandBlock.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/RichSoilFarmlandBlock.java
@@ -104,7 +104,8 @@ public class RichSoilFarmlandBlock extends FarmBlock
 	}
 
 	@Override
-	public void fallOn(Level level, BlockState state, BlockPos pos, Entity entityIn, float fallDistance) {
-		// Rich Soil is immune to trampling
+	public void fallOn(Level level, BlockState state, BlockPos pos, Entity entity, float fallDistance) {
+		// Rich Soil is immune to trampling, so the Block::fallOn behavior is restored.
+		entity.causeFallDamage(fallDistance, 1.0F, entity.damageSources().fall());
 	}
 }

--- a/src/main/java/vectorwing/farmersdelight/common/mixin/KeepRichSoilUntrampledMixin.java
+++ b/src/main/java/vectorwing/farmersdelight/common/mixin/KeepRichSoilUntrampledMixin.java
@@ -1,0 +1,19 @@
+package vectorwing.farmersdelight.common.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.FarmBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vectorwing.farmersdelight.common.block.RichSoilFarmlandBlock;
+
+@Mixin(FarmBlock.class)
+public class KeepRichSoilUntrampledMixin {
+    @Inject(at = @At(value = "HEAD"), method = "turnToDirt", cancellable = true)
+    private static void turnToDirt(BlockState blockState, Level level, BlockPos blockPos, CallbackInfo ci) {
+        if (blockState.getBlock() instanceof RichSoilFarmlandBlock) ci.cancel();
+    }
+}

--- a/src/main/resources/farmersdelight.mixins.json
+++ b/src/main/resources/farmersdelight.mixins.json
@@ -8,6 +8,7 @@
     "CuttingBoardDispenserMixin",
     "KeepRichSoilGiantTreeMixin",
     "KeepRichSoilTreeMixin",
+    "KeepRichSoilUntrampledMixin",
     "RabbitsEatCabbageMixin",
     "SoupItemMixin",
     "accessor.RecipeManagerAccessor"


### PR DESCRIPTION
This is a twofer:
1. `RichSoilFarmlandBlock::fallOn` has to call `Entity::causeFallDamage`, otherwise if you fall onto it, you take no fall damage.
2. There are certain interactions with other mods that cause the rich soil farmland to turn into dirt. I noticed this with Allurement's Shockwave enchantment, which turns surrounding farm land back into dirt by calling `FarmBlock::turnToDirt`. The mixin just checks at the top of that static function if it's a `RichSoilFarmlandBlock` and returns early if so. Some friends and me did some brainstorming and weren't able to come up with a situation where this would cause an issue.