### PR TITLE
Make the CookingPotRecipeBookTab enum StringRepresentable

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/client/recipebook/CookingPotRecipeBookTab.java
+++ b/src/main/java/vectorwing/farmersdelight/client/recipebook/CookingPotRecipeBookTab.java
@@ -2,10 +2,11 @@ package vectorwing.farmersdelight.client.recipebook;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import net.minecraft.util.StringRepresentable;
 
 import java.util.EnumSet;
 
-public enum CookingPotRecipeBookTab
+public enum CookingPotRecipeBookTab implements StringRepresentable
 {
 	MEALS("meals"),
 	DRINKS("drinks"),
@@ -36,6 +37,11 @@ public enum CookingPotRecipeBookTab
 
 	@Override
 	public String toString() {
+		return this.name;
+	}
+
+	@Override
+	public String getSerializedName() {
 		return this.name;
 	}
 }


### PR DESCRIPTION
I noticed that the `CookingPotRecipeBookTab` enum wasn't `StringRepresentable` when updating KubeJS Delight to 1.21.1, when I tried to add it as a enum recipe component, which requires the enum to be `StringRepresentable`.

This change would make it so I don't need to work around with a duplicate of the enum that implements that interface, and of course the addon would adapt to any future changes (idk if there would be any, but just in case)