### PR TITLE
Add EMI integration for info recipes

### DIFF
--- a/src/main/java/vectorwing/farmersdelight/integration/InfoRecipe.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/InfoRecipe.java
@@ -1,0 +1,41 @@
+package vectorwing.farmersdelight.integration;
+
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import vectorwing.farmersdelight.common.registry.ModItems;
+import vectorwing.farmersdelight.common.utility.TextUtils;
+
+import java.util.List;
+
+/**
+ * A generic representation of an info recipe, can be used with EMI/JEI/etc.
+ */
+public record InfoRecipe(List<ItemStack> stacks, MutableComponent info) {
+	public InfoRecipe(ItemStack stack, MutableComponent info) {
+		this(List.of(stack), info);
+	}
+
+	public static List<InfoRecipe> infoRecipes() {
+		return List.of(
+			new InfoRecipe(new ItemStack(ModItems.WHEAT_DOUGH.get()), TextUtils.JEI("info.dough")),
+			new InfoRecipe(new ItemStack(ModItems.STRAW.get()), TextUtils.JEI("info.straw")),
+			new InfoRecipe(new ItemStack(ModItems.HAM.get()), TextUtils.JEI("info.ham")),
+			new InfoRecipe(new ItemStack(ModItems.SMOKED_HAM.get()), TextUtils.JEI("info.ham")),
+			new InfoRecipe(new ItemStack(ModItems.FLINT_KNIFE.get()), TextUtils.JEI("info.knife")),
+			new InfoRecipe(new ItemStack(ModItems.IRON_KNIFE.get()), TextUtils.JEI("info.knife")),
+			new InfoRecipe(new ItemStack(ModItems.DIAMOND_KNIFE.get()), TextUtils.JEI("info.knife")),
+			new InfoRecipe(new ItemStack(ModItems.NETHERITE_KNIFE.get()), TextUtils.JEI("info.knife")),
+			new InfoRecipe(new ItemStack(ModItems.GOLDEN_KNIFE.get()), TextUtils.JEI("info.knife")),
+
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_CABBAGES.get()), new ItemStack(ModItems.CABBAGE.get()), new ItemStack(ModItems.CABBAGE_LEAF.get())), TextUtils.JEI("info.wild_cabbages")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_BEETROOTS.get()), new ItemStack(Items.BEETROOT)), TextUtils.JEI("info.wild_beetroots")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_CARROTS.get()), new ItemStack(Items.CARROT)), TextUtils.JEI("info.wild_carrots")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_ONIONS.get()), new ItemStack(ModItems.ONION.get())), TextUtils.JEI("info.wild_onions")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_POTATOES.get()), new ItemStack(Items.POTATO)), TextUtils.JEI("info.wild_potatoes")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_TOMATOES.get()), new ItemStack(ModItems.TOMATO.get())), TextUtils.JEI("info.wild_tomatoes")),
+			new InfoRecipe(List.of(new ItemStack(ModItems.WILD_RICE.get()), new ItemStack(ModItems.RICE.get()), new ItemStack(ModItems.RICE_PANICLE.get())), TextUtils.JEI("info.wild_rice"))
+
+		);
+	}
+}

--- a/src/main/java/vectorwing/farmersdelight/integration/emi/EMIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/emi/EMIPlugin.java
@@ -4,9 +4,11 @@ import dev.emi.emi.api.EmiEntrypoint;
 import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiCraftingRecipe;
+import dev.emi.emi.api.recipe.EmiInfoRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeHolder;
@@ -17,6 +19,7 @@ import vectorwing.farmersdelight.common.registry.ModItems;
 import vectorwing.farmersdelight.common.registry.ModMenuTypes;
 import vectorwing.farmersdelight.common.registry.ModRecipeTypes;
 import vectorwing.farmersdelight.common.utility.RecipeUtils;
+import vectorwing.farmersdelight.integration.InfoRecipe;
 import vectorwing.farmersdelight.integration.emi.handler.CookingPotEmiRecipeHandler;
 import vectorwing.farmersdelight.integration.emi.recipe.CookingPotEmiRecipe;
 import vectorwing.farmersdelight.integration.emi.recipe.CuttingEmiRecipe;
@@ -49,6 +52,11 @@ public class EMIPlugin implements EmiPlugin {
                     recipe.getRollableResults().stream().map(chanceResult -> EmiStack.of(chanceResult.stack()).setChance(chanceResult.chance())).toList()));
         }
         registry.addRecipe(new DecompositionEmiRecipe());
