### PR TITLE
Adjust fried egg recipe to allow other egg types

### DIFF
--- a/src/generated/resources/data/farmersdelight/recipes/fried_egg.json
+++ b/src/generated/resources/data/farmersdelight/recipes/fried_egg.json
@@ -4,7 +4,7 @@
   "cookingtime": 200,
   "experience": 0.35,
   "ingredient": {
-    "item": "minecraft:egg"
+    "tag": "forge:eggs"
   },
   "result": "farmersdelight:fried_egg"
 }

--- a/src/generated/resources/data/farmersdelight/recipes/fried_egg_from_campfire_cooking.json
+++ b/src/generated/resources/data/farmersdelight/recipes/fried_egg_from_campfire_cooking.json
@@ -4,7 +4,7 @@
   "cookingtime": 600,
   "experience": 0.35,
   "ingredient": {
-    "item": "minecraft:egg"
+    "tag": "forge:eggs"
   },
   "result": "farmersdelight:fried_egg"
 }

--- a/src/generated/resources/data/farmersdelight/recipes/fried_egg_from_smoking.json
+++ b/src/generated/resources/data/farmersdelight/recipes/fried_egg_from_smoking.json
@@ -4,7 +4,7 @@
   "cookingtime": 100,
   "experience": 0.35,
   "ingredient": {
-    "item": "minecraft:egg"
+    "tag": "forge:eggs"
   },
   "result": "farmersdelight:fried_egg"
 }


### PR DESCRIPTION
Fried eggs currently can only be made by cooking the normal egg, excluding even brown or blue eggs. This fixes that.