### PR TITLE
Fix Cutting Board missing proper footstep sounds

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
@@ -209,8 +209,7 @@ public class BlockTags extends BlockTagsProvider
 				ModBlocks.CANVAS_RUG.get(),
 				ModBlocks.FULL_TATAMI_MAT.get(),
 				ModBlocks.HALF_TATAMI_MAT.get(),
-				ModBlocks.CUTTING_BOARD.get(),
-				ModBlocks.ROPE.get()
+				ModBlocks.CUTTING_BOARD.get()
 		);
 	}
 

--- a/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
+++ b/src/main/java/vectorwing/farmersdelight/data/BlockTags.java
@@ -208,7 +208,9 @@ public class BlockTags extends BlockTagsProvider
 		tag(net.minecraft.tags.BlockTags.COMBINATION_STEP_SOUND_BLOCKS).add(
 				ModBlocks.CANVAS_RUG.get(),
 				ModBlocks.FULL_TATAMI_MAT.get(),
-				ModBlocks.HALF_TATAMI_MAT.get()
+				ModBlocks.HALF_TATAMI_MAT.get(),
+				ModBlocks.CUTTING_BOARD.get(),
+				ModBlocks.ROPE.get()
 		);
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/vectorwing/FarmersDelight/pull/1246 (see https://github.com/vectorwing/FarmersDelight/commit/70451420c3c272fcb953535627bbdcf0d1d01b39)

There indeed were a few more blocks that did not play foostep noises as expected, as they miss `minecraft:combination_step_sound_blocks`. ~~The rope is particularly affected, as it has no physical collision, so the steps can only be heard while climbing it rather than walking through it on the floor.~~

This change is admittedly more opinionated than https://github.com/vectorwing/FarmersDelight/pull/1246, because both blocks could just as well fit into `minecraft:inside_step_sound_blocks`, instead. The only difference between the two tags is whether the underlying block can be heard or not, which is purely up to interpretation. It depends on what "material" or how "sturdy" a block is deemed to be.

~~*Technically*, the Basket could've *also* been added to `minecraft:inside_step_sound_blocks`, but that is exceedingly pedantic. It's basically impossible to hear the wrong sound in normal play. Not even Minecraft's own Composter is added to that tag.~~