+
+		for (InfoRecipe infoRecipe : InfoRecipe.infoRecipes()) {
+			ResourceLocation id = BuiltInRegistries.ITEM.getKey(infoRecipe.stacks().getFirst().getItem()).withPrefix("/info/"); // e.g. 'farmersdelight:/info/ham'
+			registry.addRecipe(new EmiInfoRecipe(infoRecipe.stacks().stream().map(stack-> (EmiIngredient) EmiStack.of(stack)).toList(), List.of(infoRecipe.info()), id));
+		}
 
         addSpecialRecipes(registry);
     }

--- a/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
+++ b/src/main/java/vectorwing/farmersdelight/integration/jei/JEIPlugin.java
@@ -9,14 +9,13 @@ import mezz.jei.api.registration.*;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import vectorwing.farmersdelight.FarmersDelight;
 import vectorwing.farmersdelight.client.gui.CookingPotScreen;
 import vectorwing.farmersdelight.common.block.entity.container.CookingPotMenu;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.registry.ModItems;
 import vectorwing.farmersdelight.common.registry.ModMenuTypes;
-import vectorwing.farmersdelight.common.utility.TextUtils;
+import vectorwing.farmersdelight.integration.InfoRecipe;
 import vectorwing.farmersdelight.integration.jei.category.CookingRecipeCategory;
 import vectorwing.farmersdelight.integration.jei.category.CuttingRecipeCategory;
 import vectorwing.farmersdelight.integration.jei.category.DecompositionRecipeCategory;
@@ -49,23 +48,9 @@ public class JEIPlugin implements IModPlugin
 
 		registration.addRecipes(RecipeTypes.CRAFTING, modRecipes.getSpecialCraftingRecipes());
 
-		registration.addIngredientInfo(new ItemStack(ModItems.WHEAT_DOUGH.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.dough"));
-		registration.addIngredientInfo(new ItemStack(ModItems.STRAW.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.straw"));
-		registration.addIngredientInfo(new ItemStack(ModItems.HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.ham"));
-		registration.addIngredientInfo(new ItemStack(ModItems.SMOKED_HAM.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.ham"));
-		registration.addIngredientInfo(new ItemStack(ModItems.FLINT_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.knife"));
-		registration.addIngredientInfo(new ItemStack(ModItems.IRON_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.knife"));
-		registration.addIngredientInfo(new ItemStack(ModItems.DIAMOND_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.knife"));
-		registration.addIngredientInfo(new ItemStack(ModItems.NETHERITE_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.knife"));
-		registration.addIngredientInfo(new ItemStack(ModItems.GOLDEN_KNIFE.get()), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.knife"));
-
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CABBAGES.get()), new ItemStack(ModItems.CABBAGE.get()), new ItemStack(ModItems.CABBAGE_LEAF.get())), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_cabbages"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_BEETROOTS.get()), new ItemStack(Items.BEETROOT)), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_beetroots"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_CARROTS.get()), new ItemStack(Items.CARROT)), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_carrots"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_ONIONS.get()), new ItemStack(ModItems.ONION.get())), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_onions"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_POTATOES.get()), new ItemStack(Items.POTATO)), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_potatoes"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_TOMATOES.get()), new ItemStack(ModItems.TOMATO.get())), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_tomatoes"));
-		registration.addIngredientInfo(List.of(new ItemStack(ModItems.WILD_RICE.get()), new ItemStack(ModItems.RICE.get()), new ItemStack(ModItems.RICE_PANICLE.get())), VanillaTypes.ITEM_STACK, TextUtils.JEI("info.wild_rice"));
+		for (InfoRecipe infoRecipe : InfoRecipe.infoRecipes()) {
+			registration.addIngredientInfo(infoRecipe.stacks(), VanillaTypes.ITEM_STACK, infoRecipe.info());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds support for EMI info recipes, which were excluded from #972. EMI expects all recipes, including info, to have an associated `ResourceLocation`, so one is generated from a stack.

Rather than unnecessarily duplicate code and potentially lead to maintenance issues leading to EMI or JEI drifting out of sync, this PR adds a basic `InfoRecipe` record shared between the two recipe viewers. Should Farmer's Delight port forward to 26.1 and add support for other recipe viewers like my own [RRV](https://modrinth.com/mod/rrv), having an abstraction like this will cut down on any extra work supporting and maintaining it.

Fixes #1385 