### PR TITLE
[1.21.1-1.3] Hotfix uk_ua.json and ru_ru.json

### DIFF
--- a/src/main/resources/assets/farmersdelight/lang/en_us.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_us.json
@@ -274,7 +274,7 @@
   "farmersdelight.tooltip.melon_juice": "Minor Instant Health",
   "farmersdelight.tooltip.placeable": "Placeable",
   "farmersdelight.tooltip.placeable_sneaking": "Placeable when sneaking",
-  "farmersdelight.tooltip.debug_item": "Debug item - Not meant for gameplay",
+  "farmersdelight.tooltip.debug_item": "Debug item — Not meant for gameplay",
 
   "farmersdelight.advancement.root": "Farmer's Delight",
   "farmersdelight.advancement.root.desc": "A world of flavor awaits you!",

--- a/src/main/resources/assets/farmersdelight/lang/en_us.json
+++ b/src/main/resources/assets/farmersdelight/lang/en_us.json
@@ -456,7 +456,7 @@
   "tag.item.farmersdelight.tools.knives": "Knives",
   "tag.item.farmersdelight.wild_crops": "Wild Crops",
 
-  "farmersdelight.configuration.title": "Farmer's Delight - Settings",
+  "farmersdelight.configuration.title": "Farmer's Delight — Settings",
 
   "farmersdelight.configuration.section.farmersdelight.client.toml": "Client settings",
   "farmersdelight.configuration.section.farmersdelight.client.toml.title": "Client settings",

--- a/src/main/resources/assets/farmersdelight/lang/ru_ru.json
+++ b/src/main/resources/assets/farmersdelight/lang/ru_ru.json
@@ -456,7 +456,7 @@
   "tag.item.farmersdelight.tools.knives": "Ножи",
   "tag.item.farmersdelight.wild_crops": "Дикие культуры",
 
-  "farmersdelight.configuration.title": "Настройки Фермерского восторга",
+  "farmersdelight.configuration.title": "Фермерский восторг — настройки",
 
   "farmersdelight.configuration.section.farmersdelight.client.toml": "Клиентские настройки",
   "farmersdelight.configuration.section.farmersdelight.client.toml.title": "Клиентские настройки",
@@ -470,7 +470,7 @@
   "farmersdelight.configuration.stack_size": "Переопределения размера стака",
   "farmersdelight.configuration.world": "Генерация мира",
   "farmersdelight.configuration.debug": "Настройки отладки",
-  "farmersdelight.configuration.debug.tooltip": "Этот раздел предназначен исключительно для тестирования и не рассчитан для игрового процесса.",
+  "farmersdelight.configuration.debug.tooltip": "§lВнимание:§r Этот раздел не предназначен для стандартного игрового процесса.",
 
   "farmersdelight.configuration.enableFarmerFDTrades": "Особые сделки у фермеров",
   "farmersdelight.configuration.enableFarmerFDTrades.tooltip": "Если включено, жители-фермеры уровня «Новичок» и «Подмастерье» будут иметь шанс покупать культуры из этого мода.",
@@ -517,7 +517,7 @@
   "farmersdelight.configuration.generateFDCropsOnVillageFarms.tooltip": "Если включено, культуры из Фермерского Восторга иногда будут заменять стандартные культуры на фермерских участках деревень.",
 
   "farmersdelight.configuration.enableTomatoRopePermanence": "Постоянство верёвки томатов",
-  "farmersdelight.configuration.enableTomatoRopePermanence.tooltip": "Томатные культуры, висящие на верёвке, принудительно размещают блок верёвки при разрушении. Из-за технических ограничений это влияет на такие вещи, как команды, заставляя их не срабатывать при первом «setblock».\n\nОтключите это, если данный блок мешает редактировать область в режиме творчества или с помощью команд. Для обычного игрового процесса рекомендуется оставить включённым.",
+  "farmersdelight.configuration.enableTomatoRopePermanence.tooltip": "Томатные культуры, висящие на верёвке, принудительно размещают блок верёвки при разрушении. Из-за технических ограничений это сказывается, в частности, на команды, из-за чего не удаётся выполнить команду «setblock» для данного блока с первого раза.\n\nОтключите это, если данный блок мешает редактировать область в режиме творчества или с помощью команд. Для обычного игрового процесса рекомендуется оставить включённым.",
 
   "farmersdelight.configuration.enableNourishmentHungerOverlay": "Наложение эффекта сытости на шкалу голода",
   "farmersdelight.configuration.enableNourishmentHungerOverlay.tooltip": "Если включено, при наличии у игрока эффекта Сытости поверх шкалы еды будет отображаться золотистое наложение.",

--- a/src/main/resources/assets/farmersdelight/lang/ru_ru.json
+++ b/src/main/resources/assets/farmersdelight/lang/ru_ru.json
@@ -274,7 +274,7 @@
   "farmersdelight.tooltip.melon_juice": "Восстанавливает немного здоровья",
   "farmersdelight.tooltip.placeable": "Можно разместить",
   "farmersdelight.tooltip.placeable_sneaking": "Можно разместить при подкрадывании",
-  "farmersdelight.tooltip.debug_item": "Предмет для отладки - не предназначен для игры",
+  "farmersdelight.tooltip.debug_item": "Предмет для отладки — не предназначен для игры",
 
   "farmersdelight.advancement.root": "Фермерский восторг",
   "farmersdelight.advancement.root.desc": "Вас ожидает целый мир разнообразных вкусов!",

