### PR TITLE
26.1 JEI Recipe Compat Fix.

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipeTypes.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipeTypes.java
@@ -1,6 +1,5 @@
 package vectorwing.farmersdelight.integration.jei;
 
-import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.types.IRecipeType;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import vectorwing.farmersdelight.FarmersDelight;

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/FDRecipes.java
@@ -1,47 +1,43 @@
 package vectorwing.farmersdelight.integration.jei;
 
 import com.google.common.collect.Lists;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.NonNullList;
+import net.minecraft.data.recipes.RecipeBuilder;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.ItemLike;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
+import net.neoforged.neoforge.event.OnDatapackSyncEvent;
+import net.neoforged.neoforge.registries.DeferredHolder;
 import vectorwing.farmersdelight.common.crafting.CookingPotRecipe;
 import vectorwing.farmersdelight.common.crafting.CuttingBoardRecipe;
 import vectorwing.farmersdelight.common.registry.ModItems;
 import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
 import vectorwing.farmersdelight.common.utility.RecipeUtils;
 
+
 import java.util.List;
 import java.util.Optional;
 
-public class FDRecipes
+@EventBusSubscriber
+public final class FDRecipes
 {
-	// TODO: RecipeAccess isn't the same thing. Maybe you'll have to access the registries directly?
-	private final RecipeAccess recipeManager;
 
-	public FDRecipes() {
-		Minecraft minecraft = Minecraft.getInstance();
-		ClientLevel level = minecraft.level;
+	private static RecipeMap recipeManager = RecipeMap.EMPTY;
 
-		if (level != null) {
-			this.recipeManager = level.recipeAccess();
-		} else {
-			throw new NullPointerException("Minecraft level must not be null.");
-		}
+	public static List<RecipeHolder<CookingPotRecipe>> getCookingPotRecipes() {
+		return getRecipesByType(ModRecipeTypes.COOKING.get());
 	}
 
-	public List<RecipeHolder<CookingPotRecipe>> getCookingPotRecipes() {
-		return recipeManager.getAllRecipesFor(ModRecipeTypes.COOKING.get());
+	public static List<RecipeHolder<CuttingBoardRecipe>> getCuttingBoardRecipes() {
+		return getRecipesByType(ModRecipeTypes.CUTTING.get());
 	}
 
-	public List<RecipeHolder<CuttingBoardRecipe>> getCuttingBoardRecipes() {
-		return recipeManager.getAllRecipesFor(ModRecipeTypes.CUTTING.get());
-	}
-
-	public List<RecipeHolder<CraftingRecipe>> getSpecialCraftingRecipes() {
+	public static List<RecipeHolder<CraftingRecipe>> getSpecialCraftingRecipes() {
 		List<RecipeHolder<CraftingRecipe>> recipes = Lists.newArrayList();
 
 		addValidatedSpecialRecipe(recipes, "wheat_dough_from_water", "fd_dough",
@@ -56,11 +52,38 @@ public class FDRecipes
 		return recipes;
 	}
 
-	public void addValidatedSpecialRecipe(List<RecipeHolder<CraftingRecipe>> recipeList, String recipeId, String group, NonNullList<Ingredient> inputs, ItemLike output) {
-		Optional<RecipeHolder<?>> specialRecipe = recipeManager.byKey(RecipeUtils.FDLocation(recipeId));
+	public static void addValidatedSpecialRecipe(List<RecipeHolder<CraftingRecipe>> recipeList, String recipeId, String group, NonNullList<Ingredient> inputs, ItemLike output) {
+		Optional<RecipeHolder<?>> specialRecipe = Optional.ofNullable(recipeManager.byKey(RecipeUtils.FDKey(recipeId)));
 
 		specialRecipe.ifPresent((recipe) -> {
-			recipeList.add(new RecipeHolder<>(specialRecipe.get().id(), new ShapelessRecipe(group, CraftingBookCategory.MISC, new ItemStack(output.asItem()), inputs)));
+			recipeList.add(new RecipeHolder<>(
+				specialRecipe.get().id(),
+				new ShapelessRecipe(
+					RecipeBuilder.createCraftingCommonInfo(true),
+					new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, group),
+					ItemStackTemplate.fromNonEmptyStack(new ItemStack(output.asItem())),
+					inputs)
+				)
+			);
 		});
 	}
+
+	public static <I extends RecipeInput, T extends Recipe<I>> List<RecipeHolder<T>> getRecipesByType(RecipeType<T> type) {
+		return recipeManager.byType(type).stream().toList();
+	}
+
+	@SubscribeEvent
+	public static void onReceiveRecipes(RecipesReceivedEvent event) {
+		recipeManager = event.getRecipeMap();
+	}
+
+	@SubscribeEvent
+	public static void onRecipeSend(OnDatapackSyncEvent event) {
+		ModRecipeTypes.RECIPE_TYPES.getEntries()
+			.stream()
+			.map(DeferredHolder::get)
+			.forEach(event::sendRecipes);
+	}
+
+	private FDRecipes() {}
 }

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -42,12 +42,11 @@ public class JEIPlugin implements IModPlugin
 
 	@Override
 	public void registerRecipes(IRecipeRegistration registration) {
-		FDRecipes modRecipes = new FDRecipes();
-		registration.addRecipes(FDRecipeTypes.COOKING, modRecipes.getCookingPotRecipes());
-		registration.addRecipes(FDRecipeTypes.CUTTING, modRecipes.getCuttingBoardRecipes());
+		registration.addRecipes(FDRecipeTypes.COOKING, FDRecipes.getCookingPotRecipes());
+		registration.addRecipes(FDRecipeTypes.CUTTING, FDRecipes.getCuttingBoardRecipes());
 		registration.addRecipes(FDRecipeTypes.DECOMPOSITION, ImmutableList.of(new DecompositionDummy()));
 
-		registration.addRecipes(RecipeTypes.CRAFTING, modRecipes.getSpecialCraftingRecipes());
+		registration.addRecipes(RecipeTypes.CRAFTING, FDRecipes.getSpecialCraftingRecipes());
 
 		registration.addIngredientInfo(new ItemStack(ModItems.WHEAT_DOUGH.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.dough"));
 		registration.addIngredientInfo(new ItemStack(ModItems.STRAW.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.straw"));


### PR DESCRIPTION
Since the method ClientLevel.getRecipeManager() has been removed in mc 26.1.x, the proper way to sync recipe is subscribe OnDatapackSyncEvent for send recipes to sync and RecipesReceivedEvent for recieve recipes from server. I've done quite simple changes that:
- Add a static RecipeMap cache to FDRecipes.java
- Turn FDRecipes.java to a completely static utility class
- Update JEIPlugin.registerRecipes() to fit changes above