### PR TITLE
Fix Canvas Rug & Mats missing proper footstep sounds

### DIFF
--- a/src/generated/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
+++ b/src/generated/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "farmersdelight:canvas_rug",
+    "farmersdelight:full_tatami_mat",
+    "farmersdelight:half_tatami_mat"
+  ]
+}


### PR DESCRIPTION
When stepping onto a Canvas Rug, Half Tatami Mat and Full Tatami Mat, the sound that plays is of the block underneath. This PR adds these blocks to the proper tag to fix it, akin to carpets.

Similar to https://github.com/MehVahdJukaar/Supplementaries/pull/1922 .

The tag also exists in 1.20 so this can be cherrypicked.