--- a/src/main/resources/assets/farmersdelight/lang/ru_ru.json
+++ b/src/main/resources/assets/farmersdelight/lang/ru_ru.json
@@ -216,6 +216,7 @@
   "item.farmersdelight.pumpkin_soup": "Тыквенный суп",
   "item.farmersdelight.baked_cod_stew": "Запечённая тушеная треска",
   "item.farmersdelight.noodle_soup": "Лапшичный суп",
+  "item.farmersdelight.onion_soup": "Луковый суп",
   "item.farmersdelight.bone_broth": "Костяной бульон",
 
   "item.farmersdelight.bacon_and_eggs": "Яичница с беконом",

--- a/src/main/resources/assets/farmersdelight/lang/uk_ua.json
+++ b/src/main/resources/assets/farmersdelight/lang/uk_ua.json
@@ -274,7 +274,7 @@
   "farmersdelight.tooltip.melon_juice": "Відновлює трохи здоров'я",
   "farmersdelight.tooltip.placeable": "Можна розмістити",
   "farmersdelight.tooltip.placeable_sneaking": "Можна розмістити крадучись",
-  "farmersdelight.tooltip.debug_item": "Предмет для налагодження - не призначений для гри",
+  "farmersdelight.tooltip.debug_item": "Предмет для налагодження — не призначений для гри",
 
   "farmersdelight.advancement.root": "Farmer's Delight",
   "farmersdelight.advancement.root.desc": "Світ смаків чекає на вас!",

--- a/src/main/resources/assets/farmersdelight/lang/uk_ua.json
+++ b/src/main/resources/assets/farmersdelight/lang/uk_ua.json
@@ -456,7 +456,7 @@
   "tag.item.farmersdelight.tools.knives": "Ножі",
   "tag.item.farmersdelight.wild_crops": "Дикі культури",
 
-  "farmersdelight.configuration.title": "Конфігурація Farmer's Delight",
+  "farmersdelight.configuration.title": "Farmer's Delight — налаштування",
 
   "farmersdelight.configuration.section.farmersdelight.client.toml": "Клієнтські налаштування",
   "farmersdelight.configuration.section.farmersdelight.client.toml.title": "Клієнтські налаштування",
@@ -470,7 +470,7 @@
   "farmersdelight.configuration.stack_size": "Заміна розміру стопки",
   "farmersdelight.configuration.world": "Генерація світу",
   "farmersdelight.configuration.debug": "Налаштування налагодження",
-  "farmersdelight.configuration.debug.tooltip": "Цей розділ призначений виключно для тестування і не призначений для ігрового процесу.",
+  "farmersdelight.configuration.debug.tooltip": "§lУвага:§r Цей розділ не призначений для стандартного ігрового процесу.",
 
   "farmersdelight.configuration.enableFarmerFDTrades": "Особливі торги у фермерів",
   "farmersdelight.configuration.enableFarmerFDTrades.tooltip": "Якщо увімкнено, селяни-фермери рівнів «Новачок» і «Підмайстер» матимуть шанс купувати культури з цього мода.",
@@ -517,7 +517,7 @@
   "farmersdelight.configuration.generateFDCropsOnVillageFarms.tooltip": "Якщо увімкнено, культури з Farmer's Delight іноді замінятимуть стандартні культури на фермах сіл.",
 
   "farmersdelight.configuration.enableTomatoRopePermanence": "Постійність томатної мотузки",
-  "farmersdelight.configuration.enableTomatoRopePermanence.tooltip": "Томатні культури, підвішені на мотузці, примусово розміщують блок мотузки при зламі. Через технічні обмеження це впливає на такі речі, як команди, змушуючи їх не виконувати «setblock» з першого разу.\n\nВимкніть це, якщо цей блок заважає вам редагувати регіон у творчому режимі або за допомогою команд. Для звичайного геймплею рекомендовано залишити увімкненим.",
+  "farmersdelight.configuration.enableTomatoRopePermanence.tooltip": "Томатні культури, підвішені на мотузці, примусово розміщують блок мотузки при зламі. Через технічні обмеження це впливає, зокрема, на команди, через що не вдається виконати команду «setblock» для цього блоку з першої спроби.\n\nВимкніть це, якщо цей блок заважає вам редагувати регіон у творчому режимі або за допомогою команд. Для звичайного геймплею рекомендовано залишити увімкненим.",
 
   "farmersdelight.configuration.enableNourishmentHungerOverlay": "Накладення ситості на індикатор голоду",
   "farmersdelight.configuration.enableNourishmentHungerOverlay.tooltip": "Якщо увімкнено, на індикаторі їжі відображатиметься позолочене накладення, коли гравець має ефект ситості.",

--- a/src/main/resources/assets/farmersdelight/lang/uk_ua.json
+++ b/src/main/resources/assets/farmersdelight/lang/uk_ua.json
@@ -216,6 +216,7 @@
   "item.farmersdelight.pumpkin_soup": "Гарбузовий суп",
   "item.farmersdelight.baked_cod_stew": "Запечена тушкована тріска",
   "item.farmersdelight.noodle_soup": "Суп з локшиною",
+  "item.farmersdelight.onion_soup": "Цибулевий суп",
   "item.farmersdelight.bone_broth": "Кістяний бульйон",
 
   "item.farmersdelight.bacon_and_eggs": "Яєчня з беконом",


### PR DESCRIPTION
There have been some changes after my previous pull request, so I needed to apply them to uk_ua.json and ru_ru.json before I forget.

Also changed the hyphens in `Farmer's Delight - Settings` and `Debug item - Not meant for gameplay` to em dashes. Hyphens are usually used to separate words ("add-on", for example) while em dashes are puctuation marks.