### PR TITLE
Replace use of RegistryObject with Supplier

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModBiomeFeatures.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModBiomeFeatures.java
@@ -4,7 +4,7 @@ import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.RandomPatchConfiguration;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.world.configuration.WildCropConfiguration;
 import vectorwing.farmersdelight.common.world.feature.WildCropFeature;
@@ -14,6 +14,6 @@ public class ModBiomeFeatures
 {
 	public static final DeferredRegister<Feature<?>> FEATURES = DeferredRegister.create(ForgeRegistries.FEATURES, FarmersDelight.MODID);
 
-	public static final RegistryObject<Feature<RandomPatchConfiguration>> WILD_RICE = FEATURES.register("wild_rice", () -> new WildRiceFeature(RandomPatchConfiguration.CODEC));
-	public static final RegistryObject<Feature<WildCropConfiguration>> WILD_CROP = FEATURES.register("wild_crop", () -> new WildCropFeature(WildCropConfiguration.CODEC));
+	public static final Supplier<Feature<RandomPatchConfiguration>> WILD_RICE = FEATURES.register("wild_rice", () -> new WildRiceFeature(RandomPatchConfiguration.CODEC));
+	public static final Supplier<Feature<WildCropConfiguration>> WILD_CROP = FEATURES.register("wild_crop", () -> new WildCropFeature(WildCropConfiguration.CODEC));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModBiomeModifiers.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModBiomeModifiers.java
@@ -8,7 +8,7 @@ import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraftforge.common.world.BiomeModifier;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.world.modifier.AddFeaturesByFilterBiomeModifier;
 
@@ -19,7 +19,7 @@ public class ModBiomeModifiers
 	public static DeferredRegister<Codec<? extends BiomeModifier>> BIOME_MODIFIER_SERIALIZERS =
 			DeferredRegister.create(ForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, FarmersDelight.MODID);
 
-	public static RegistryObject<Codec<AddFeaturesByFilterBiomeModifier>> ADD_FEATURES_BY_FILTER = BIOME_MODIFIER_SERIALIZERS.register("add_features_by_filter", () ->
+	public static Supplier<Codec<AddFeaturesByFilterBiomeModifier>> ADD_FEATURES_BY_FILTER = BIOME_MODIFIER_SERIALIZERS.register("add_features_by_filter", () ->
 			RecordCodecBuilder.create(builder -> builder.group(
 					Biome.LIST_CODEC.fieldOf("allowed_biomes").forGetter(AddFeaturesByFilterBiomeModifier::allowedBiomes),
 					Biome.LIST_CODEC.optionalFieldOf("denied_biomes").orElse(Optional.empty()).forGetter(AddFeaturesByFilterBiomeModifier::deniedBiomes),

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModBlockEntityTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModBlockEntityTypes.java
@@ -3,7 +3,7 @@ package vectorwing.farmersdelight.common.registry;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.block.entity.*;
 
@@ -11,17 +11,17 @@ public class ModBlockEntityTypes
 {
 	public static final DeferredRegister<BlockEntityType<?>> TILES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, FarmersDelight.MODID);
 
-	public static final RegistryObject<BlockEntityType<StoveBlockEntity>> STOVE = TILES.register("stove",
+	public static final Supplier<BlockEntityType<StoveBlockEntity>> STOVE = TILES.register("stove",
 			() -> BlockEntityType.Builder.of(StoveBlockEntity::new, ModBlocks.STOVE.get()).build(null));
-	public static final RegistryObject<BlockEntityType<CookingPotBlockEntity>> COOKING_POT = TILES.register("cooking_pot",
+	public static final Supplier<BlockEntityType<CookingPotBlockEntity>> COOKING_POT = TILES.register("cooking_pot",
 			() -> BlockEntityType.Builder.of(CookingPotBlockEntity::new, ModBlocks.COOKING_POT.get()).build(null));
-	public static final RegistryObject<BlockEntityType<BasketBlockEntity>> BASKET = TILES.register("basket",
+	public static final Supplier<BlockEntityType<BasketBlockEntity>> BASKET = TILES.register("basket",
 			() -> BlockEntityType.Builder.of(BasketBlockEntity::new, ModBlocks.BASKET.get()).build(null));
-	public static final RegistryObject<BlockEntityType<CuttingBoardBlockEntity>> CUTTING_BOARD = TILES.register("cutting_board",
+	public static final Supplier<BlockEntityType<CuttingBoardBlockEntity>> CUTTING_BOARD = TILES.register("cutting_board",
 			() -> BlockEntityType.Builder.of(CuttingBoardBlockEntity::new, ModBlocks.CUTTING_BOARD.get()).build(null));
-	public static final RegistryObject<BlockEntityType<SkilletBlockEntity>> SKILLET = TILES.register("skillet",
+	public static final Supplier<BlockEntityType<SkilletBlockEntity>> SKILLET = TILES.register("skillet",
 			() -> BlockEntityType.Builder.of(SkilletBlockEntity::new, ModBlocks.SKILLET.get()).build(null));
-	public static final RegistryObject<BlockEntityType<CabinetBlockEntity>> CABINET = TILES.register("cabinet",
+	public static final Supplier<BlockEntityType<CabinetBlockEntity>> CABINET = TILES.register("cabinet",
 			() -> BlockEntityType.Builder.of(CabinetBlockEntity::new,
 							ModBlocks.OAK_CABINET.get(),
 							ModBlocks.BIRCH_CABINET.get(),
@@ -34,7 +34,7 @@ public class ModBlockEntityTypes
 							ModBlocks.CRIMSON_CABINET.get(),
 							ModBlocks.WARPED_CABINET.get())
 					.build(null));
-	public static final RegistryObject<BlockEntityType<CanvasSignBlockEntity>> CANVAS_SIGN = TILES.register("canvas_sign",
+	public static final Supplier<BlockEntityType<CanvasSignBlockEntity>> CANVAS_SIGN = TILES.register("canvas_sign",
 			() -> BlockEntityType.Builder.of(CanvasSignBlockEntity::new,
 							ModBlocks.CANVAS_SIGN.get(),
 							ModBlocks.WHITE_CANVAS_SIGN.get(),
@@ -71,7 +71,7 @@ public class ModBlockEntityTypes
 							ModBlocks.RED_CANVAS_WALL_SIGN.get(),
 							ModBlocks.BLACK_CANVAS_WALL_SIGN.get())
 					.build(null));
-	public static final RegistryObject<BlockEntityType<HangingCanvasSignBlockEntity>> HANGING_CANVAS_SIGN = TILES.register("hanging_canvas_sign",
+	public static final Supplier<BlockEntityType<HangingCanvasSignBlockEntity>> HANGING_CANVAS_SIGN = TILES.register("hanging_canvas_sign",
 			() -> BlockEntityType.Builder.of(HangingCanvasSignBlockEntity::new,
 							ModBlocks.HANGING_CANVAS_SIGN.get(),
 							ModBlocks.WHITE_HANGING_CANVAS_SIGN.get(),

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModBlocks.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModBlocks.java
@@ -16,7 +16,7 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.block.*;
@@ -32,233 +32,233 @@ public class ModBlocks
 	}
 
 	// Workstations
-	public static final RegistryObject<Block> STOVE = BLOCKS.register("stove",
+	public static final Supplier<Block> STOVE = BLOCKS.register("stove",
 			() -> new StoveBlock(Block.Properties.copy(Blocks.BRICKS).lightLevel(litBlockEmission(13))));
-	public static final RegistryObject<Block> COOKING_POT = BLOCKS.register("cooking_pot",
+	public static final Supplier<Block> COOKING_POT = BLOCKS.register("cooking_pot",
 			() -> new CookingPotBlock(Block.Properties.of().mapColor(MapColor.METAL).strength(0.5F, 6.0F).sound(SoundType.LANTERN)));
-	public static final RegistryObject<Block> SKILLET = BLOCKS.register("skillet",
+	public static final Supplier<Block> SKILLET = BLOCKS.register("skillet",
 			() -> new SkilletBlock(Block.Properties.of().mapColor(MapColor.METAL).strength(0.5F, 6.0F).sound(SoundType.LANTERN)));
-	public static final RegistryObject<Block> BASKET = BLOCKS.register("basket",
+	public static final Supplier<Block> BASKET = BLOCKS.register("basket",
 			() -> new BasketBlock(Block.Properties.of().strength(1.5F).sound(SoundType.BAMBOO_WOOD)));
-	public static final RegistryObject<Block> CUTTING_BOARD = BLOCKS.register("cutting_board",
+	public static final Supplier<Block> CUTTING_BOARD = BLOCKS.register("cutting_board",
 			() -> new CuttingBoardBlock(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F).sound(SoundType.WOOD)));
 
 	// Crop Storage
-	public static final RegistryObject<Block> CARROT_CRATE = BLOCKS.register("carrot_crate",
+	public static final Supplier<Block> CARROT_CRATE = BLOCKS.register("carrot_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> POTATO_CRATE = BLOCKS.register("potato_crate",
+	public static final Supplier<Block> POTATO_CRATE = BLOCKS.register("potato_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> BEETROOT_CRATE = BLOCKS.register("beetroot_crate",
+	public static final Supplier<Block> BEETROOT_CRATE = BLOCKS.register("beetroot_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> CABBAGE_CRATE = BLOCKS.register("cabbage_crate",
+	public static final Supplier<Block> CABBAGE_CRATE = BLOCKS.register("cabbage_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> TOMATO_CRATE = BLOCKS.register("tomato_crate",
+	public static final Supplier<Block> TOMATO_CRATE = BLOCKS.register("tomato_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> ONION_CRATE = BLOCKS.register("onion_crate",
+	public static final Supplier<Block> ONION_CRATE = BLOCKS.register("onion_crate",
 			() -> new Block(Block.Properties.copy(Blocks.OAK_PLANKS).strength(2.0F, 3.0F).sound(SoundType.WOOD)));
-	public static final RegistryObject<Block> RICE_BALE = BLOCKS.register("rice_bale",
+	public static final Supplier<Block> RICE_BALE = BLOCKS.register("rice_bale",
 			() -> new RiceBaleBlock(Block.Properties.copy(Blocks.HAY_BLOCK)));
-	public static final RegistryObject<Block> RICE_BAG = BLOCKS.register("rice_bag",
+	public static final Supplier<Block> RICE_BAG = BLOCKS.register("rice_bag",
 			() -> new Block(Block.Properties.copy(Blocks.WHITE_WOOL)));
-	public static final RegistryObject<Block> STRAW_BALE = BLOCKS.register("straw_bale",
+	public static final Supplier<Block> STRAW_BALE = BLOCKS.register("straw_bale",
 			() -> new StrawBaleBlock(Block.Properties.copy(Blocks.HAY_BLOCK)));
 
 	// Building
-	public static final RegistryObject<Block> ROPE = BLOCKS.register("rope",
+	public static final Supplier<Block> ROPE = BLOCKS.register("rope",
 			() -> new RopeBlock(Block.Properties.copy(Blocks.BROWN_CARPET).noCollission().noOcclusion().strength(0.2F).sound(SoundType.WOOL)));
-	public static final RegistryObject<Block> SAFETY_NET = BLOCKS.register("safety_net",
+	public static final Supplier<Block> SAFETY_NET = BLOCKS.register("safety_net",
 			() -> new SafetyNetBlock(Block.Properties.copy(Blocks.BROWN_CARPET).strength(0.2F).sound(SoundType.WOOL)));
-	public static final RegistryObject<Block> OAK_CABINET = BLOCKS.register("oak_cabinet",
+	public static final Supplier<Block> OAK_CABINET = BLOCKS.register("oak_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> SPRUCE_CABINET = BLOCKS.register("spruce_cabinet",
+	public static final Supplier<Block> SPRUCE_CABINET = BLOCKS.register("spruce_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> BIRCH_CABINET = BLOCKS.register("birch_cabinet",
+	public static final Supplier<Block> BIRCH_CABINET = BLOCKS.register("birch_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> JUNGLE_CABINET = BLOCKS.register("jungle_cabinet",
+	public static final Supplier<Block> JUNGLE_CABINET = BLOCKS.register("jungle_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> ACACIA_CABINET = BLOCKS.register("acacia_cabinet",
+	public static final Supplier<Block> ACACIA_CABINET = BLOCKS.register("acacia_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> DARK_OAK_CABINET = BLOCKS.register("dark_oak_cabinet",
+	public static final Supplier<Block> DARK_OAK_CABINET = BLOCKS.register("dark_oak_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> MANGROVE_CABINET = BLOCKS.register("mangrove_cabinet",
+	public static final Supplier<Block> MANGROVE_CABINET = BLOCKS.register("mangrove_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL)));
-	public static final RegistryObject<Block> CHERRY_CABINET = BLOCKS.register("cherry_cabinet",
+	public static final Supplier<Block> CHERRY_CABINET = BLOCKS.register("cherry_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL).sound(SoundType.CHERRY_WOOD)));
-	public static final RegistryObject<Block> BAMBOO_CABINET = BLOCKS.register("bamboo_cabinet",
+	public static final Supplier<Block> BAMBOO_CABINET = BLOCKS.register("bamboo_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL).sound(SoundType.BAMBOO_WOOD)));
-	public static final RegistryObject<Block> CRIMSON_CABINET = BLOCKS.register("crimson_cabinet",
+	public static final Supplier<Block> CRIMSON_CABINET = BLOCKS.register("crimson_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL).sound(SoundType.NETHER_WOOD)));
-	public static final RegistryObject<Block> WARPED_CABINET = BLOCKS.register("warped_cabinet",
+	public static final Supplier<Block> WARPED_CABINET = BLOCKS.register("warped_cabinet",
 			() -> new CabinetBlock(Block.Properties.copy(Blocks.BARREL).sound(SoundType.NETHER_WOOD)));
-	public static final RegistryObject<Block> CANVAS_RUG = BLOCKS.register("canvas_rug",
+	public static final Supplier<Block> CANVAS_RUG = BLOCKS.register("canvas_rug",
 			() -> new CanvasRugBlock(Block.Properties.copy(Blocks.WHITE_CARPET).sound(SoundType.GRASS).strength(0.2F)));
-	public static final RegistryObject<Block> TATAMI = BLOCKS.register("tatami",
+	public static final Supplier<Block> TATAMI = BLOCKS.register("tatami",
 			() -> new TatamiBlock(Block.Properties.copy(Blocks.WHITE_WOOL)));
-	public static final RegistryObject<Block> FULL_TATAMI_MAT = BLOCKS.register("full_tatami_mat",
+	public static final Supplier<Block> FULL_TATAMI_MAT = BLOCKS.register("full_tatami_mat",
 			() -> new TatamiMatBlock(Block.Properties.copy(Blocks.WHITE_WOOL).strength(0.3F)));
-	public static final RegistryObject<Block> HALF_TATAMI_MAT = BLOCKS.register("half_tatami_mat",
+	public static final Supplier<Block> HALF_TATAMI_MAT = BLOCKS.register("half_tatami_mat",
 			() -> new TatamiHalfMatBlock(BlockBehaviour.Properties.copy(Blocks.WHITE_WOOL).strength(0.3F).pushReaction(PushReaction.DESTROY)));
 
-	public static final RegistryObject<Block> CANVAS_SIGN = BLOCKS.register("canvas_sign",
+	public static final Supplier<Block> CANVAS_SIGN = BLOCKS.register("canvas_sign",
 			() -> new StandingCanvasSignBlock(null));
-	public static final RegistryObject<Block> WHITE_CANVAS_SIGN = BLOCKS.register("white_canvas_sign",
+	public static final Supplier<Block> WHITE_CANVAS_SIGN = BLOCKS.register("white_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.WHITE));
-	public static final RegistryObject<Block> ORANGE_CANVAS_SIGN = BLOCKS.register("orange_canvas_sign",
+	public static final Supplier<Block> ORANGE_CANVAS_SIGN = BLOCKS.register("orange_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.ORANGE));
-	public static final RegistryObject<Block> MAGENTA_CANVAS_SIGN = BLOCKS.register("magenta_canvas_sign",
+	public static final Supplier<Block> MAGENTA_CANVAS_SIGN = BLOCKS.register("magenta_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.MAGENTA));
-	public static final RegistryObject<Block> LIGHT_BLUE_CANVAS_SIGN = BLOCKS.register("light_blue_canvas_sign",
+	public static final Supplier<Block> LIGHT_BLUE_CANVAS_SIGN = BLOCKS.register("light_blue_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.LIGHT_BLUE));
-	public static final RegistryObject<Block> YELLOW_CANVAS_SIGN = BLOCKS.register("yellow_canvas_sign",
+	public static final Supplier<Block> YELLOW_CANVAS_SIGN = BLOCKS.register("yellow_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.YELLOW));
-	public static final RegistryObject<Block> LIME_CANVAS_SIGN = BLOCKS.register("lime_canvas_sign",
+	public static final Supplier<Block> LIME_CANVAS_SIGN = BLOCKS.register("lime_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.LIME));
-	public static final RegistryObject<Block> PINK_CANVAS_SIGN = BLOCKS.register("pink_canvas_sign",
+	public static final Supplier<Block> PINK_CANVAS_SIGN = BLOCKS.register("pink_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.PINK));
-	public static final RegistryObject<Block> GRAY_CANVAS_SIGN = BLOCKS.register("gray_canvas_sign",
+	public static final Supplier<Block> GRAY_CANVAS_SIGN = BLOCKS.register("gray_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.GRAY));
-	public static final RegistryObject<Block> LIGHT_GRAY_CANVAS_SIGN = BLOCKS.register("light_gray_canvas_sign",
+	public static final Supplier<Block> LIGHT_GRAY_CANVAS_SIGN = BLOCKS.register("light_gray_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.LIGHT_GRAY));
-	public static final RegistryObject<Block> CYAN_CANVAS_SIGN = BLOCKS.register("cyan_canvas_sign",
+	public static final Supplier<Block> CYAN_CANVAS_SIGN = BLOCKS.register("cyan_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.CYAN));
-	public static final RegistryObject<Block> PURPLE_CANVAS_SIGN = BLOCKS.register("purple_canvas_sign",
+	public static final Supplier<Block> PURPLE_CANVAS_SIGN = BLOCKS.register("purple_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.PURPLE));
-	public static final RegistryObject<Block> BLUE_CANVAS_SIGN = BLOCKS.register("blue_canvas_sign",
+	public static final Supplier<Block> BLUE_CANVAS_SIGN = BLOCKS.register("blue_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.BLUE));
-	public static final RegistryObject<Block> BROWN_CANVAS_SIGN = BLOCKS.register("brown_canvas_sign",
+	public static final Supplier<Block> BROWN_CANVAS_SIGN = BLOCKS.register("brown_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.BROWN));
-	public static final RegistryObject<Block> GREEN_CANVAS_SIGN = BLOCKS.register("green_canvas_sign",
+	public static final Supplier<Block> GREEN_CANVAS_SIGN = BLOCKS.register("green_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.GREEN));
-	public static final RegistryObject<Block> RED_CANVAS_SIGN = BLOCKS.register("red_canvas_sign",
+	public static final Supplier<Block> RED_CANVAS_SIGN = BLOCKS.register("red_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.RED));
-	public static final RegistryObject<Block> BLACK_CANVAS_SIGN = BLOCKS.register("black_canvas_sign",
+	public static final Supplier<Block> BLACK_CANVAS_SIGN = BLOCKS.register("black_canvas_sign",
 			() -> new StandingCanvasSignBlock(DyeColor.BLACK));
 
-	public static final RegistryObject<Block> CANVAS_WALL_SIGN = BLOCKS.register("canvas_wall_sign",
+	public static final Supplier<Block> CANVAS_WALL_SIGN = BLOCKS.register("canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(CANVAS_SIGN), null));
-	public static final RegistryObject<Block> WHITE_CANVAS_WALL_SIGN = BLOCKS.register("white_canvas_wall_sign",
+	public static final Supplier<Block> WHITE_CANVAS_WALL_SIGN = BLOCKS.register("white_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(WHITE_CANVAS_SIGN), DyeColor.WHITE));
-	public static final RegistryObject<Block> ORANGE_CANVAS_WALL_SIGN = BLOCKS.register("orange_canvas_wall_sign",
+	public static final Supplier<Block> ORANGE_CANVAS_WALL_SIGN = BLOCKS.register("orange_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(ORANGE_CANVAS_SIGN), DyeColor.ORANGE));
-	public static final RegistryObject<Block> MAGENTA_CANVAS_WALL_SIGN = BLOCKS.register("magenta_canvas_wall_sign",
+	public static final Supplier<Block> MAGENTA_CANVAS_WALL_SIGN = BLOCKS.register("magenta_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(MAGENTA_CANVAS_SIGN), DyeColor.MAGENTA));
-	public static final RegistryObject<Block> LIGHT_BLUE_CANVAS_WALL_SIGN = BLOCKS.register("light_blue_canvas_wall_sign",
+	public static final Supplier<Block> LIGHT_BLUE_CANVAS_WALL_SIGN = BLOCKS.register("light_blue_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(LIGHT_BLUE_CANVAS_SIGN), DyeColor.LIGHT_BLUE));
-	public static final RegistryObject<Block> YELLOW_CANVAS_WALL_SIGN = BLOCKS.register("yellow_canvas_wall_sign",
+	public static final Supplier<Block> YELLOW_CANVAS_WALL_SIGN = BLOCKS.register("yellow_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(YELLOW_CANVAS_SIGN), DyeColor.YELLOW));
-	public static final RegistryObject<Block> LIME_CANVAS_WALL_SIGN = BLOCKS.register("lime_canvas_wall_sign",
+	public static final Supplier<Block> LIME_CANVAS_WALL_SIGN = BLOCKS.register("lime_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(LIME_CANVAS_SIGN), DyeColor.LIME));
-	public static final RegistryObject<Block> PINK_CANVAS_WALL_SIGN = BLOCKS.register("pink_canvas_wall_sign",
+	public static final Supplier<Block> PINK_CANVAS_WALL_SIGN = BLOCKS.register("pink_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(PINK_CANVAS_SIGN), DyeColor.PINK));
-	public static final RegistryObject<Block> GRAY_CANVAS_WALL_SIGN = BLOCKS.register("gray_canvas_wall_sign",
+	public static final Supplier<Block> GRAY_CANVAS_WALL_SIGN = BLOCKS.register("gray_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(GRAY_CANVAS_SIGN), DyeColor.GRAY));
-	public static final RegistryObject<Block> LIGHT_GRAY_CANVAS_WALL_SIGN = BLOCKS.register("light_gray_canvas_wall_sign",
+	public static final Supplier<Block> LIGHT_GRAY_CANVAS_WALL_SIGN = BLOCKS.register("light_gray_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(LIGHT_GRAY_CANVAS_SIGN), DyeColor.LIGHT_GRAY));
-	public static final RegistryObject<Block> CYAN_CANVAS_WALL_SIGN = BLOCKS.register("cyan_canvas_wall_sign",
+	public static final Supplier<Block> CYAN_CANVAS_WALL_SIGN = BLOCKS.register("cyan_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(CYAN_CANVAS_SIGN), DyeColor.CYAN));
-	public static final RegistryObject<Block> PURPLE_CANVAS_WALL_SIGN = BLOCKS.register("purple_canvas_wall_sign",
+	public static final Supplier<Block> PURPLE_CANVAS_WALL_SIGN = BLOCKS.register("purple_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(PURPLE_CANVAS_SIGN), DyeColor.PURPLE));
-	public static final RegistryObject<Block> BLUE_CANVAS_WALL_SIGN = BLOCKS.register("blue_canvas_wall_sign",
+	public static final Supplier<Block> BLUE_CANVAS_WALL_SIGN = BLOCKS.register("blue_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(BLUE_CANVAS_SIGN), DyeColor.BLUE));
-	public static final RegistryObject<Block> BROWN_CANVAS_WALL_SIGN = BLOCKS.register("brown_canvas_wall_sign",
+	public static final Supplier<Block> BROWN_CANVAS_WALL_SIGN = BLOCKS.register("brown_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(BROWN_CANVAS_SIGN), DyeColor.BROWN));
-	public static final RegistryObject<Block> GREEN_CANVAS_WALL_SIGN = BLOCKS.register("green_canvas_wall_sign",
+	public static final Supplier<Block> GREEN_CANVAS_WALL_SIGN = BLOCKS.register("green_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(GREEN_CANVAS_SIGN), DyeColor.GREEN));
-	public static final RegistryObject<Block> RED_CANVAS_WALL_SIGN = BLOCKS.register("red_canvas_wall_sign",
+	public static final Supplier<Block> RED_CANVAS_WALL_SIGN = BLOCKS.register("red_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(RED_CANVAS_SIGN), DyeColor.RED));
-	public static final RegistryObject<Block> BLACK_CANVAS_WALL_SIGN = BLOCKS.register("black_canvas_wall_sign",
+	public static final Supplier<Block> BLACK_CANVAS_WALL_SIGN = BLOCKS.register("black_canvas_wall_sign",
 			() -> new WallCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_SIGN).lootFrom(BLACK_CANVAS_SIGN), DyeColor.BLACK));
 
-	public static final RegistryObject<Block> HANGING_CANVAS_SIGN = BLOCKS.register("hanging_canvas_sign",
+	public static final Supplier<Block> HANGING_CANVAS_SIGN = BLOCKS.register("hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(null));
-	public static final RegistryObject<Block> WHITE_HANGING_CANVAS_SIGN = BLOCKS.register("white_hanging_canvas_sign",
+	public static final Supplier<Block> WHITE_HANGING_CANVAS_SIGN = BLOCKS.register("white_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.WHITE));
-	public static final RegistryObject<Block> ORANGE_HANGING_CANVAS_SIGN = BLOCKS.register("orange_hanging_canvas_sign",
+	public static final Supplier<Block> ORANGE_HANGING_CANVAS_SIGN = BLOCKS.register("orange_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.ORANGE));
-	public static final RegistryObject<Block> MAGENTA_HANGING_CANVAS_SIGN = BLOCKS.register("magenta_hanging_canvas_sign",
+	public static final Supplier<Block> MAGENTA_HANGING_CANVAS_SIGN = BLOCKS.register("magenta_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.MAGENTA));
-	public static final RegistryObject<Block> LIGHT_BLUE_HANGING_CANVAS_SIGN = BLOCKS.register("light_blue_hanging_canvas_sign",
+	public static final Supplier<Block> LIGHT_BLUE_HANGING_CANVAS_SIGN = BLOCKS.register("light_blue_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.LIGHT_BLUE));
-	public static final RegistryObject<Block> YELLOW_HANGING_CANVAS_SIGN = BLOCKS.register("yellow_hanging_canvas_sign",
+	public static final Supplier<Block> YELLOW_HANGING_CANVAS_SIGN = BLOCKS.register("yellow_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.YELLOW));
-	public static final RegistryObject<Block> LIME_HANGING_CANVAS_SIGN = BLOCKS.register("lime_hanging_canvas_sign",
+	public static final Supplier<Block> LIME_HANGING_CANVAS_SIGN = BLOCKS.register("lime_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.LIME));
-	public static final RegistryObject<Block> PINK_HANGING_CANVAS_SIGN = BLOCKS.register("pink_hanging_canvas_sign",
+	public static final Supplier<Block> PINK_HANGING_CANVAS_SIGN = BLOCKS.register("pink_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.PINK));
-	public static final RegistryObject<Block> GRAY_HANGING_CANVAS_SIGN = BLOCKS.register("gray_hanging_canvas_sign",
+	public static final Supplier<Block> GRAY_HANGING_CANVAS_SIGN = BLOCKS.register("gray_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.GRAY));
-	public static final RegistryObject<Block> LIGHT_GRAY_HANGING_CANVAS_SIGN = BLOCKS.register("light_gray_hanging_canvas_sign",
+	public static final Supplier<Block> LIGHT_GRAY_HANGING_CANVAS_SIGN = BLOCKS.register("light_gray_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.LIGHT_GRAY));
-	public static final RegistryObject<Block> CYAN_HANGING_CANVAS_SIGN = BLOCKS.register("cyan_hanging_canvas_sign",
+	public static final Supplier<Block> CYAN_HANGING_CANVAS_SIGN = BLOCKS.register("cyan_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.CYAN));
-	public static final RegistryObject<Block> PURPLE_HANGING_CANVAS_SIGN = BLOCKS.register("purple_hanging_canvas_sign",
+	public static final Supplier<Block> PURPLE_HANGING_CANVAS_SIGN = BLOCKS.register("purple_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.PURPLE));
-	public static final RegistryObject<Block> BLUE_HANGING_CANVAS_SIGN = BLOCKS.register("blue_hanging_canvas_sign",
+	public static final Supplier<Block> BLUE_HANGING_CANVAS_SIGN = BLOCKS.register("blue_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.BLUE));
-	public static final RegistryObject<Block> BROWN_HANGING_CANVAS_SIGN = BLOCKS.register("brown_hanging_canvas_sign",
+	public static final Supplier<Block> BROWN_HANGING_CANVAS_SIGN = BLOCKS.register("brown_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.BROWN));
-	public static final RegistryObject<Block> GREEN_HANGING_CANVAS_SIGN = BLOCKS.register("green_hanging_canvas_sign",
+	public static final Supplier<Block> GREEN_HANGING_CANVAS_SIGN = BLOCKS.register("green_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.GREEN));
-	public static final RegistryObject<Block> RED_HANGING_CANVAS_SIGN = BLOCKS.register("red_hanging_canvas_sign",
+	public static final Supplier<Block> RED_HANGING_CANVAS_SIGN = BLOCKS.register("red_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.RED));
-	public static final RegistryObject<Block> BLACK_HANGING_CANVAS_SIGN = BLOCKS.register("black_hanging_canvas_sign",
+	public static final Supplier<Block> BLACK_HANGING_CANVAS_SIGN = BLOCKS.register("black_hanging_canvas_sign",
 			() -> new CeilingHangingCanvasSignBlock(DyeColor.BLACK));
 
-	public static final RegistryObject<Block> HANGING_CANVAS_WALL_SIGN = BLOCKS.register("wall_hanging_canvas_sign",
+	public static final Supplier<Block> HANGING_CANVAS_WALL_SIGN = BLOCKS.register("wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(HANGING_CANVAS_SIGN), null));
-	public static final RegistryObject<Block> WHITE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("white_wall_hanging_canvas_sign",
+	public static final Supplier<Block> WHITE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("white_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(WHITE_HANGING_CANVAS_SIGN), DyeColor.WHITE));
-	public static final RegistryObject<Block> ORANGE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("orange_wall_hanging_canvas_sign",
+	public static final Supplier<Block> ORANGE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("orange_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(ORANGE_HANGING_CANVAS_SIGN), DyeColor.ORANGE));
-	public static final RegistryObject<Block> MAGENTA_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("magenta_wall_hanging_canvas_sign",
+	public static final Supplier<Block> MAGENTA_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("magenta_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(MAGENTA_HANGING_CANVAS_SIGN), DyeColor.MAGENTA));
-	public static final RegistryObject<Block> LIGHT_BLUE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("light_blue_wall_hanging_canvas_sign",
+	public static final Supplier<Block> LIGHT_BLUE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("light_blue_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(LIGHT_BLUE_HANGING_CANVAS_SIGN), DyeColor.LIGHT_BLUE));
-	public static final RegistryObject<Block> YELLOW_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("yellow_wall_hanging_canvas_sign",
+	public static final Supplier<Block> YELLOW_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("yellow_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(YELLOW_HANGING_CANVAS_SIGN), DyeColor.YELLOW));
-	public static final RegistryObject<Block> LIME_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("lime_wall_hanging_canvas_sign",
+	public static final Supplier<Block> LIME_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("lime_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(LIME_HANGING_CANVAS_SIGN), DyeColor.LIME));
-	public static final RegistryObject<Block> PINK_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("pink_wall_hanging_canvas_sign",
+	public static final Supplier<Block> PINK_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("pink_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(PINK_HANGING_CANVAS_SIGN), DyeColor.PINK));
-	public static final RegistryObject<Block> GRAY_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("gray_wall_hanging_canvas_sign",
+	public static final Supplier<Block> GRAY_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("gray_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(GRAY_HANGING_CANVAS_SIGN), DyeColor.GRAY));
-	public static final RegistryObject<Block> LIGHT_GRAY_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("light_gray_wall_hanging_canvas_sign",
+	public static final Supplier<Block> LIGHT_GRAY_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("light_gray_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(LIGHT_GRAY_HANGING_CANVAS_SIGN), DyeColor.LIGHT_GRAY));
-	public static final RegistryObject<Block> CYAN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("cyan_wall_hanging_canvas_sign",
+	public static final Supplier<Block> CYAN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("cyan_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(CYAN_HANGING_CANVAS_SIGN), DyeColor.CYAN));
-	public static final RegistryObject<Block> PURPLE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("purple_wall_hanging_canvas_sign",
+	public static final Supplier<Block> PURPLE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("purple_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(PURPLE_HANGING_CANVAS_SIGN), DyeColor.PURPLE));
-	public static final RegistryObject<Block> BLUE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("blue_wall_hanging_canvas_sign",
+	public static final Supplier<Block> BLUE_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("blue_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(BLUE_HANGING_CANVAS_SIGN), DyeColor.BLUE));
-	public static final RegistryObject<Block> BROWN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("brown_wall_hanging_canvas_sign",
+	public static final Supplier<Block> BROWN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("brown_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(BROWN_HANGING_CANVAS_SIGN), DyeColor.BROWN));
-	public static final RegistryObject<Block> GREEN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("green_wall_hanging_canvas_sign",
+	public static final Supplier<Block> GREEN_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("green_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(GREEN_HANGING_CANVAS_SIGN), DyeColor.GREEN));
-	public static final RegistryObject<Block> RED_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("red_wall_hanging_canvas_sign",
+	public static final Supplier<Block> RED_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("red_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(RED_HANGING_CANVAS_SIGN), DyeColor.RED));
-	public static final RegistryObject<Block> BLACK_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("black_wall_hanging_canvas_sign",
+	public static final Supplier<Block> BLACK_HANGING_CANVAS_WALL_SIGN = BLOCKS.register("black_wall_hanging_canvas_sign",
 			() -> new WallHangingCanvasSignBlock(Block.Properties.copy(Blocks.SPRUCE_WALL_HANGING_SIGN).lootFrom(BLACK_HANGING_CANVAS_SIGN), DyeColor.BLACK));
 
 	// Composting
-	public static final RegistryObject<Block> BROWN_MUSHROOM_COLONY = BLOCKS.register("brown_mushroom_colony",
+	public static final Supplier<Block> BROWN_MUSHROOM_COLONY = BLOCKS.register("brown_mushroom_colony",
 			() -> new MushroomColonyBlock(Block.Properties.copy(Blocks.BROWN_MUSHROOM), () -> Items.BROWN_MUSHROOM));
-	public static final RegistryObject<Block> RED_MUSHROOM_COLONY = BLOCKS.register("red_mushroom_colony",
+	public static final Supplier<Block> RED_MUSHROOM_COLONY = BLOCKS.register("red_mushroom_colony",
 			() -> new MushroomColonyBlock(Block.Properties.copy(Blocks.RED_MUSHROOM), () -> Items.RED_MUSHROOM));
-	public static final RegistryObject<Block> ORGANIC_COMPOST = BLOCKS.register("organic_compost",
+	public static final Supplier<Block> ORGANIC_COMPOST = BLOCKS.register("organic_compost",
 			() -> new OrganicCompostBlock(Block.Properties.copy(Blocks.DIRT).strength(1.2F).sound(SoundType.CROP)));
-	public static final RegistryObject<Block> RICH_SOIL = BLOCKS.register("rich_soil",
+	public static final Supplier<Block> RICH_SOIL = BLOCKS.register("rich_soil",
 			() -> new RichSoilBlock(Block.Properties.copy(Blocks.DIRT).randomTicks()));
-	public static final RegistryObject<Block> RICH_SOIL_FARMLAND = BLOCKS.register("rich_soil_farmland",
+	public static final Supplier<Block> RICH_SOIL_FARMLAND = BLOCKS.register("rich_soil_farmland",
 			() -> new RichSoilFarmlandBlock(Block.Properties.copy(Blocks.FARMLAND)));
 
 	// Pastries
-	public static final RegistryObject<Block> APPLE_PIE = BLOCKS.register("apple_pie",
+	public static final Supplier<Block> APPLE_PIE = BLOCKS.register("apple_pie",
 			() -> new PieBlock(Block.Properties.copy(Blocks.CAKE), ModItems.APPLE_PIE_SLICE));
-	public static final RegistryObject<Block> SWEET_BERRY_CHEESECAKE = BLOCKS.register("sweet_berry_cheesecake",
+	public static final Supplier<Block> SWEET_BERRY_CHEESECAKE = BLOCKS.register("sweet_berry_cheesecake",
 			() -> new PieBlock(Block.Properties.copy(Blocks.CAKE), ModItems.SWEET_BERRY_CHEESECAKE_SLICE));
-	public static final RegistryObject<Block> CHOCOLATE_PIE = BLOCKS.register("chocolate_pie",
+	public static final Supplier<Block> CHOCOLATE_PIE = BLOCKS.register("chocolate_pie",
 			() -> new PieBlock(Block.Properties.copy(Blocks.CAKE), ModItems.CHOCOLATE_PIE_SLICE));
-	public static final RegistryObject<Block> PUMPKIN_PIE = BLOCKS.register("pumpkin_pie",
+	public static final Supplier<Block> PUMPKIN_PIE = BLOCKS.register("pumpkin_pie",
 			() -> new PieBlock(Block.Properties.copy(Blocks.CAKE), ModItems.PUMPKIN_PIE_SLICE)
 			{
 				@Override
@@ -269,47 +269,47 @@ public class ModBlocks
 			});
 
 	// Wild Crops
-	public static final RegistryObject<Block> SANDY_SHRUB = BLOCKS.register("sandy_shrub",
+	public static final Supplier<Block> SANDY_SHRUB = BLOCKS.register("sandy_shrub",
 			() -> new SandyShrubBlock(Block.Properties.copy(Blocks.TALL_GRASS)));
 
-	public static final RegistryObject<Block> WILD_CABBAGES = BLOCKS.register("wild_cabbages",
+	public static final Supplier<Block> WILD_CABBAGES = BLOCKS.register("wild_cabbages",
 			() -> new WildCropBlock(MobEffects.DAMAGE_BOOST, 6, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_ONIONS = BLOCKS.register("wild_onions",
+	public static final Supplier<Block> WILD_ONIONS = BLOCKS.register("wild_onions",
 			() -> new WildCropBlock(MobEffects.FIRE_RESISTANCE, 6, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_TOMATOES = BLOCKS.register("wild_tomatoes",
+	public static final Supplier<Block> WILD_TOMATOES = BLOCKS.register("wild_tomatoes",
 			() -> new WildCropBlock(MobEffects.POISON, 10, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_CARROTS = BLOCKS.register("wild_carrots",
+	public static final Supplier<Block> WILD_CARROTS = BLOCKS.register("wild_carrots",
 			() -> new WildCropBlock(MobEffects.DIG_SLOWDOWN, 6, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_POTATOES = BLOCKS.register("wild_potatoes",
+	public static final Supplier<Block> WILD_POTATOES = BLOCKS.register("wild_potatoes",
 			() -> new WildCropBlock(MobEffects.CONFUSION, 8, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_BEETROOTS = BLOCKS.register("wild_beetroots",
+	public static final Supplier<Block> WILD_BEETROOTS = BLOCKS.register("wild_beetroots",
 			() -> new WildCropBlock(MobEffects.WATER_BREATHING, 8, Block.Properties.copy(Blocks.TALL_GRASS)));
-	public static final RegistryObject<Block> WILD_RICE = BLOCKS.register("wild_rice",
+	public static final Supplier<Block> WILD_RICE = BLOCKS.register("wild_rice",
 			() -> new WildRiceBlock(Block.Properties.copy(Blocks.TALL_GRASS)));
 
 	// Crops
-	public static final RegistryObject<Block> CABBAGE_CROP = BLOCKS.register("cabbages",
+	public static final Supplier<Block> CABBAGE_CROP = BLOCKS.register("cabbages",
 			() -> new CabbageBlock(Block.Properties.copy(Blocks.WHEAT)));
-	public static final RegistryObject<Block> ONION_CROP = BLOCKS.register("onions",
+	public static final Supplier<Block> ONION_CROP = BLOCKS.register("onions",
 			() -> new OnionBlock(Block.Properties.copy(Blocks.WHEAT)));
-	public static final RegistryObject<Block> BUDDING_TOMATO_CROP = BLOCKS.register("budding_tomatoes",
+	public static final Supplier<Block> BUDDING_TOMATO_CROP = BLOCKS.register("budding_tomatoes",
 			() -> new BuddingTomatoBlock(Block.Properties.copy(Blocks.WHEAT)));
-	public static final RegistryObject<Block> TOMATO_CROP = BLOCKS.register("tomatoes",
+	public static final Supplier<Block> TOMATO_CROP = BLOCKS.register("tomatoes",
 			() -> new TomatoVineBlock(Block.Properties.copy(Blocks.WHEAT)));
-	public static final RegistryObject<Block> RICE_CROP = BLOCKS.register("rice",
+	public static final Supplier<Block> RICE_CROP = BLOCKS.register("rice",
 			() -> new RiceBlock(Block.Properties.copy(Blocks.WHEAT).strength(0.2F)));
-	public static final RegistryObject<Block> RICE_CROP_PANICLES = BLOCKS.register("rice_panicles",
+	public static final Supplier<Block> RICE_CROP_PANICLES = BLOCKS.register("rice_panicles",
 			() -> new RicePaniclesBlock(Block.Properties.copy(Blocks.WHEAT)));
 
 	// Feasts
-	public static final RegistryObject<Block> ROAST_CHICKEN_BLOCK = BLOCKS.register("roast_chicken_block",
+	public static final Supplier<Block> ROAST_CHICKEN_BLOCK = BLOCKS.register("roast_chicken_block",
 			() -> new RoastChickenBlock(Block.Properties.copy(Blocks.CAKE), ModItems.ROAST_CHICKEN, true));
-	public static final RegistryObject<Block> STUFFED_PUMPKIN_BLOCK = BLOCKS.register("stuffed_pumpkin_block",
+	public static final Supplier<Block> STUFFED_PUMPKIN_BLOCK = BLOCKS.register("stuffed_pumpkin_block",
 			() -> new FeastBlock(Block.Properties.copy(Blocks.PUMPKIN), ModItems.STUFFED_PUMPKIN, false));
-	public static final RegistryObject<Block> HONEY_GLAZED_HAM_BLOCK = BLOCKS.register("honey_glazed_ham_block",
+	public static final Supplier<Block> HONEY_GLAZED_HAM_BLOCK = BLOCKS.register("honey_glazed_ham_block",
 			() -> new HoneyGlazedHamBlock(Block.Properties.copy(Blocks.CAKE), ModItems.HONEY_GLAZED_HAM, true));
-	public static final RegistryObject<Block> SHEPHERDS_PIE_BLOCK = BLOCKS.register("shepherds_pie_block",
+	public static final Supplier<Block> SHEPHERDS_PIE_BLOCK = BLOCKS.register("shepherds_pie_block",
 			() -> new ShepherdsPieBlock(Block.Properties.copy(Blocks.CAKE), ModItems.SHEPHERDS_PIE, true));
-	public static final RegistryObject<Block> RICE_ROLL_MEDLEY_BLOCK = BLOCKS.register("rice_roll_medley_block",
+	public static final Supplier<Block> RICE_ROLL_MEDLEY_BLOCK = BLOCKS.register("rice_roll_medley_block",
 			() -> new RiceRollMedleyBlock(Block.Properties.copy(Blocks.CAKE)));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModCreativeTabs.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModCreativeTabs.java
@@ -5,14 +5,14 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.DeferredRegister;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 
 public class ModCreativeTabs
 {
 	public static final DeferredRegister<CreativeModeTab> CREATIVE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, FarmersDelight.MODID);
 
-	public static final RegistryObject<CreativeModeTab> TAB_FARMERS_DELIGHT = CREATIVE_TABS.register(FarmersDelight.MODID,
+	public static final Supplier<CreativeModeTab> TAB_FARMERS_DELIGHT = CREATIVE_TABS.register(FarmersDelight.MODID,
 			() -> CreativeModeTab.builder()
 					.title(Component.translatable("itemGroup.farmersdelight"))
 					.icon(() -> new ItemStack(ModBlocks.STOVE.get()))

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModEffects.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModEffects.java
@@ -3,7 +3,7 @@ package vectorwing.farmersdelight.common.registry;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.effect.ComfortEffect;
 import vectorwing.farmersdelight.common.effect.NourishmentEffect;
@@ -12,6 +12,6 @@ public class ModEffects
 {
 	public static final DeferredRegister<MobEffect> EFFECTS = DeferredRegister.create(ForgeRegistries.MOB_EFFECTS, FarmersDelight.MODID);
 
-	public static final RegistryObject<MobEffect> NOURISHMENT = EFFECTS.register("nourishment", NourishmentEffect::new);
-	public static final RegistryObject<MobEffect> COMFORT = EFFECTS.register("comfort", ComfortEffect::new);
+	public static final Supplier<MobEffect> NOURISHMENT = EFFECTS.register("nourishment", NourishmentEffect::new);
+	public static final Supplier<MobEffect> COMFORT = EFFECTS.register("comfort", ComfortEffect::new);
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModEnchantments.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModEnchantments.java
@@ -5,7 +5,7 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.item.KnifeItem;
 import vectorwing.farmersdelight.common.item.enchantment.BackstabbingEnchantment;
@@ -16,6 +16,6 @@ public class ModEnchantments
 
 	public static final DeferredRegister<Enchantment> ENCHANTMENTS = DeferredRegister.create(ForgeRegistries.ENCHANTMENTS, FarmersDelight.MODID);
 
-	public static final RegistryObject<Enchantment> BACKSTABBING = ENCHANTMENTS.register("backstabbing",
+	public static final Supplier<Enchantment> BACKSTABBING = ENCHANTMENTS.register("backstabbing",
 			() -> new BackstabbingEnchantment(Enchantment.Rarity.UNCOMMON, KNIFE, EquipmentSlot.MAINHAND));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModEntityTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModEntityTypes.java
@@ -4,7 +4,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.entity.RottenTomatoEntity;
 
@@ -12,7 +12,7 @@ public class ModEntityTypes
 {
 	public static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES, FarmersDelight.MODID);
 
-	public static final RegistryObject<EntityType<RottenTomatoEntity>> ROTTEN_TOMATO = ENTITIES.register("rotten_tomato", () -> (
+	public static final Supplier<EntityType<RottenTomatoEntity>> ROTTEN_TOMATO = ENTITIES.register("rotten_tomato", () -> (
 			EntityType.Builder.<RottenTomatoEntity>of(RottenTomatoEntity::new, MobCategory.MISC)
 					.sized(0.25F, 0.25F)
 					.clientTrackingRange(4)

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModItems.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModItems.java
@@ -10,7 +10,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.FoodValues;
 import vectorwing.farmersdelight.common.item.*;
@@ -26,15 +26,15 @@ import java.util.function.Supplier;
 public class ModItems
 {
 	public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, FarmersDelight.MODID);
-	public static LinkedHashSet<RegistryObject<Item>> CREATIVE_TAB_ITEMS = Sets.newLinkedHashSet();
+	public static LinkedHashSet<Supplier<Item>> CREATIVE_TAB_ITEMS = Sets.newLinkedHashSet();
 
-	public static RegistryObject<Item> registerWithTab(final String name, final Supplier<Item> supplier) {
-		RegistryObject<Item> newItem = ITEMS.register(name, supplier);
+	public static Supplier<Item> registerWithTab(final String name, final Supplier<Item> supplier) {
+		Supplier<Item> newItem = ITEMS.register(name, supplier);
 		CREATIVE_TAB_ITEMS.add(newItem);
 		return newItem;
 	}
 
-	public static RegistryObject<Item> registerHidden(final String name, final Supplier<Item> supplier) {
+	public static Supplier<Item> registerHidden(final String name, final Supplier<Item> supplier) {
 		return ITEMS.register(name, supplier);
 	}
 
@@ -56,214 +56,214 @@ public class ModItems
 	}
 
 	// Blocks
-	public static final RegistryObject<Item> STOVE = registerWithTab("stove",
+	public static final Supplier<Item> STOVE = registerWithTab("stove",
 			() -> new BlockItem(ModBlocks.STOVE.get(), basicItem()));
-	public static final RegistryObject<Item> COOKING_POT = registerWithTab("cooking_pot",
+	public static final Supplier<Item> COOKING_POT = registerWithTab("cooking_pot",
 			() -> new CookingPotItem(ModBlocks.COOKING_POT.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> SKILLET = registerWithTab("skillet",
+	public static final Supplier<Item> SKILLET = registerWithTab("skillet",
 			() -> new SkilletItem(ModBlocks.SKILLET.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> CUTTING_BOARD = registerWithTab("cutting_board",
+	public static final Supplier<Item> CUTTING_BOARD = registerWithTab("cutting_board",
 			() -> new FuelBlockItem(ModBlocks.CUTTING_BOARD.get(), basicItem(), 200));
-	public static final RegistryObject<Item> BASKET = registerWithTab("basket",
+	public static final Supplier<Item> BASKET = registerWithTab("basket",
 			() -> new FuelBlockItem(ModBlocks.BASKET.get(), basicItem(), 300));
 
-	public static final RegistryObject<Item> CARROT_CRATE = registerWithTab("carrot_crate",
+	public static final Supplier<Item> CARROT_CRATE = registerWithTab("carrot_crate",
 			() -> new BlockItem(ModBlocks.CARROT_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> POTATO_CRATE = registerWithTab("potato_crate",
+	public static final Supplier<Item> POTATO_CRATE = registerWithTab("potato_crate",
 			() -> new BlockItem(ModBlocks.POTATO_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> BEETROOT_CRATE = registerWithTab("beetroot_crate",
+	public static final Supplier<Item> BEETROOT_CRATE = registerWithTab("beetroot_crate",
 			() -> new BlockItem(ModBlocks.BEETROOT_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> CABBAGE_CRATE = registerWithTab("cabbage_crate",
+	public static final Supplier<Item> CABBAGE_CRATE = registerWithTab("cabbage_crate",
 			() -> new BlockItem(ModBlocks.CABBAGE_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> TOMATO_CRATE = registerWithTab("tomato_crate",
+	public static final Supplier<Item> TOMATO_CRATE = registerWithTab("tomato_crate",
 			() -> new BlockItem(ModBlocks.TOMATO_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> ONION_CRATE = registerWithTab("onion_crate",
+	public static final Supplier<Item> ONION_CRATE = registerWithTab("onion_crate",
 			() -> new BlockItem(ModBlocks.ONION_CRATE.get(), basicItem()));
-	public static final RegistryObject<Item> RICE_BALE = registerWithTab("rice_bale",
+	public static final Supplier<Item> RICE_BALE = registerWithTab("rice_bale",
 			() -> new BlockItem(ModBlocks.RICE_BALE.get(), basicItem()));
-	public static final RegistryObject<Item> RICE_BAG = registerWithTab("rice_bag",
+	public static final Supplier<Item> RICE_BAG = registerWithTab("rice_bag",
 			() -> new BlockItem(ModBlocks.RICE_BAG.get(), basicItem()));
-	public static final RegistryObject<Item> STRAW_BALE = registerWithTab("straw_bale",
+	public static final Supplier<Item> STRAW_BALE = registerWithTab("straw_bale",
 			() -> new BlockItem(ModBlocks.STRAW_BALE.get(), basicItem()));
 
-	public static final RegistryObject<Item> SAFETY_NET = registerWithTab("safety_net",
+	public static final Supplier<Item> SAFETY_NET = registerWithTab("safety_net",
 			() -> new FuelBlockItem(ModBlocks.SAFETY_NET.get(), basicItem(), 200));
-	public static final RegistryObject<Item> OAK_CABINET = registerWithTab("oak_cabinet",
+	public static final Supplier<Item> OAK_CABINET = registerWithTab("oak_cabinet",
 			() -> new FuelBlockItem(ModBlocks.OAK_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> SPRUCE_CABINET = registerWithTab("spruce_cabinet",
+	public static final Supplier<Item> SPRUCE_CABINET = registerWithTab("spruce_cabinet",
 			() -> new FuelBlockItem(ModBlocks.SPRUCE_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> BIRCH_CABINET = registerWithTab("birch_cabinet",
+	public static final Supplier<Item> BIRCH_CABINET = registerWithTab("birch_cabinet",
 			() -> new FuelBlockItem(ModBlocks.BIRCH_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> JUNGLE_CABINET = registerWithTab("jungle_cabinet",
+	public static final Supplier<Item> JUNGLE_CABINET = registerWithTab("jungle_cabinet",
 			() -> new FuelBlockItem(ModBlocks.JUNGLE_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> ACACIA_CABINET = registerWithTab("acacia_cabinet",
+	public static final Supplier<Item> ACACIA_CABINET = registerWithTab("acacia_cabinet",
 			() -> new FuelBlockItem(ModBlocks.ACACIA_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> DARK_OAK_CABINET = registerWithTab("dark_oak_cabinet",
+	public static final Supplier<Item> DARK_OAK_CABINET = registerWithTab("dark_oak_cabinet",
 			() -> new FuelBlockItem(ModBlocks.DARK_OAK_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> MANGROVE_CABINET = registerWithTab("mangrove_cabinet",
+	public static final Supplier<Item> MANGROVE_CABINET = registerWithTab("mangrove_cabinet",
 			() -> new FuelBlockItem(ModBlocks.MANGROVE_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> CHERRY_CABINET = registerWithTab("cherry_cabinet",
+	public static final Supplier<Item> CHERRY_CABINET = registerWithTab("cherry_cabinet",
 			() -> new FuelBlockItem(ModBlocks.CHERRY_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> BAMBOO_CABINET = registerWithTab("bamboo_cabinet",
+	public static final Supplier<Item> BAMBOO_CABINET = registerWithTab("bamboo_cabinet",
 			() -> new FuelBlockItem(ModBlocks.BAMBOO_CABINET.get(), basicItem(), 300));
-	public static final RegistryObject<Item> CRIMSON_CABINET = registerWithTab("crimson_cabinet",
+	public static final Supplier<Item> CRIMSON_CABINET = registerWithTab("crimson_cabinet",
 			() -> new BlockItem(ModBlocks.CRIMSON_CABINET.get(), basicItem()));
-	public static final RegistryObject<Item> WARPED_CABINET = registerWithTab("warped_cabinet",
+	public static final Supplier<Item> WARPED_CABINET = registerWithTab("warped_cabinet",
 			() -> new BlockItem(ModBlocks.WARPED_CABINET.get(), basicItem()));
-	public static final RegistryObject<Item> TATAMI = registerWithTab("tatami",
+	public static final Supplier<Item> TATAMI = registerWithTab("tatami",
 			() -> new FuelBlockItem(ModBlocks.TATAMI.get(), basicItem(), 400));
-	public static final RegistryObject<Item> FULL_TATAMI_MAT = registerWithTab("full_tatami_mat",
+	public static final Supplier<Item> FULL_TATAMI_MAT = registerWithTab("full_tatami_mat",
 			() -> new FuelBlockItem(ModBlocks.FULL_TATAMI_MAT.get(), basicItem(), 200));
-	public static final RegistryObject<Item> HALF_TATAMI_MAT = registerWithTab("half_tatami_mat",
+	public static final Supplier<Item> HALF_TATAMI_MAT = registerWithTab("half_tatami_mat",
 			() -> new FuelBlockItem(ModBlocks.HALF_TATAMI_MAT.get(), basicItem()));
-	public static final RegistryObject<Item> CANVAS_RUG = registerWithTab("canvas_rug",
+	public static final Supplier<Item> CANVAS_RUG = registerWithTab("canvas_rug",
 			() -> new FuelBlockItem(ModBlocks.CANVAS_RUG.get(), basicItem(), 200));
-	public static final RegistryObject<Item> ORGANIC_COMPOST = registerWithTab("organic_compost",
+	public static final Supplier<Item> ORGANIC_COMPOST = registerWithTab("organic_compost",
 			() -> new BlockItem(ModBlocks.ORGANIC_COMPOST.get(), basicItem()));
-	public static final RegistryObject<Item> RICH_SOIL = registerWithTab("rich_soil",
+	public static final Supplier<Item> RICH_SOIL = registerWithTab("rich_soil",
 			() -> new BlockItem(ModBlocks.RICH_SOIL.get(), basicItem()));
-	public static final RegistryObject<Item> RICH_SOIL_FARMLAND = registerWithTab("rich_soil_farmland",
+	public static final Supplier<Item> RICH_SOIL_FARMLAND = registerWithTab("rich_soil_farmland",
 			() -> new BlockItem(ModBlocks.RICH_SOIL_FARMLAND.get(), basicItem()));
-	public static final RegistryObject<Item> ROPE = registerWithTab("rope",
+	public static final Supplier<Item> ROPE = registerWithTab("rope",
 			() -> new RopeItem(ModBlocks.ROPE.get(), basicItem()));
 
 	// Canvas Signs...
-	public static final RegistryObject<Item> CANVAS_SIGN = registerWithTab("canvas_sign",
+	public static final Supplier<Item> CANVAS_SIGN = registerWithTab("canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.CANVAS_SIGN.get(), ModBlocks.CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> HANGING_CANVAS_SIGN = registerWithTab("hanging_canvas_sign",
+	public static final Supplier<Item> HANGING_CANVAS_SIGN = registerWithTab("hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.HANGING_CANVAS_SIGN.get(), ModBlocks.HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> WHITE_CANVAS_SIGN = registerWithTab("white_canvas_sign",
+	public static final Supplier<Item> WHITE_CANVAS_SIGN = registerWithTab("white_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.WHITE_CANVAS_SIGN.get(), ModBlocks.WHITE_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> WHITE_HANGING_CANVAS_SIGN = registerWithTab("white_hanging_canvas_sign",
+	public static final Supplier<Item> WHITE_HANGING_CANVAS_SIGN = registerWithTab("white_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.WHITE_HANGING_CANVAS_SIGN.get(), ModBlocks.WHITE_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> LIGHT_GRAY_CANVAS_SIGN = registerWithTab("light_gray_canvas_sign",
+	public static final Supplier<Item> LIGHT_GRAY_CANVAS_SIGN = registerWithTab("light_gray_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.LIGHT_GRAY_CANVAS_SIGN.get(), ModBlocks.LIGHT_GRAY_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> LIGHT_GRAY_HANGING_CANVAS_SIGN = registerWithTab("light_gray_hanging_canvas_sign",
+	public static final Supplier<Item> LIGHT_GRAY_HANGING_CANVAS_SIGN = registerWithTab("light_gray_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.LIGHT_GRAY_HANGING_CANVAS_SIGN.get(), ModBlocks.LIGHT_GRAY_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> GRAY_CANVAS_SIGN = registerWithTab("gray_canvas_sign",
+	public static final Supplier<Item> GRAY_CANVAS_SIGN = registerWithTab("gray_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.GRAY_CANVAS_SIGN.get(), ModBlocks.GRAY_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> GRAY_HANGING_CANVAS_SIGN = registerWithTab("gray_hanging_canvas_sign",
+	public static final Supplier<Item> GRAY_HANGING_CANVAS_SIGN = registerWithTab("gray_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.GRAY_HANGING_CANVAS_SIGN.get(), ModBlocks.GRAY_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> BLACK_CANVAS_SIGN = registerWithTab("black_canvas_sign",
+	public static final Supplier<Item> BLACK_CANVAS_SIGN = registerWithTab("black_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.BLACK_CANVAS_SIGN.get(), ModBlocks.BLACK_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> BLACK_HANGING_CANVAS_SIGN = registerWithTab("black_hanging_canvas_sign",
+	public static final Supplier<Item> BLACK_HANGING_CANVAS_SIGN = registerWithTab("black_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.BLACK_HANGING_CANVAS_SIGN.get(), ModBlocks.BLACK_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> BROWN_CANVAS_SIGN = registerWithTab("brown_canvas_sign",
+	public static final Supplier<Item> BROWN_CANVAS_SIGN = registerWithTab("brown_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.BROWN_CANVAS_SIGN.get(), ModBlocks.BROWN_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> BROWN_HANGING_CANVAS_SIGN = registerWithTab("brown_hanging_canvas_sign",
+	public static final Supplier<Item> BROWN_HANGING_CANVAS_SIGN = registerWithTab("brown_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.BROWN_HANGING_CANVAS_SIGN.get(), ModBlocks.BROWN_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> RED_CANVAS_SIGN = registerWithTab("red_canvas_sign",
+	public static final Supplier<Item> RED_CANVAS_SIGN = registerWithTab("red_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.RED_CANVAS_SIGN.get(), ModBlocks.RED_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> RED_HANGING_CANVAS_SIGN = registerWithTab("red_hanging_canvas_sign",
+	public static final Supplier<Item> RED_HANGING_CANVAS_SIGN = registerWithTab("red_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.RED_HANGING_CANVAS_SIGN.get(), ModBlocks.RED_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> ORANGE_CANVAS_SIGN = registerWithTab("orange_canvas_sign",
+	public static final Supplier<Item> ORANGE_CANVAS_SIGN = registerWithTab("orange_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.ORANGE_CANVAS_SIGN.get(), ModBlocks.ORANGE_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> ORANGE_HANGING_CANVAS_SIGN = registerWithTab("orange_hanging_canvas_sign",
+	public static final Supplier<Item> ORANGE_HANGING_CANVAS_SIGN = registerWithTab("orange_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.ORANGE_HANGING_CANVAS_SIGN.get(), ModBlocks.ORANGE_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> YELLOW_CANVAS_SIGN = registerWithTab("yellow_canvas_sign",
+	public static final Supplier<Item> YELLOW_CANVAS_SIGN = registerWithTab("yellow_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.YELLOW_CANVAS_SIGN.get(), ModBlocks.YELLOW_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> YELLOW_HANGING_CANVAS_SIGN = registerWithTab("yellow_hanging_canvas_sign",
+	public static final Supplier<Item> YELLOW_HANGING_CANVAS_SIGN = registerWithTab("yellow_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.YELLOW_HANGING_CANVAS_SIGN.get(), ModBlocks.YELLOW_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> LIME_CANVAS_SIGN = registerWithTab("lime_canvas_sign",
+	public static final Supplier<Item> LIME_CANVAS_SIGN = registerWithTab("lime_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.LIME_CANVAS_SIGN.get(), ModBlocks.LIME_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> LIME_HANGING_CANVAS_SIGN = registerWithTab("lime_hanging_canvas_sign",
+	public static final Supplier<Item> LIME_HANGING_CANVAS_SIGN = registerWithTab("lime_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.LIME_HANGING_CANVAS_SIGN.get(), ModBlocks.LIME_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> GREEN_CANVAS_SIGN = registerWithTab("green_canvas_sign",
+	public static final Supplier<Item> GREEN_CANVAS_SIGN = registerWithTab("green_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.GREEN_CANVAS_SIGN.get(), ModBlocks.GREEN_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> GREEN_HANGING_CANVAS_SIGN = registerWithTab("green_hanging_canvas_sign",
+	public static final Supplier<Item> GREEN_HANGING_CANVAS_SIGN = registerWithTab("green_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.GREEN_HANGING_CANVAS_SIGN.get(), ModBlocks.GREEN_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> CYAN_CANVAS_SIGN = registerWithTab("cyan_canvas_sign",
+	public static final Supplier<Item> CYAN_CANVAS_SIGN = registerWithTab("cyan_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.CYAN_CANVAS_SIGN.get(), ModBlocks.CYAN_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> CYAN_HANGING_CANVAS_SIGN = registerWithTab("cyan_hanging_canvas_sign",
+	public static final Supplier<Item> CYAN_HANGING_CANVAS_SIGN = registerWithTab("cyan_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.CYAN_HANGING_CANVAS_SIGN.get(), ModBlocks.CYAN_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> LIGHT_BLUE_CANVAS_SIGN = registerWithTab("light_blue_canvas_sign",
+	public static final Supplier<Item> LIGHT_BLUE_CANVAS_SIGN = registerWithTab("light_blue_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.LIGHT_BLUE_CANVAS_SIGN.get(), ModBlocks.LIGHT_BLUE_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> LIGHT_BLUE_HANGING_CANVAS_SIGN = registerWithTab("light_blue_hanging_canvas_sign",
+	public static final Supplier<Item> LIGHT_BLUE_HANGING_CANVAS_SIGN = registerWithTab("light_blue_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.LIGHT_BLUE_HANGING_CANVAS_SIGN.get(), ModBlocks.LIGHT_BLUE_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> BLUE_CANVAS_SIGN = registerWithTab("blue_canvas_sign",
+	public static final Supplier<Item> BLUE_CANVAS_SIGN = registerWithTab("blue_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.BLUE_CANVAS_SIGN.get(), ModBlocks.BLUE_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> BLUE_HANGING_CANVAS_SIGN = registerWithTab("blue_hanging_canvas_sign",
+	public static final Supplier<Item> BLUE_HANGING_CANVAS_SIGN = registerWithTab("blue_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.BLUE_HANGING_CANVAS_SIGN.get(), ModBlocks.BLUE_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> PURPLE_CANVAS_SIGN = registerWithTab("purple_canvas_sign",
+	public static final Supplier<Item> PURPLE_CANVAS_SIGN = registerWithTab("purple_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.PURPLE_CANVAS_SIGN.get(), ModBlocks.PURPLE_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> PURPLE_HANGING_CANVAS_SIGN = registerWithTab("purple_hanging_canvas_sign",
+	public static final Supplier<Item> PURPLE_HANGING_CANVAS_SIGN = registerWithTab("purple_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.PURPLE_HANGING_CANVAS_SIGN.get(), ModBlocks.PURPLE_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> MAGENTA_CANVAS_SIGN = registerWithTab("magenta_canvas_sign",
+	public static final Supplier<Item> MAGENTA_CANVAS_SIGN = registerWithTab("magenta_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.MAGENTA_CANVAS_SIGN.get(), ModBlocks.MAGENTA_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> MAGENTA_HANGING_CANVAS_SIGN = registerWithTab("magenta_hanging_canvas_sign",
+	public static final Supplier<Item> MAGENTA_HANGING_CANVAS_SIGN = registerWithTab("magenta_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.MAGENTA_HANGING_CANVAS_SIGN.get(), ModBlocks.MAGENTA_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
-	public static final RegistryObject<Item> PINK_CANVAS_SIGN = registerWithTab("pink_canvas_sign",
+	public static final Supplier<Item> PINK_CANVAS_SIGN = registerWithTab("pink_canvas_sign",
 			() -> new SignItem(basicItem(), ModBlocks.PINK_CANVAS_SIGN.get(), ModBlocks.PINK_CANVAS_WALL_SIGN.get()));
-	public static final RegistryObject<Item> PINK_HANGING_CANVAS_SIGN = registerWithTab("pink_hanging_canvas_sign",
+	public static final Supplier<Item> PINK_HANGING_CANVAS_SIGN = registerWithTab("pink_hanging_canvas_sign",
 			() -> new HangingSignItem(ModBlocks.PINK_HANGING_CANVAS_SIGN.get(), ModBlocks.PINK_HANGING_CANVAS_WALL_SIGN.get(), basicItem()));
 
 	// Tools
-	public static final RegistryObject<Item> FLINT_KNIFE = registerWithTab("flint_knife",
+	public static final Supplier<Item> FLINT_KNIFE = registerWithTab("flint_knife",
 			() -> new KnifeItem(ModMaterials.FLINT, 0.5F, -2.0F, basicItem()));
-	public static final RegistryObject<Item> IRON_KNIFE = registerWithTab("iron_knife",
+	public static final Supplier<Item> IRON_KNIFE = registerWithTab("iron_knife",
 			() -> new KnifeItem(Tiers.IRON, 0.5F, -2.0F, basicItem()));
-	public static final RegistryObject<Item> DIAMOND_KNIFE = registerWithTab("diamond_knife",
+	public static final Supplier<Item> DIAMOND_KNIFE = registerWithTab("diamond_knife",
 			() -> new KnifeItem(Tiers.DIAMOND, 0.5F, -2.0F, basicItem()));
-	public static final RegistryObject<Item> NETHERITE_KNIFE = registerWithTab("netherite_knife",
+	public static final Supplier<Item> NETHERITE_KNIFE = registerWithTab("netherite_knife",
 			() -> new KnifeItem(Tiers.NETHERITE, 0.5F, -2.0F, basicItem().fireResistant()));
-	public static final RegistryObject<Item> GOLDEN_KNIFE = registerWithTab("golden_knife",
+	public static final Supplier<Item> GOLDEN_KNIFE = registerWithTab("golden_knife",
 			() -> new KnifeItem(Tiers.GOLD, 0.5F, -2.0F, basicItem()));
 
-	public static final RegistryObject<Item> STRAW = registerWithTab("straw", () -> new FuelItem(basicItem()));
-	public static final RegistryObject<Item> CANVAS = registerWithTab("canvas", () -> new FuelItem(basicItem(), 400));
-	public static final RegistryObject<Item> TREE_BARK = registerWithTab("tree_bark", () -> new FuelItem(basicItem(), 200));
+	public static final Supplier<Item> STRAW = registerWithTab("straw", () -> new FuelItem(basicItem()));
+	public static final Supplier<Item> CANVAS = registerWithTab("canvas", () -> new FuelItem(basicItem(), 400));
+	public static final Supplier<Item> TREE_BARK = registerWithTab("tree_bark", () -> new FuelItem(basicItem(), 200));
 
 	// Wild Crops
-	public static final RegistryObject<Item> SANDY_SHRUB = registerWithTab("sandy_shrub",
+	public static final Supplier<Item> SANDY_SHRUB = registerWithTab("sandy_shrub",
 			() -> new BlockItem(ModBlocks.SANDY_SHRUB.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_CABBAGES = registerWithTab("wild_cabbages",
+	public static final Supplier<Item> WILD_CABBAGES = registerWithTab("wild_cabbages",
 			() -> new BlockItem(ModBlocks.WILD_CABBAGES.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_ONIONS = registerWithTab("wild_onions",
+	public static final Supplier<Item> WILD_ONIONS = registerWithTab("wild_onions",
 			() -> new BlockItem(ModBlocks.WILD_ONIONS.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_TOMATOES = registerWithTab("wild_tomatoes",
+	public static final Supplier<Item> WILD_TOMATOES = registerWithTab("wild_tomatoes",
 			() -> new BlockItem(ModBlocks.WILD_TOMATOES.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_CARROTS = registerWithTab("wild_carrots",
+	public static final Supplier<Item> WILD_CARROTS = registerWithTab("wild_carrots",
 			() -> new BlockItem(ModBlocks.WILD_CARROTS.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_POTATOES = registerWithTab("wild_potatoes",
+	public static final Supplier<Item> WILD_POTATOES = registerWithTab("wild_potatoes",
 			() -> new BlockItem(ModBlocks.WILD_POTATOES.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_BEETROOTS = registerWithTab("wild_beetroots",
+	public static final Supplier<Item> WILD_BEETROOTS = registerWithTab("wild_beetroots",
 			() -> new BlockItem(ModBlocks.WILD_BEETROOTS.get(), basicItem()));
-	public static final RegistryObject<Item> WILD_RICE = registerWithTab("wild_rice",
+	public static final Supplier<Item> WILD_RICE = registerWithTab("wild_rice",
 			() -> new DoubleHighBlockItem(ModBlocks.WILD_RICE.get(), basicItem()));
 
-	public static final RegistryObject<Item> BROWN_MUSHROOM_COLONY = registerWithTab("brown_mushroom_colony",
+	public static final Supplier<Item> BROWN_MUSHROOM_COLONY = registerWithTab("brown_mushroom_colony",
 			() -> new MushroomColonyItem(ModBlocks.BROWN_MUSHROOM_COLONY.get(), basicItem()));
-	public static final RegistryObject<Item> RED_MUSHROOM_COLONY = registerWithTab("red_mushroom_colony",
+	public static final Supplier<Item> RED_MUSHROOM_COLONY = registerWithTab("red_mushroom_colony",
 			() -> new MushroomColonyItem(ModBlocks.RED_MUSHROOM_COLONY.get(), basicItem()));
 
 	// Basic Crops
-	public static final RegistryObject<Item> CABBAGE = registerWithTab("cabbage",
+	public static final Supplier<Item> CABBAGE = registerWithTab("cabbage",
 			() -> new Item(foodItem(FoodValues.CABBAGE)));
-	public static final RegistryObject<Item> TOMATO = registerWithTab("tomato",
+	public static final Supplier<Item> TOMATO = registerWithTab("tomato",
 			() -> new Item(foodItem(FoodValues.TOMATO)));
-	public static final RegistryObject<Item> ONION = registerWithTab("onion",
+	public static final Supplier<Item> ONION = registerWithTab("onion",
 			() -> new ItemNameBlockItem(ModBlocks.ONION_CROP.get(), foodItem(FoodValues.ONION)));
-	public static final RegistryObject<Item> RICE_PANICLE = registerWithTab("rice_panicle", () -> new Item(basicItem()));
-	public static final RegistryObject<Item> RICE = registerWithTab("rice",
+	public static final Supplier<Item> RICE_PANICLE = registerWithTab("rice_panicle", () -> new Item(basicItem()));
+	public static final Supplier<Item> RICE = registerWithTab("rice",
 			() -> new RiceItem(ModBlocks.RICE_CROP.get(), basicItem()));
-	public static final RegistryObject<Item> CABBAGE_SEEDS = registerWithTab("cabbage_seeds", () -> new ItemNameBlockItem(ModBlocks.CABBAGE_CROP.get(), basicItem()));
-	public static final RegistryObject<Item> TOMATO_SEEDS = registerWithTab("tomato_seeds", () -> new ItemNameBlockItem(ModBlocks.BUDDING_TOMATO_CROP.get(), basicItem())
+	public static final Supplier<Item> CABBAGE_SEEDS = registerWithTab("cabbage_seeds", () -> new ItemNameBlockItem(ModBlocks.CABBAGE_CROP.get(), basicItem()));
+	public static final Supplier<Item> TOMATO_SEEDS = registerWithTab("tomato_seeds", () -> new ItemNameBlockItem(ModBlocks.BUDDING_TOMATO_CROP.get(), basicItem())
 	{
 		@Override
 		public void registerBlocks(Map<Block, Item> blockToItemMap, Item item) {
@@ -277,197 +277,197 @@ public class ModItems
 			blockToItemMap.remove(ModBlocks.TOMATO_CROP.get());
 		}
 	});
-	public static final RegistryObject<Item> ROTTEN_TOMATO = registerWithTab("rotten_tomato",
+	public static final Supplier<Item> ROTTEN_TOMATO = registerWithTab("rotten_tomato",
 			() -> new RottenTomatoItem(new Item.Properties().stacksTo(16)));
 
 	// Foodstuffs
-	public static final RegistryObject<Item> FRIED_EGG = registerWithTab("fried_egg",
+	public static final Supplier<Item> FRIED_EGG = registerWithTab("fried_egg",
 			() -> new Item(foodItem(FoodValues.FRIED_EGG)));
-	public static final RegistryObject<Item> MILK_BOTTLE = registerWithTab("milk_bottle",
+	public static final Supplier<Item> MILK_BOTTLE = registerWithTab("milk_bottle",
 			() -> new MilkBottleItem(drinkItem()));
-	public static final RegistryObject<Item> HOT_COCOA = registerWithTab("hot_cocoa",
+	public static final Supplier<Item> HOT_COCOA = registerWithTab("hot_cocoa",
 			() -> new HotCocoaItem(drinkItem()));
-	public static final RegistryObject<Item> APPLE_CIDER = registerWithTab("apple_cider",
+	public static final Supplier<Item> APPLE_CIDER = registerWithTab("apple_cider",
 			() -> new DrinkableItem(drinkItem().food(FoodValues.APPLE_CIDER), true, false));
-	public static final RegistryObject<Item> MELON_JUICE = registerWithTab("melon_juice",
+	public static final Supplier<Item> MELON_JUICE = registerWithTab("melon_juice",
 			() -> new MelonJuiceItem(drinkItem()));
-	public static final RegistryObject<Item> TOMATO_SAUCE = registerWithTab("tomato_sauce",
+	public static final Supplier<Item> TOMATO_SAUCE = registerWithTab("tomato_sauce",
 			() -> new ConsumableItem(foodItem(FoodValues.TOMATO_SAUCE).craftRemainder(Items.BOWL)));
-	public static final RegistryObject<Item> WHEAT_DOUGH = registerWithTab("wheat_dough",
+	public static final Supplier<Item> WHEAT_DOUGH = registerWithTab("wheat_dough",
 			() -> new Item(foodItem(FoodValues.WHEAT_DOUGH)));
-	public static final RegistryObject<Item> RAW_PASTA = registerWithTab("raw_pasta",
+	public static final Supplier<Item> RAW_PASTA = registerWithTab("raw_pasta",
 			() -> new Item(foodItem(FoodValues.RAW_PASTA)));
-	public static final RegistryObject<Item> PUMPKIN_SLICE = registerWithTab("pumpkin_slice",
+	public static final Supplier<Item> PUMPKIN_SLICE = registerWithTab("pumpkin_slice",
 			() -> new Item(foodItem(FoodValues.PUMPKIN_SLICE)));
-	public static final RegistryObject<Item> CABBAGE_LEAF = registerWithTab("cabbage_leaf",
+	public static final Supplier<Item> CABBAGE_LEAF = registerWithTab("cabbage_leaf",
 			() -> new Item(foodItem(FoodValues.CABBAGE_LEAF)));
-	public static final RegistryObject<Item> MINCED_BEEF = registerWithTab("minced_beef",
+	public static final Supplier<Item> MINCED_BEEF = registerWithTab("minced_beef",
 			() -> new Item(foodItem(FoodValues.MINCED_BEEF)));
-	public static final RegistryObject<Item> BEEF_PATTY = registerWithTab("beef_patty",
+	public static final Supplier<Item> BEEF_PATTY = registerWithTab("beef_patty",
 			() -> new Item(foodItem(FoodValues.BEEF_PATTY)));
-	public static final RegistryObject<Item> CHICKEN_CUTS = registerWithTab("chicken_cuts",
+	public static final Supplier<Item> CHICKEN_CUTS = registerWithTab("chicken_cuts",
 			() -> new Item(foodItem(FoodValues.CHICKEN_CUTS)));
-	public static final RegistryObject<Item> COOKED_CHICKEN_CUTS = registerWithTab("cooked_chicken_cuts",
+	public static final Supplier<Item> COOKED_CHICKEN_CUTS = registerWithTab("cooked_chicken_cuts",
 			() -> new Item(foodItem(FoodValues.COOKED_CHICKEN_CUTS)));
-	public static final RegistryObject<Item> BACON = registerWithTab("bacon",
+	public static final Supplier<Item> BACON = registerWithTab("bacon",
 			() -> new Item(foodItem(FoodValues.BACON)));
-	public static final RegistryObject<Item> COOKED_BACON = registerWithTab("cooked_bacon",
+	public static final Supplier<Item> COOKED_BACON = registerWithTab("cooked_bacon",
 			() -> new Item(foodItem(FoodValues.COOKED_BACON)));
-	public static final RegistryObject<Item> COD_SLICE = registerWithTab("cod_slice",
+	public static final Supplier<Item> COD_SLICE = registerWithTab("cod_slice",
 			() -> new Item(foodItem(FoodValues.COD_SLICE)));
-	public static final RegistryObject<Item> COOKED_COD_SLICE = registerWithTab("cooked_cod_slice",
+	public static final Supplier<Item> COOKED_COD_SLICE = registerWithTab("cooked_cod_slice",
 			() -> new Item(foodItem(FoodValues.COOKED_COD_SLICE)));
-	public static final RegistryObject<Item> SALMON_SLICE = registerWithTab("salmon_slice",
+	public static final Supplier<Item> SALMON_SLICE = registerWithTab("salmon_slice",
 			() -> new Item(foodItem(FoodValues.SALMON_SLICE)));
-	public static final RegistryObject<Item> COOKED_SALMON_SLICE = registerWithTab("cooked_salmon_slice",
+	public static final Supplier<Item> COOKED_SALMON_SLICE = registerWithTab("cooked_salmon_slice",
 			() -> new Item(foodItem(FoodValues.COOKED_SALMON_SLICE)));
-	public static final RegistryObject<Item> MUTTON_CHOPS = registerWithTab("mutton_chops",
+	public static final Supplier<Item> MUTTON_CHOPS = registerWithTab("mutton_chops",
 			() -> new Item(foodItem(FoodValues.MUTTON_CHOP)));
-	public static final RegistryObject<Item> COOKED_MUTTON_CHOPS = registerWithTab("cooked_mutton_chops",
+	public static final Supplier<Item> COOKED_MUTTON_CHOPS = registerWithTab("cooked_mutton_chops",
 			() -> new Item(foodItem(FoodValues.COOKED_MUTTON_CHOP)));
-	public static final RegistryObject<Item> HAM = registerWithTab("ham",
+	public static final Supplier<Item> HAM = registerWithTab("ham",
 			() -> new Item(foodItem(FoodValues.HAM)));
-	public static final RegistryObject<Item> SMOKED_HAM = registerWithTab("smoked_ham",
+	public static final Supplier<Item> SMOKED_HAM = registerWithTab("smoked_ham",
 			() -> new Item(foodItem(FoodValues.SMOKED_HAM)));
 
 	// Sweets
-	public static final RegistryObject<Item> PIE_CRUST = registerWithTab("pie_crust",
+	public static final Supplier<Item> PIE_CRUST = registerWithTab("pie_crust",
 			() -> new Item(foodItem(FoodValues.PIE_CRUST)));
-	public static final RegistryObject<Item> APPLE_PIE = registerWithTab("apple_pie",
+	public static final Supplier<Item> APPLE_PIE = registerWithTab("apple_pie",
 			() -> new BlockItem(ModBlocks.APPLE_PIE.get(), basicItem()));
-	public static final RegistryObject<Item> SWEET_BERRY_CHEESECAKE = registerWithTab("sweet_berry_cheesecake",
+	public static final Supplier<Item> SWEET_BERRY_CHEESECAKE = registerWithTab("sweet_berry_cheesecake",
 			() -> new BlockItem(ModBlocks.SWEET_BERRY_CHEESECAKE.get(), basicItem()));
-	public static final RegistryObject<Item> CHOCOLATE_PIE = registerWithTab("chocolate_pie",
+	public static final Supplier<Item> CHOCOLATE_PIE = registerWithTab("chocolate_pie",
 			() -> new BlockItem(ModBlocks.CHOCOLATE_PIE.get(), basicItem()));
-	public static final RegistryObject<Item> CAKE_SLICE = registerWithTab("cake_slice",
+	public static final Supplier<Item> CAKE_SLICE = registerWithTab("cake_slice",
 			() -> new Item(foodItem(FoodValues.CAKE_SLICE)));
-	public static final RegistryObject<Item> APPLE_PIE_SLICE = registerWithTab("apple_pie_slice",
+	public static final Supplier<Item> APPLE_PIE_SLICE = registerWithTab("apple_pie_slice",
 			() -> new Item(foodItem(FoodValues.PIE_SLICE)));
-	public static final RegistryObject<Item> SWEET_BERRY_CHEESECAKE_SLICE = registerWithTab("sweet_berry_cheesecake_slice",
+	public static final Supplier<Item> SWEET_BERRY_CHEESECAKE_SLICE = registerWithTab("sweet_berry_cheesecake_slice",
 			() -> new Item(foodItem(FoodValues.PIE_SLICE)));
-	public static final RegistryObject<Item> CHOCOLATE_PIE_SLICE = registerWithTab("chocolate_pie_slice",
+	public static final Supplier<Item> CHOCOLATE_PIE_SLICE = registerWithTab("chocolate_pie_slice",
 			() -> new Item(foodItem(FoodValues.PIE_SLICE)));
-	public static final RegistryObject<Item> PUMPKIN_PIE_SLICE = registerWithTab("pumpkin_pie_slice",
+	public static final Supplier<Item> PUMPKIN_PIE_SLICE = registerWithTab("pumpkin_pie_slice",
 			() -> new Item(foodItem(FoodValues.PIE_SLICE)));
-	public static final RegistryObject<Item> SWEET_BERRY_COOKIE = registerWithTab("sweet_berry_cookie",
+	public static final Supplier<Item> SWEET_BERRY_COOKIE = registerWithTab("sweet_berry_cookie",
 			() -> new Item(foodItem(FoodValues.COOKIES)));
-	public static final RegistryObject<Item> HONEY_COOKIE = registerWithTab("honey_cookie",
+	public static final Supplier<Item> HONEY_COOKIE = registerWithTab("honey_cookie",
 			() -> new Item(foodItem(FoodValues.COOKIES)));
-	public static final RegistryObject<Item> MELON_POPSICLE = registerWithTab("melon_popsicle",
+	public static final Supplier<Item> MELON_POPSICLE = registerWithTab("melon_popsicle",
 			() -> new PopsicleItem(foodItem(FoodValues.POPSICLE)));
-	public static final RegistryObject<Item> GLOW_BERRY_CUSTARD = registerWithTab("glow_berry_custard",
+	public static final Supplier<Item> GLOW_BERRY_CUSTARD = registerWithTab("glow_berry_custard",
 			() -> new ConsumableItem(foodItem(FoodValues.GLOW_BERRY_CUSTARD).craftRemainder(Items.GLASS_BOTTLE).stacksTo(16)));
-	public static final RegistryObject<Item> FRUIT_SALAD = registerWithTab("fruit_salad",
+	public static final Supplier<Item> FRUIT_SALAD = registerWithTab("fruit_salad",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.FRUIT_SALAD), true));
 
 	// Basic Meals
-	public static final RegistryObject<Item> MIXED_SALAD = registerWithTab("mixed_salad",
+	public static final Supplier<Item> MIXED_SALAD = registerWithTab("mixed_salad",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.MIXED_SALAD), true));
-	public static final RegistryObject<Item> NETHER_SALAD = registerWithTab("nether_salad",
+	public static final Supplier<Item> NETHER_SALAD = registerWithTab("nether_salad",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.NETHER_SALAD)));
-	public static final RegistryObject<Item> BARBECUE_STICK = registerWithTab("barbecue_stick",
+	public static final Supplier<Item> BARBECUE_STICK = registerWithTab("barbecue_stick",
 			() -> new Item(foodItem(FoodValues.BARBECUE_STICK)));
-	public static final RegistryObject<Item> EGG_SANDWICH = registerWithTab("egg_sandwich",
+	public static final Supplier<Item> EGG_SANDWICH = registerWithTab("egg_sandwich",
 			() -> new Item(foodItem(FoodValues.EGG_SANDWICH)));
-	public static final RegistryObject<Item> CHICKEN_SANDWICH = registerWithTab("chicken_sandwich",
+	public static final Supplier<Item> CHICKEN_SANDWICH = registerWithTab("chicken_sandwich",
 			() -> new Item(foodItem(FoodValues.CHICKEN_SANDWICH)));
-	public static final RegistryObject<Item> HAMBURGER = registerWithTab("hamburger",
+	public static final Supplier<Item> HAMBURGER = registerWithTab("hamburger",
 			() -> new Item(foodItem(FoodValues.HAMBURGER)));
-	public static final RegistryObject<Item> BACON_SANDWICH = registerWithTab("bacon_sandwich",
+	public static final Supplier<Item> BACON_SANDWICH = registerWithTab("bacon_sandwich",
 			() -> new Item(foodItem(FoodValues.BACON_SANDWICH)));
-	public static final RegistryObject<Item> MUTTON_WRAP = registerWithTab("mutton_wrap",
+	public static final Supplier<Item> MUTTON_WRAP = registerWithTab("mutton_wrap",
 			() -> new Item(foodItem(FoodValues.MUTTON_WRAP)));
-	public static final RegistryObject<Item> DUMPLINGS = registerWithTab("dumplings",
+	public static final Supplier<Item> DUMPLINGS = registerWithTab("dumplings",
 			() -> new Item(foodItem(FoodValues.DUMPLINGS)));
-	public static final RegistryObject<Item> STUFFED_POTATO = registerWithTab("stuffed_potato",
+	public static final Supplier<Item> STUFFED_POTATO = registerWithTab("stuffed_potato",
 			() -> new Item(foodItem(FoodValues.STUFFED_POTATO)));
-	public static final RegistryObject<Item> CABBAGE_ROLLS = registerWithTab("cabbage_rolls",
+	public static final Supplier<Item> CABBAGE_ROLLS = registerWithTab("cabbage_rolls",
 			() -> new Item(foodItem(FoodValues.CABBAGE_ROLLS)));
-	public static final RegistryObject<Item> SALMON_ROLL = registerWithTab("salmon_roll",
+	public static final Supplier<Item> SALMON_ROLL = registerWithTab("salmon_roll",
 			() -> new Item(foodItem(FoodValues.SALMON_ROLL)));
-	public static final RegistryObject<Item> COD_ROLL = registerWithTab("cod_roll",
+	public static final Supplier<Item> COD_ROLL = registerWithTab("cod_roll",
 			() -> new Item(foodItem(FoodValues.COD_ROLL)));
-	public static final RegistryObject<Item> KELP_ROLL = registerWithTab("kelp_roll",
+	public static final Supplier<Item> KELP_ROLL = registerWithTab("kelp_roll",
 			() -> new KelpRollItem(foodItem(FoodValues.KELP_ROLL)));
-	public static final RegistryObject<Item> KELP_ROLL_SLICE = registerWithTab("kelp_roll_slice",
+	public static final Supplier<Item> KELP_ROLL_SLICE = registerWithTab("kelp_roll_slice",
 			() -> new Item(foodItem(FoodValues.KELP_ROLL_SLICE)));
 
 	// Soups and Stews
-	public static final RegistryObject<Item> COOKED_RICE = registerWithTab("cooked_rice",
+	public static final Supplier<Item> COOKED_RICE = registerWithTab("cooked_rice",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.COOKED_RICE), true));
-	public static final RegistryObject<Item> BONE_BROTH = registerWithTab("bone_broth",
+	public static final Supplier<Item> BONE_BROTH = registerWithTab("bone_broth",
 			() -> new DrinkableItem(bowlFoodItem(FoodValues.BONE_BROTH), true));
-	public static final RegistryObject<Item> BEEF_STEW = registerWithTab("beef_stew",
+	public static final Supplier<Item> BEEF_STEW = registerWithTab("beef_stew",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.BEEF_STEW), true));
-	public static final RegistryObject<Item> CHICKEN_SOUP = registerWithTab("chicken_soup",
+	public static final Supplier<Item> CHICKEN_SOUP = registerWithTab("chicken_soup",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.CHICKEN_SOUP), true));
-	public static final RegistryObject<Item> VEGETABLE_SOUP = registerWithTab("vegetable_soup",
+	public static final Supplier<Item> VEGETABLE_SOUP = registerWithTab("vegetable_soup",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.VEGETABLE_SOUP), true));
-	public static final RegistryObject<Item> FISH_STEW = registerWithTab("fish_stew",
+	public static final Supplier<Item> FISH_STEW = registerWithTab("fish_stew",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.FISH_STEW), true));
-	public static final RegistryObject<Item> FRIED_RICE = registerWithTab("fried_rice",
+	public static final Supplier<Item> FRIED_RICE = registerWithTab("fried_rice",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.FRIED_RICE), true));
-	public static final RegistryObject<Item> PUMPKIN_SOUP = registerWithTab("pumpkin_soup",
+	public static final Supplier<Item> PUMPKIN_SOUP = registerWithTab("pumpkin_soup",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.PUMPKIN_SOUP), true));
-	public static final RegistryObject<Item> BAKED_COD_STEW = registerWithTab("baked_cod_stew",
+	public static final Supplier<Item> BAKED_COD_STEW = registerWithTab("baked_cod_stew",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.BAKED_COD_STEW), true));
-	public static final RegistryObject<Item> NOODLE_SOUP = registerWithTab("noodle_soup",
+	public static final Supplier<Item> NOODLE_SOUP = registerWithTab("noodle_soup",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.NOODLE_SOUP), true));
 
 	// Plated Meals
-	public static final RegistryObject<Item> BACON_AND_EGGS = registerWithTab("bacon_and_eggs",
+	public static final Supplier<Item> BACON_AND_EGGS = registerWithTab("bacon_and_eggs",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.BACON_AND_EGGS), true));
-	public static final RegistryObject<Item> PASTA_WITH_MEATBALLS = registerWithTab("pasta_with_meatballs",
+	public static final Supplier<Item> PASTA_WITH_MEATBALLS = registerWithTab("pasta_with_meatballs",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.PASTA_WITH_MEATBALLS), true));
-	public static final RegistryObject<Item> PASTA_WITH_MUTTON_CHOP = registerWithTab("pasta_with_mutton_chop",
+	public static final Supplier<Item> PASTA_WITH_MUTTON_CHOP = registerWithTab("pasta_with_mutton_chop",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.PASTA_WITH_MUTTON_CHOP), true));
-	public static final RegistryObject<Item> MUSHROOM_RICE = registerWithTab("mushroom_rice",
+	public static final Supplier<Item> MUSHROOM_RICE = registerWithTab("mushroom_rice",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.MUSHROOM_RICE), true));
-	public static final RegistryObject<Item> ROASTED_MUTTON_CHOPS = registerWithTab("roasted_mutton_chops",
+	public static final Supplier<Item> ROASTED_MUTTON_CHOPS = registerWithTab("roasted_mutton_chops",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.ROASTED_MUTTON_CHOPS), true));
-	public static final RegistryObject<Item> VEGETABLE_NOODLES = registerWithTab("vegetable_noodles",
+	public static final Supplier<Item> VEGETABLE_NOODLES = registerWithTab("vegetable_noodles",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.VEGETABLE_NOODLES), true));
-	public static final RegistryObject<Item> STEAK_AND_POTATOES = registerWithTab("steak_and_potatoes",
+	public static final Supplier<Item> STEAK_AND_POTATOES = registerWithTab("steak_and_potatoes",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.STEAK_AND_POTATOES), true));
-	public static final RegistryObject<Item> RATATOUILLE = registerWithTab("ratatouille",
+	public static final Supplier<Item> RATATOUILLE = registerWithTab("ratatouille",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.RATATOUILLE), true));
-	public static final RegistryObject<Item> SQUID_INK_PASTA = registerWithTab("squid_ink_pasta",
+	public static final Supplier<Item> SQUID_INK_PASTA = registerWithTab("squid_ink_pasta",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.SQUID_INK_PASTA), true));
-	public static final RegistryObject<Item> GRILLED_SALMON = registerWithTab("grilled_salmon",
+	public static final Supplier<Item> GRILLED_SALMON = registerWithTab("grilled_salmon",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.GRILLED_SALMON), true));
 
 	// Feasts
-	public static final RegistryObject<Item> ROAST_CHICKEN_BLOCK = registerWithTab("roast_chicken_block",
+	public static final Supplier<Item> ROAST_CHICKEN_BLOCK = registerWithTab("roast_chicken_block",
 			() -> new BlockItem(ModBlocks.ROAST_CHICKEN_BLOCK.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> ROAST_CHICKEN = registerWithTab("roast_chicken",
+	public static final Supplier<Item> ROAST_CHICKEN = registerWithTab("roast_chicken",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.ROAST_CHICKEN), true));
 
-	public static final RegistryObject<Item> STUFFED_PUMPKIN_BLOCK = registerWithTab("stuffed_pumpkin_block",
+	public static final Supplier<Item> STUFFED_PUMPKIN_BLOCK = registerWithTab("stuffed_pumpkin_block",
 			() -> new BlockItem(ModBlocks.STUFFED_PUMPKIN_BLOCK.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> STUFFED_PUMPKIN = registerWithTab("stuffed_pumpkin",
+	public static final Supplier<Item> STUFFED_PUMPKIN = registerWithTab("stuffed_pumpkin",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.STUFFED_PUMPKIN), true));
 
-	public static final RegistryObject<Item> HONEY_GLAZED_HAM_BLOCK = registerWithTab("honey_glazed_ham_block",
+	public static final Supplier<Item> HONEY_GLAZED_HAM_BLOCK = registerWithTab("honey_glazed_ham_block",
 			() -> new BlockItem(ModBlocks.HONEY_GLAZED_HAM_BLOCK.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> HONEY_GLAZED_HAM = registerWithTab("honey_glazed_ham",
+	public static final Supplier<Item> HONEY_GLAZED_HAM = registerWithTab("honey_glazed_ham",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.HONEY_GLAZED_HAM), true));
 
-	public static final RegistryObject<Item> SHEPHERDS_PIE_BLOCK = registerWithTab("shepherds_pie_block",
+	public static final Supplier<Item> SHEPHERDS_PIE_BLOCK = registerWithTab("shepherds_pie_block",
 			() -> new BlockItem(ModBlocks.SHEPHERDS_PIE_BLOCK.get(), basicItem().stacksTo(1)));
-	public static final RegistryObject<Item> SHEPHERDS_PIE = registerWithTab("shepherds_pie",
+	public static final Supplier<Item> SHEPHERDS_PIE = registerWithTab("shepherds_pie",
 			() -> new ConsumableItem(bowlFoodItem(FoodValues.SHEPHERDS_PIE), true));
 
-	public static final RegistryObject<Item> RICE_ROLL_MEDLEY_BLOCK = registerWithTab("rice_roll_medley_block",
+	public static final Supplier<Item> RICE_ROLL_MEDLEY_BLOCK = registerWithTab("rice_roll_medley_block",
 			() -> new BlockItem(ModBlocks.RICE_ROLL_MEDLEY_BLOCK.get(), basicItem().stacksTo(1)));
 
 	// Pet Foods
-	public static final RegistryObject<Item> DOG_FOOD = registerWithTab("dog_food",
+	public static final Supplier<Item> DOG_FOOD = registerWithTab("dog_food",
 			() -> new DogFoodItem(bowlFoodItem(FoodValues.DOG_FOOD)));
-	public static final RegistryObject<Item> HORSE_FEED = registerWithTab("horse_feed",
+	public static final Supplier<Item> HORSE_FEED = registerWithTab("horse_feed",
 			() -> new HorseFeedItem(basicItem().stacksTo(16)));
 
 	// Hidden (Debug) Items
-	public static final RegistryObject<Item> DEBUG_PUMPKIN_PIE = registerHidden("debug_pumpkin_pie",
+	public static final Supplier<Item> DEBUG_PUMPKIN_PIE = registerHidden("debug_pumpkin_pie",
 			() -> new BlockItem(ModBlocks.PUMPKIN_PIE.get(), basicItem()){
 				@Override
 				public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModLootFunctions.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModLootFunctions.java
@@ -3,7 +3,7 @@ package vectorwing.farmersdelight.common.registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
 import net.minecraftforge.registries.DeferredRegister;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.loot.function.CopyMealFunction;
 import vectorwing.farmersdelight.common.loot.function.CopySkilletFunction;
@@ -13,7 +13,7 @@ public class ModLootFunctions
 {
 	public static final DeferredRegister<LootItemFunctionType> LOOT_FUNCTIONS = DeferredRegister.create(BuiltInRegistries.LOOT_FUNCTION_TYPE.key(), FarmersDelight.MODID);
 
-	public static final RegistryObject<LootItemFunctionType> COPY_MEAL = LOOT_FUNCTIONS.register("copy_meal", () -> new LootItemFunctionType(new CopyMealFunction.Serializer()));
-	public static final RegistryObject<LootItemFunctionType> COPY_SKILLET = LOOT_FUNCTIONS.register("copy_skillet", () -> new LootItemFunctionType(new CopySkilletFunction.Serializer()));
-	public static final RegistryObject<LootItemFunctionType> SMOKER_COOK = LOOT_FUNCTIONS.register("smoker_cook", () -> new LootItemFunctionType(new SmokerCookFunction.Serializer()));
+	public static final Supplier<LootItemFunctionType> COPY_MEAL = LOOT_FUNCTIONS.register("copy_meal", () -> new LootItemFunctionType(new CopyMealFunction.Serializer()));
+	public static final Supplier<LootItemFunctionType> COPY_SKILLET = LOOT_FUNCTIONS.register("copy_skillet", () -> new LootItemFunctionType(new CopySkilletFunction.Serializer()));
+	public static final Supplier<LootItemFunctionType> SMOKER_COOK = LOOT_FUNCTIONS.register("smoker_cook", () -> new LootItemFunctionType(new SmokerCookFunction.Serializer()));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModLootModifiers.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModLootModifiers.java
@@ -4,7 +4,7 @@ import com.mojang.serialization.Codec;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.loot.modifier.AddItemModifier;
 import vectorwing.farmersdelight.common.loot.modifier.AddLootTableModifier;
@@ -15,8 +15,8 @@ public class ModLootModifiers
 {
 	public static final DeferredRegister<Codec<? extends IGlobalLootModifier>> LOOT_MODIFIERS = DeferredRegister.create(ForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, FarmersDelight.MODID);
 
-	public static final RegistryObject<Codec<? extends IGlobalLootModifier>> ADD_ITEM = LOOT_MODIFIERS.register("add_item", AddItemModifier.CODEC);
-	public static final RegistryObject<Codec<? extends IGlobalLootModifier>> REPLACE_ITEM = LOOT_MODIFIERS.register("replace_item", ReplaceItemModifier.CODEC);
-	public static final RegistryObject<Codec<? extends IGlobalLootModifier>> ADD_LOOT_TABLE = LOOT_MODIFIERS.register("add_loot_table", AddLootTableModifier.CODEC);
-	public static final RegistryObject<Codec<? extends IGlobalLootModifier>> PASTRY_SLICING = LOOT_MODIFIERS.register("pastry_slicing", PastrySlicingModifier.CODEC);
+	public static final Supplier<Codec<? extends IGlobalLootModifier>> ADD_ITEM = LOOT_MODIFIERS.register("add_item", AddItemModifier.CODEC);
+	public static final Supplier<Codec<? extends IGlobalLootModifier>> REPLACE_ITEM = LOOT_MODIFIERS.register("replace_item", ReplaceItemModifier.CODEC);
+	public static final Supplier<Codec<? extends IGlobalLootModifier>> ADD_LOOT_TABLE = LOOT_MODIFIERS.register("add_loot_table", AddLootTableModifier.CODEC);
+	public static final Supplier<Codec<? extends IGlobalLootModifier>> PASTRY_SLICING = LOOT_MODIFIERS.register("pastry_slicing", PastrySlicingModifier.CODEC);
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModMenuTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModMenuTypes.java
@@ -4,7 +4,7 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.block.entity.container.CookingPotMenu;
 
@@ -12,6 +12,6 @@ public class ModMenuTypes
 {
 	public static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create(ForgeRegistries.MENU_TYPES, FarmersDelight.MODID);
 
-	public static final RegistryObject<MenuType<CookingPotMenu>> COOKING_POT = MENU_TYPES
+	public static final Supplier<MenuType<CookingPotMenu>> COOKING_POT = MENU_TYPES
 			.register("cooking_pot", () -> IForgeMenuType.create(CookingPotMenu::new));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModParticleTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModParticleTypes.java
@@ -4,15 +4,15 @@ import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 
 public class ModParticleTypes
 {
 	public static final DeferredRegister<ParticleType<?>> PARTICLE_TYPES = DeferredRegister.create(ForgeRegistries.PARTICLE_TYPES, FarmersDelight.MODID);
 
-	public static final RegistryObject<SimpleParticleType> STAR = PARTICLE_TYPES.register("star",
+	public static final Supplier<SimpleParticleType> STAR = PARTICLE_TYPES.register("star",
 			() -> new SimpleParticleType(true));
-	public static final RegistryObject<SimpleParticleType> STEAM = PARTICLE_TYPES.register("steam",
+	public static final Supplier<SimpleParticleType> STEAM = PARTICLE_TYPES.register("steam",
 			() -> new SimpleParticleType(true));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModPlacementModifiers.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModPlacementModifiers.java
@@ -5,7 +5,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
 import net.minecraftforge.registries.DeferredRegister;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.world.filter.BiomeTagFilter;
 
@@ -13,7 +13,7 @@ public class ModPlacementModifiers
 {
 	public static final DeferredRegister<PlacementModifierType<?>> PLACEMENT_MODIFIERS = DeferredRegister.create(BuiltInRegistries.PLACEMENT_MODIFIER_TYPE.key(), FarmersDelight.MODID);
 
-	public static final RegistryObject<PlacementModifierType<BiomeTagFilter>> BIOME_TAG = PLACEMENT_MODIFIERS.register("biome_tag", () -> typeConvert(BiomeTagFilter.CODEC));
+	public static final Supplier<PlacementModifierType<BiomeTagFilter>> BIOME_TAG = PLACEMENT_MODIFIERS.register("biome_tag", () -> typeConvert(BiomeTagFilter.CODEC));
 
 	private static <P extends PlacementModifier> PlacementModifierType<P> typeConvert(Codec<P> codec) {
 		return () -> codec;

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeSerializers.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeSerializers.java
@@ -4,7 +4,7 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.SimpleCraftingRecipeSerializer;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
@@ -15,11 +15,11 @@ public class ModRecipeSerializers
 {
 	public static final DeferredRegister<RecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, FarmersDelight.MODID);
 
-	public static final RegistryObject<RecipeSerializer<?>> COOKING = RECIPE_SERIALIZERS.register("cooking", CookingPotRecipe.Serializer::new);
-	public static final RegistryObject<RecipeSerializer<?>> CUTTING = RECIPE_SERIALIZERS.register("cutting", CuttingBoardRecipe.Serializer::new);
+	public static final Supplier<RecipeSerializer<?>> COOKING = RECIPE_SERIALIZERS.register("cooking", CookingPotRecipe.Serializer::new);
+	public static final Supplier<RecipeSerializer<?>> CUTTING = RECIPE_SERIALIZERS.register("cutting", CuttingBoardRecipe.Serializer::new);
 
-	public static final RegistryObject<SimpleCraftingRecipeSerializer<?>> FOOD_SERVING =
+	public static final Supplier<SimpleCraftingRecipeSerializer<?>> FOOD_SERVING =
 			RECIPE_SERIALIZERS.register("food_serving", () -> new SimpleCraftingRecipeSerializer<>(FoodServingRecipe::new));
-	public static final RegistryObject<SimpleCraftingRecipeSerializer<?>> DOUGH =
+	public static final Supplier<SimpleCraftingRecipeSerializer<?>> DOUGH =
 			RECIPE_SERIALIZERS.register("dough", () -> new SimpleCraftingRecipeSerializer<>(DoughRecipe::new));
 }

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModRecipeTypes.java
@@ -4,7 +4,7 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
@@ -13,8 +13,8 @@ public class ModRecipeTypes
 {
 	public static final DeferredRegister<RecipeType<?>> RECIPE_TYPES = DeferredRegister.create(ForgeRegistries.RECIPE_TYPES, FarmersDelight.MODID);
 
-	public static final RegistryObject<RecipeType<CookingPotRecipe>> COOKING = RECIPE_TYPES.register("cooking", () -> registerRecipeType("cooking"));
-	public static final RegistryObject<RecipeType<CuttingBoardRecipe>> CUTTING = RECIPE_TYPES.register("cutting", () -> registerRecipeType("cutting"));
+	public static final Supplier<RecipeType<CookingPotRecipe>> COOKING = RECIPE_TYPES.register("cooking", () -> registerRecipeType("cooking"));
+	public static final Supplier<RecipeType<CuttingBoardRecipe>> CUTTING = RECIPE_TYPES.register("cutting", () -> registerRecipeType("cutting"));
 
 	public static <T extends Recipe<?>> RecipeType<T> registerRecipeType(final String identifier) {
 		return new RecipeType<>()

--- a/src/main/java/vectorwing/farmersdelight/common/registry/ModSounds.java
+++ b/src/main/java/vectorwing/farmersdelight/common/registry/ModSounds.java
@@ -4,7 +4,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
+import java.util.function.Supplier;
 import vectorwing.farmersdelight.FarmersDelight;
 
 public class ModSounds
@@ -12,47 +12,47 @@ public class ModSounds
 	public static final DeferredRegister<SoundEvent> SOUNDS = DeferredRegister.create(ForgeRegistries.SOUND_EVENTS, FarmersDelight.MODID);
 
 	// Stove
-	public static final RegistryObject<SoundEvent> BLOCK_STOVE_CRACKLE = SOUNDS.register("block.stove.crackle",
+	public static final Supplier<SoundEvent> BLOCK_STOVE_CRACKLE = SOUNDS.register("block.stove.crackle",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.stove.crackle")));
 
 	// Cooking Pot
-	public static final RegistryObject<SoundEvent> BLOCK_COOKING_POT_BOIL = SOUNDS.register("block.cooking_pot.boil",
+	public static final Supplier<SoundEvent> BLOCK_COOKING_POT_BOIL = SOUNDS.register("block.cooking_pot.boil",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cooking_pot.boil")));
-	public static final RegistryObject<SoundEvent> BLOCK_COOKING_POT_BOIL_SOUP = SOUNDS.register("block.cooking_pot.boil_soup",
+	public static final Supplier<SoundEvent> BLOCK_COOKING_POT_BOIL_SOUP = SOUNDS.register("block.cooking_pot.boil_soup",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cooking_pot.boil_soup")));
 
 	// Cutting Board
-	public static final RegistryObject<SoundEvent> BLOCK_CUTTING_BOARD_PLACE = SOUNDS.register("block.cutting_board.place",
+	public static final Supplier<SoundEvent> BLOCK_CUTTING_BOARD_PLACE = SOUNDS.register("block.cutting_board.place",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cutting_board.place")));
-	public static final RegistryObject<SoundEvent> BLOCK_CUTTING_BOARD_REMOVE = SOUNDS.register("block.cutting_board.remove",
+	public static final Supplier<SoundEvent> BLOCK_CUTTING_BOARD_REMOVE = SOUNDS.register("block.cutting_board.remove",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cutting_board.remove")));
-	public static final RegistryObject<SoundEvent> BLOCK_CUTTING_BOARD_CARVE = SOUNDS.register("block.cutting_board.carve",
+	public static final Supplier<SoundEvent> BLOCK_CUTTING_BOARD_CARVE = SOUNDS.register("block.cutting_board.carve",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cutting_board.carve")));
-	public static final RegistryObject<SoundEvent> BLOCK_CUTTING_BOARD_KNIFE = SOUNDS.register("block.cutting_board.knife",
+	public static final Supplier<SoundEvent> BLOCK_CUTTING_BOARD_KNIFE = SOUNDS.register("block.cutting_board.knife",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cutting_board.knife")));
 
 	// Cabinet
-	public static final RegistryObject<SoundEvent> BLOCK_CABINET_OPEN = SOUNDS.register("block.cabinet.open",
+	public static final Supplier<SoundEvent> BLOCK_CABINET_OPEN = SOUNDS.register("block.cabinet.open",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cabinet.open")));
-	public static final RegistryObject<SoundEvent> BLOCK_CABINET_CLOSE = SOUNDS.register("block.cabinet.close",
+	public static final Supplier<SoundEvent> BLOCK_CABINET_CLOSE = SOUNDS.register("block.cabinet.close",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.cabinet.close")));
 
 	// Skillet
-	public static final RegistryObject<SoundEvent> BLOCK_SKILLET_SIZZLE = SOUNDS.register("block.skillet.sizzle",
+	public static final Supplier<SoundEvent> BLOCK_SKILLET_SIZZLE = SOUNDS.register("block.skillet.sizzle",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.skillet.sizzle")));
-	public static final RegistryObject<SoundEvent> BLOCK_SKILLET_ADD_FOOD = SOUNDS.register("block.skillet.add_food",
+	public static final Supplier<SoundEvent> BLOCK_SKILLET_ADD_FOOD = SOUNDS.register("block.skillet.add_food",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.skillet.add_food")));
-	public static final RegistryObject<SoundEvent> ITEM_SKILLET_ATTACK_STRONG = SOUNDS.register("item.skillet.attack.strong",
+	public static final Supplier<SoundEvent> ITEM_SKILLET_ATTACK_STRONG = SOUNDS.register("item.skillet.attack.strong",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "item.skillet.attack.strong")));
-	public static final RegistryObject<SoundEvent> ITEM_SKILLET_ATTACK_WEAK = SOUNDS.register("item.skillet.attack.weak",
+	public static final Supplier<SoundEvent> ITEM_SKILLET_ATTACK_WEAK = SOUNDS.register("item.skillet.attack.weak",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "item.skillet.attack.weak")));
 
 	// Tomato Bush
-	public static final RegistryObject<SoundEvent> ITEM_TOMATO_PICK_FROM_BUSH = SOUNDS.register("block.tomato_bush.pick_tomatoes",
+	public static final Supplier<SoundEvent> ITEM_TOMATO_PICK_FROM_BUSH = SOUNDS.register("block.tomato_bush.pick_tomatoes",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "block.tomato_bush.pick_tomatoes")));
 	
-	public static final RegistryObject<SoundEvent> ENTITY_ROTTEN_TOMATO_THROW = SOUNDS.register("entity.rotten_tomato.throw",
+	public static final Supplier<SoundEvent> ENTITY_ROTTEN_TOMATO_THROW = SOUNDS.register("entity.rotten_tomato.throw",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "entity.rotten_tomato.throw")));
-	public static final RegistryObject<SoundEvent> ENTITY_ROTTEN_TOMATO_HIT = SOUNDS.register("entity.rotten_tomato.hit",
+	public static final Supplier<SoundEvent> ENTITY_ROTTEN_TOMATO_HIT = SOUNDS.register("entity.rotten_tomato.hit",
 			() -> SoundEvent.createVariableRangeEvent(new ResourceLocation(FarmersDelight.MODID, "entity.rotten_tomato.hit")));
 }


### PR DESCRIPTION
This PR replaces the use of the Forge-specific `RegistryObject` with the more universal `Supplier`. This increases compatibility with addons wishing to support both the official Farmer's Delight on Forge and Farmer's Delight Refabricated, or for people using Farmer's Delight addons through tools like Sinytra Connector or Kilt. This also brings the 1.20 version further into parity with the 1.21 version, which already uses Suppliers.