### PR TITLE
QuickMoving food from Cooking pot output to player inventory gives crafting xp

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/container/CookingPotMenu.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/container/CookingPotMenu.java
@@ -121,6 +121,7 @@ public class CookingPotMenu extends RecipeBookMenu<RecipeWrapper>
 				if (!this.moveItemStackTo(slotStack, startPlayerInv, endPlayerInv, true)) {
 					return ItemStack.EMPTY;
 				}
+				slot.onQuickCraft(slotStackCopy, slotStack);
 			} else if (index > indexOutput) {
 				boolean isValidContainer = slotStack.is(ModTags.SERVING_CONTAINERS) || slotStack.is(blockEntity.getContainer().getItem());
 				if (isValidContainer && !this.moveItemStackTo(slotStack, indexContainerInput, indexContainerInput + 1, false)) {


### PR DESCRIPTION
call Slot#onQuickCraft() in ,QuickMoveStack, much like abstractFurnaceMenu does.
quickMoving food from the result slot into player's inventory should now give XP / achievement, just like when they would've if they dragged the item.