### PR TITLE
Update CuttingBoardRecipeBuilder.java

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -45,7 +45,7 @@ public class CuttingBoardRecipeBuilder
 	/**
 	 * Creates a new builder for a cutting recipe, providing a chance for the main output to drop.
 	 */
-	public static CuttingBoardRecipeBuilder cuttingRecipe(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, int chance) {
+	public static CuttingBoardRecipeBuilder cuttingRecipe(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
 		return new CuttingBoardRecipeBuilder(ingredient, tool, mainResult, count, chance);
 	}
 


### PR DESCRIPTION
The private constructor for CuttingBoardRecipeBuilder accepts `chance` as type float, however this `cuttingRecipe` method accepts and casts it to type int instead. This means that the current RecipeBuilder can only build recipes with 100% chance for the main result. This commit fixes the type of `chance` to be float in the builder method.