### PR TITLE
Fix #1139.

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
@@ -287,7 +287,7 @@ public class CookingPotBlockEntity extends SyncedBlockEntity implements MenuProv
 					return true;
 				} else if (!ItemStack.isSameItem(storedMealStack, resultStack)) {
 					return false;
-				} else if (storedMealStack.getCount() + resultStack.getCount() <= inventory.getSlotLimit(MEAL_DISPLAY_SLOT)) {
+				} else if (storedMealStack.getCount() + resultStack.getCount() <= Math.max(64, storedMealStack.getMaxStackSize())) {
 					return true;
 				} else {
 					return storedMealStack.getCount() + resultStack.getCount() <= resultStack.getMaxStackSize();
@@ -518,6 +518,14 @@ public class CookingPotBlockEntity extends SyncedBlockEntity implements MenuProv
 	private ItemStackHandler createHandler() {
 		return new ItemStackHandler(INVENTORY_SIZE)
 		{
+			@Override
+			protected int getStackLimit(int slot, ItemStack stack) {
+				if (slot == MEAL_DISPLAY_SLOT) {
+					return Math.max(64, stack.getMaxStackSize());
+				}
+				return super.getStackLimit(slot, stack);
+			}
+
 			@Override
 			protected void onContentsChanged(int slot) {
 				inventoryChanged();


### PR DESCRIPTION
Resolves #1139.

Pretty much has the Cooking Pot display stack max out to 64 unless it has a max stack size above that value.