### PR TITLE
Added & adjusted effectTick checks for the Comfort effect

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
@@ -6,6 +6,7 @@ import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameRules;
 
 @SuppressWarnings("unused")
 public class ComfortEffect extends MobEffect
@@ -21,13 +22,21 @@ public class ComfortEffect extends MobEffect
 
 	@Override
 	public void applyEffectTick(LivingEntity entity, int amplifier) {
+		boolean flag = entity.level().getGameRules().getBoolean(GameRules.RULE_NATURAL_REGENERATION);
+		if (!flag){
+			return;
+		}
 		if (entity.hasEffect(MobEffects.REGENERATION)) {
 			return;
 		}
 		if (entity instanceof Player player) {
+			if (player.getFoodData().getFoodLevel()>=18){
+				return;
+			}
 			if (player.getFoodData().getSaturationLevel() > 0.0) {
 				return;
 			}
+
 		}
 		if (entity.getHealth() < entity.getMaxHealth()) {
 			entity.heal(1.0F);

--- a/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
@@ -33,8 +33,8 @@ public class ComfortEffect extends MobEffect
 			if (player.getFoodData().getFoodLevel()>=18){
 				return;
 			}
-			if (player.getFoodData().getSaturationLevel() > 0.0) {
-				return;
+			if (player.getFoodData().getSaturationLevel() > 0.0 && player.getFoodData().getFoodLevel()<18) {
+					return;
 			}
 
 		}

--- a/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
+++ b/src/main/java/vectorwing/farmersdelight/common/effect/ComfortEffect.java
@@ -33,10 +33,6 @@ public class ComfortEffect extends MobEffect
 			if (player.getFoodData().getFoodLevel()>=18){
 				return;
 			}
-			if (player.getFoodData().getSaturationLevel() > 0.0 && player.getFoodData().getFoodLevel()<18) {
-					return;
-			}
-
 		}
 		if (entity.getHealth() < entity.getMaxHealth()) {
 			entity.heal(1.0F);


### PR DESCRIPTION
Currently, the comfort effect does not respect the natural regeneration gamerule, so I added a flag for that.

Also, to account for a few situations regarding food & saturation values, I swapped out the saturation check for food level checks (although I am uncertain if the main branch's behavior is actually intended. If it is, then this change can be discarded.)

These are the scenarios that I was accounting for:
1. Hunger bar greater than or equal to 18 with no saturation
2. Hunger bar less than 18 with no saturation
3. Hunger bar less than 18 with saturation

Situation 2 works as intended, and the player is healed. The concerns are situations 1 and 3.
In situation 1, as comfort is applied independently from natural regeneration, this can result in the player healing 2 HP instead of just 1.
In situation 3, comfort doesn't trigger despite not being able to consume saturation for fast healing. For instance, if I eat a beef stew when I am at 0 hunger, even though I'm below the threshold for natural regeneration, I will not heal due to having saturation. 
By checking food levels instead of saturation, this ensures the player only heals if there is no way for natural regeneration to occur.