### PR TITLE
[1.21] Make wild cabbage and beetroot compatible with any beach biome

### DIFF
--- a/src/main/resources/data/farmersdelight/neoforge/biome_modifier/wild_beetroots.json
+++ b/src/main/resources/data/farmersdelight/neoforge/biome_modifier/wild_beetroots.json
@@ -1,6 +1,6 @@
 {
-  "type": "neoforge:add_features",
-  "biomes": "minecraft:beach",
+  "type": "farmersdelight:add_features_by_filter",
+  "allowed_biomes": "#minecraft:is_beach",
   "features": "farmersdelight:patch_wild_beetroots",
   "step": "vegetal_decoration"
 }

--- a/src/main/resources/data/farmersdelight/neoforge/biome_modifier/wild_cabbages.json
+++ b/src/main/resources/data/farmersdelight/neoforge/biome_modifier/wild_cabbages.json
@@ -1,6 +1,6 @@
 {
-  "type": "neoforge:add_features",
-  "biomes": "minecraft:beach",
+  "type": "farmersdelight:add_features_by_filter",
+  "allowed_biomes": "#minecraft:is_beach",
   "features": "farmersdelight:patch_wild_cabbages",
   "step": "vegetal_decoration"
 }


### PR DESCRIPTION
Wild cabbages and wild beetroots still seem to use some old behaviour, but the main change here is this hardcoded `minecraft:beach` for the allowed biome, changing it to `#minecraft:is_beach` will allow it to be compatible with other world generation mods where no regular `minecraft:beach` might exist. *(speaking about Still Life Mod/Datapack, I had this issue there :c)*
Here is a before/after for demonstration, they are located around the same area with the same type of custom beach generated by Still Life.
Before:
<img width="1920" height="1080" alt="screenshot of a custom beach biome generation by still life with wild cabbages and wild beetroots not generating" src="https://github.com/user-attachments/assets/ad417c37-fe03-4b01-8667-4c0cb12e8c06" />
After:
<img width="1920" height="1080" alt="screenshot of a custom beach biome generation by still life with the change of making wild cabbages and wild beetroots compatible with it" src="https://github.com/user-attachments/assets/b34b3a29-a896-4c2b-9b66-7b39efacf926" />


