### PR TITLE
Update CuttingBoardRecipeBuilder.java

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
+++ b/src/main/java/vectorwing/farmersdelight/data/builder/CuttingBoardRecipeBuilder.java
@@ -29,7 +29,7 @@ public class CuttingBoardRecipeBuilder implements RecipeBuilder
 	private final Ingredient tool;
 	private SoundEvent soundEvent;
 
-	private CuttingBoardRecipeBuilder(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
+	public CuttingBoardRecipeBuilder(Ingredient ingredient, Ingredient tool, ItemLike mainResult, int count, float chance) {
 		this.results.add(new ChanceResult(new ItemStack(mainResult.asItem(), count), chance));
 		this.ingredient = ingredient;
 		this.tool = tool;


### PR DESCRIPTION
enable public reference of constructor, allow class extensions for custom implementations to piggyback on in add-on mods.

the pot recipe builder is public. allowing code of this nature.
```java
private static class PotBuilder extends CookingPotRecipeBuilder {
        private final String name;

        public PotBuilder(ItemLike result, int count, int cookingTime, float experience, @Nullable ItemLike container) {
            super(result, count, cookingTime, experience, container);
            this.name = "cookingpot_" + BuiltInRegistries.ITEM.getKey(result.asItem()).getPath();
        }

        public static CookingPotRecipeBuilder cookingPotRecipe(ItemLike mainResult, int count, int cookingTime, float experience) {
            return new PotBuilder(mainResult, count, cookingTime, experience, (ItemLike) null);
        }

        public static CookingPotRecipeBuilder cookingPotRecipe(ItemLike mainResult, int count, int cookingTime, float experience, ItemLike container) {
            return new PotBuilder(mainResult, count, cookingTime, experience, container);
        }

        @Override
        public void build(RecipeOutput output) {
            this.save(output, ResourceLocation.fromNamespaceAndPath(Qtpyedelight.MODID, name));
        }
    }
```
this creates and extend the class for a custom implementation. enabling an add-on to use the recipe builder built into the mod for there own purposes but altered to write to there own namespace. this allows add-ons to use the recepie builder instead of reimplimenting there own one from scratch.

however the cutting recipe only has  private constructors making an extends class implementation impossible. 