### PR TITLE
Fix the logic of the useHeldItemOnMeal method for the cooking pot and…

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
+++ b/src/main/java/vectorwing/farmersdelight/common/block/entity/CookingPotBlockEntity.java
@@ -468,14 +468,33 @@ public class CookingPotBlockEntity extends SyncedBlockEntity implements MenuProv
 		}
 	}
 
-	public ItemStack useHeldItemOnMeal(ItemStack container) {
-		if (isContainerValid(container) && !getMeal().isEmpty()) {
-			container.shrink(1);
-			inventoryChanged();
-			return getMeal().split(1);
-		}
-		return ItemStack.EMPTY;
-	}
+    public ItemStack useHeldItemOnMeal(ItemStack container) {
+        ItemStack mealStack = this.getMeal();
+        if (mealStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+
+        if (!this.doesMealHaveContainer(mealStack)) {
+
+            if (container.isEmpty() ||
+                    (ItemStack.isSameItem(mealStack, container) && container.getCount() < container.getMaxStackSize())) {
+                ItemStack result = mealStack.split(1);
+                this.inventoryChanged();
+                return result;
+            } else {
+                return ItemStack.EMPTY;
+            }
+        }
+
+        else if (this.isContainerValid(container)) {
+            container.shrink(1);
+            this.inventoryChanged();
+            return mealStack.split(1);
+        } else {
+            return ItemStack.EMPTY;
+        }
+    }
 
 	private boolean doesMealHaveContainer(ItemStack meal) {
 		return !mealContainerStack.isEmpty() || meal.hasCraftingRemainingItem();


### PR DESCRIPTION
… improve the handling of dishes without containers.

The following issue has been resolved:
When there is more than one stack of dishes in the pot that do not require containers, if the player right-clicks while holding the same type of dish, the dish would be incorrectly identified as a container and consumed. 
The useHeldItemOnMeal method has been modified to correctly handle the following scenarios: For dishes without containers, empty-handed interaction is allowed to take one portion. When the player right-clicks while holding the same type of dish, it will only open the pot's menu.